### PR TITLE
replace robin-hood map/set with unordered-dense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ find_package(Taskflow REQUIRED)
 find_package(Threads REQUIRED)
 find_package(fmt REQUIRED)
 find_package(pratt-parser REQUIRED)
-find_package(robin_hood REQUIRED)
+find_package(unordered_dense REQUIRED)
 find_package(vstat REQUIRED)
 find_package(FastFloat REQUIRED)
 find_package(cpp-sort REQUIRED)
@@ -212,9 +212,9 @@ target_link_libraries(operon_operon PUBLIC
 target_link_libraries(operon_operon PRIVATE
     FastFloat::fast_float
     Taskflow::Taskflow
-    vstat::vstat
-    robin_hood::robin_hood
     cpp-sort::cpp-sort
+    unordered_dense::unordered_dense
+    vstat::vstat
 )
 
 target_compile_features(operon_operon PUBLIC cxx_std_20)

--- a/cli/source/operon_parse_model.cpp
+++ b/cli/source/operon_parse_model.cpp
@@ -55,7 +55,7 @@ auto main(int argc, char** argv) -> int
     Operon::Dataset ds(result["dataset"].as<std::string>(), /*hasHeader=*/true);
     auto infix = result.unmatched().front();
     auto tmap = Operon::InfixParser::DefaultTokens();
-    robin_hood::unordered_flat_map<std::string, Operon::Hash> vmap;
+    Operon::Map<std::string, Operon::Hash> vmap;
     for (auto const& v : ds.Variables()) {
         vmap.insert({ v.Name, v.Hash });
     }

--- a/flake.nix
+++ b/flake.nix
@@ -33,24 +33,23 @@
           nativeBuildInputs = with pkgs; [ cmake ];
 
           buildInputs = (with pkgs; [
+            aria-csv
+            cpp-sort
             cxxopts
             doctest
             eigen
+            eve
+            fast_float
             fmt_8
             git
             openlibm
             pkg-config
-            xxHash
-            taskflow
             pratt-parser.defaultPackage.${system}
-            vstat.packages.${system}.default
-            # foolnotion overlay
-            aria-csv
-            cpp-sort
-            eve
-            fast_float
-            robin-hood-hashing
             scnlib
+            taskflow
+            unordered_dense
+            vstat.packages.${system}.default
+            xxHash
           ]);
         };
 

--- a/include/operon/core/pset.hpp
+++ b/include/operon/core/pset.hpp
@@ -4,10 +4,8 @@
 #ifndef OPERON_PSET_HPP
 #define OPERON_PSET_HPP
 
-#include <robin_hood.h>
 #include "contracts.hpp"
 #include "node.hpp"
