### PR TITLE
stores the model as a string during fit

### DIFF
--- a/python/operon/sklearn.py
+++ b/python/operon/sklearn.py
@@ -300,8 +300,10 @@ class SymbolicRegressor(BaseEstimator, RegressorMixin):
 
         self._model           = op.Tree(nodes).UpdateNodes()
 
+        self._model_str_ = op.InfixFormatter.Format(self._model, ds, 12)
+
         if show_model:
-            print(op.InfixFormatter.Format(self._model, ds, 12))
+            print(self._model_str_)
             print('internal model r2: ', 1 - best[0])
 
         self._stats = {


### PR DESCRIPTION
hoping to store a string version of the model that can be accessed afterward without referring to the dataset. 

could be nice to control precision as well, but I didn't want to make too many changes.