-
 
 namespace Operon {
 
@@ -20,7 +18,7 @@ class PrimitiveSet {
         >;
     enum { NODE = 0, FREQUENCY = 1, MINARITY = 2, MAXARITY = 3}; // for accessing tuple elements more easily
 
-    robin_hood::unordered_flat_map<Operon::Hash, Primitive> pset_;
+    Operon::Map<Operon::Hash, Primitive> pset_;
 
     [[nodiscard]] auto GetPrimitive(Operon::Hash hash) const -> Primitive const& {
         auto it = pset_.find(hash);

--- a/include/operon/core/types.hpp
+++ b/include/operon/core/types.hpp
@@ -4,6 +4,7 @@
 #ifndef OPERON_TYPES_HPP
 #define OPERON_TYPES_HPP
 
+#include <ankerl/unordered_dense.h>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -22,6 +23,22 @@ using Vector = std::vector<T>;
 
 template <typename T>
 using Span = std::span<T>;
+
+template <class Key,
+          class T,
+          class Hash = ankerl::unordered_dense::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<std::pair<Key, T>>,
+          class Bucket = ankerl::unordered_dense::bucket_type::standard>
+using Map = ankerl::unordered_dense::detail::table<Key, T, Hash, KeyEqual, AllocatorOrContainer, Bucket>;
+
+template <class Key,
+          class Hash = ankerl::unordered_dense::hash<Key>,
+          class KeyEqual = std::equal_to<Key>,
+          class AllocatorOrContainer = std::allocator<Key>,
+          class Bucket = ankerl::unordered_dense::bucket_type::standard>
+using Set = ankerl::unordered_dense::detail::table<Key, void, Hash, KeyEqual, AllocatorOrContainer, Bucket>;
+
 
 #if defined(USE_SINGLE_PRECISION)
 using Scalar = float;

--- a/include/operon/interpreter/dispatch_table.hpp
+++ b/include/operon/interpreter/dispatch_table.hpp
@@ -7,7 +7,6 @@
 #include <Eigen/Dense>
 #include <fmt/core.h>
 #include <optional>
-#include <robin_hood.h>
 #include <cstddef>
 #include <tuple>
 
@@ -200,7 +199,7 @@ struct DispatchTable {
     using Callable = detail::Callable<T>;
 
     using Tuple    = std::tuple<Callable<Ts>...>;
-    using Map      = robin_hood::unordered_flat_map<Operon::Hash, Tuple>;
+    using Map      = Operon::Map<Operon::Hash, Tuple>;
 
 private:
     Map map_;
@@ -228,9 +227,9 @@ public:
         return *this;
     }
 
-    DispatchTable(Map const& map) : map_(map) { }
-    DispatchTable(Map&& map) : map_(std::move(map)) { }
-    DispatchTable(std::unordered_map<Operon::Hash, Tuple> const& map) : map_(map.begin(), map.end()) { }
+    explicit DispatchTable(Map const& map) : map_(map) { }
+    explicit DispatchTable(Map&& map) : map_(std::move(map)) { }
+    explicit DispatchTable(std::unordered_map<Operon::Hash, Tuple> const& map) : map_(map.begin(), map.end()) { }
 
     DispatchTable(DispatchTable const& other) : map_(other.map_) { }
     DispatchTable(DispatchTable &&other) noexcept : map_(std::move(other.map_)) { }

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -241,7 +241,7 @@ public:
     auto Prepare(Operon::Span<Operon::Individual const> pop) const -> void override;
 
 private:
-    mutable robin_hood::unordered_flat_map<size_t, size_t> divmap_;
+    mutable Operon::Map<size_t, size_t> divmap_;
     mutable double total_{0}; // total count
     Operon::HashMode hashmode_;
 };

--- a/test/source/implementation/evaluation.cpp
+++ b/test/source/implementation/evaluation.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Evaluation correctness")
     Interpreter interpreter;
     auto const& X = ds.Values(); // NOLINT
 
-    robin_hood::unordered_map<std::string, Operon::Hash> map;
+    Operon::Map<std::string, Operon::Hash> map;
     for (auto v : ds.Variables()) {
         fmt::print("{} : {} {}\n", v.Name, v.Hash, v.Index);
         map[v.Name] = v.Hash;
@@ -99,7 +99,7 @@ TEST_CASE("Numeric optimization")
 
     auto tmap = InfixParser::DefaultTokens();
 
-    robin_hood::unordered_map<std::string, Operon::Hash> map;
+    Operon::Map<std::string, Operon::Hash> map;
     for (auto v : ds.Variables()) {
         fmt::print("{} : {}\n", v.Name, v.Hash);
         map[v.Name] = v.Hash;

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright 2019-2022 Heal Research
 
 #include <doctest/doctest.h>
-#include <robin_hood.h>
 
 #include "operon/hash/hash.hpp"
 #include "operon/interpreter/interpreter.hpp"
@@ -66,7 +65,7 @@ TEST_SUITE("[implementation]")
         parsedTrees.reserve(nTrees);
 
         // map variables
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vmap;
+        Operon::Map<std::string, Operon::Hash> vmap;
         for (auto const& v : ds.Variables()) {
             vmap.insert({ v.Name, v.Hash });
         }
@@ -134,7 +133,7 @@ TEST_SUITE("[implementation]")
     {
         auto model_str = "sin((sqrt(abs(square(sin(((-0.00191) * X6))))) - sqrt(abs(((-0.96224) / (-0.40567))))))";
         auto tokens_map = InfixParser::DefaultTokens();
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vars_map;
+        Operon::Map<std::string, Operon::Hash> vars_map;
         std::unordered_map<Operon::Hash, std::string> vars_names;
         Hasher hasher;
         for (int i = 0; i < 10; ++i) {
@@ -172,7 +171,7 @@ TEST_SUITE("[implementation]")
         Dataset ds("./data/Poly-10.csv", true);
         auto s1 = InfixFormatter::Format(t, ds, 5);
         fmt::print("s1: {}\n", s1);
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vmap;
+        Operon::Map<std::string, Operon::Hash> vmap;
         auto t2 = InfixParser::Parse(s1, InfixParser::DefaultTokens(), vmap);
         auto s2 = InfixFormatter::Format(t2, ds, 5);
         fmt::print("s2: {}\n", s1);
@@ -187,7 +186,7 @@ TEST_SUITE("[implementation]")
     TEST_CASE("Parser Expr 3")
     {
         std::string const expr{"3 aq 5"};
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vmap;
+        Operon::Map<std::string, Operon::Hash> vmap;
         auto tree = InfixParser::Parse(expr, InfixParser::DefaultTokens(), vmap);
         std::unordered_map<Operon::Hash, std::string> variableNames;
         fmt::print("tree: {}\n", InfixFormatter::Format(tree, variableNames, 2));
@@ -199,7 +198,7 @@ TEST_SUITE("[implementation]")
 
         Hasher hasher;
 
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vars_map;
+        Operon::Map<std::string, Operon::Hash> vars_map;
         std::unordered_map<Operon::Hash, std::string> vars_names;
         for (int i = 0; i < 78; ++i) {
             auto name = fmt::format("X{}", i);
@@ -219,7 +218,7 @@ TEST_SUITE("[implementation]")
 
         Hasher hasher;
 
-        robin_hood::unordered_flat_map<std::string, Operon::Hash> vars_map;
+        Operon::Map<std::string, Operon::Hash> vars_map;
         std::unordered_map<Operon::Hash, std::string> vars_names;
 
         auto tokens_map = InfixParser::DefaultTokens();
@@ -282,7 +281,7 @@ TEST_SUITE("[performance]")
         std::transform(trees.begin(), trees.end(), std::back_inserter(treeStrings), [&](auto const& tree) { return InfixFormatter::Format(tree, ds, 30); });
 
         // map dataset variables for parsing
-        robin_hood::unordered_map<std::string, Operon::Hash> map;
+        Operon::Map<std::string, Operon::Hash> map;
         for (auto const& v : ds.Variables()) {
             map.insert({ v.Name, v.Hash });
         }


### PR DESCRIPTION
[unordered-dense](https://github.com/martinus/unordered_dense) offers a bunch of features that are advantageous for Operon:

- perfect iteration speed since the underlying storage is std::vector
- low memory usage
- very fast lookup speed

Operon uses maps mostly as immutable data stores therefore we don't care that the map has comparatively more costly deletion operations.