### PR TITLE
Refactor local search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(
     source/operators/generator/brood.cpp
     source/operators/generator/os.cpp
     source/operators/generator/poly.cpp
+    source/operators/local_search.cpp
     source/operators/mutation.cpp
     source/operators/non_dominated_sorter/best_order_sort.cpp
     source/operators/non_dominated_sorter/deductive_sort.cpp

--- a/cli/source/operator_factory.cpp
+++ b/cli/source/operator_factory.cpp
@@ -4,7 +4,6 @@
 #include "operator_factory.hpp"
 #include <stdexcept>                       // for runtime_error
 #include <fmt/format.h>                        // for format
-#include <tuple>
 #include <scn/scan.h>
 #include "operon/interpreter/dispatch_table.hpp"
 #include "operon/operators/creator.hpp"    // for CreatorBase, BalancedTreeC...
@@ -12,6 +11,7 @@
 #include "operon/operators/generator.hpp"  // for OffspringGeneratorBase
 #include "operon/operators/reinserter.hpp"  // for OffspringGeneratorBase
 #include "operon/operators/selector.hpp"
+#include "operon/operators/local_search.hpp"
 #include "operon/optimizer/optimizer.hpp"
 
 #include <cxxopts.hpp>
@@ -135,13 +135,13 @@ auto ParseEvaluator(std::string const& str, Problem& problem, DefaultDispatch& d
     return evaluator;
 }
 
-auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt) -> std::unique_ptr<OffspringGeneratorBase>
+auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr) -> std::unique_ptr<OffspringGeneratorBase>
 {
     std::unique_ptr<OffspringGeneratorBase> generator;
     auto tok = Split(str, ':');
     auto name = tok[0];
     if (name == "basic") {
-        generator = std::make_unique<BasicOffspringGenerator>(eval, cx, mut, femSel, maleSel, opt);
+        generator = std::make_unique<BasicOffspringGenerator>(eval, cx, mut, femSel, maleSel, coeffOptimizer);
     } else if (name == "os") {
         size_t maxSelectionPressure{100};
         double comparisonFactor{0};
@@ -151,16 +151,16 @@ auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& 
         if (tok.size() > 2) {
             comparisonFactor = scn::scan<double>(tok[2], "{}")->value();
         }
-        generator = std::make_unique<OffspringSelectionGenerator>(eval, cx, mut, femSel, maleSel, opt);
+        generator = std::make_unique<OffspringSelectionGenerator>(eval, cx, mut, femSel, maleSel, coeffOptimizer);
         dynamic_cast<OffspringSelectionGenerator*>(generator.get())->MaxSelectionPressure(maxSelectionPressure);
         dynamic_cast<OffspringSelectionGenerator*>(generator.get())->ComparisonFactor(comparisonFactor);
     } else if (name == "brood") {
-        generator = std::make_unique<BroodOffspringGenerator>(eval, cx, mut, femSel, maleSel, opt);
+        generator = std::make_unique<BroodOffspringGenerator>(eval, cx, mut, femSel, maleSel, coeffOptimizer);
         size_t broodSize{BroodOffspringGenerator::DefaultBroodSize};
         if (tok.size() > 1) { broodSize = scn::scan<size_t>(tok[1], "{}")->value(); }
         dynamic_cast<BroodOffspringGenerator*>(generator.get())->BroodSize(broodSize);
     } else if (name == "poly") {
-        generator = std::make_unique<PolygenicOffspringGenerator>(eval, cx, mut, femSel, maleSel, opt);
+        generator = std::make_unique<PolygenicOffspringGenerator>(eval, cx, mut, femSel, maleSel, coeffOptimizer);
         size_t polygenicSize{PolygenicOffspringGenerator::DefaultBroodSize};
         if (tok.size() > 1) { polygenicSize = scn::scan<size_t>(tok[1], "{}")->value(); }
         dynamic_cast<PolygenicOffspringGenerator*>(generator.get())->PolygenicSize(polygenicSize);

--- a/cli/source/operator_factory.hpp
+++ b/cli/source/operator_factory.hpp
@@ -26,6 +26,7 @@ namespace Operon { class SelectorBase; }
 namespace Operon { struct CreatorBase; }
 namespace Operon { struct CrossoverBase; }
 namespace Operon { struct ErrorMetric; }
+namespace Operon { class CoefficientOptimizer; }
 namespace Operon { struct MutatorBase; }
 namespace Operon { struct Variable; }
 
@@ -41,7 +42,7 @@ auto ParseEvaluator(std::string const& str, Problem& problem, DefaultDispatch& d
 
 auto ParseErrorMetric(std::string const& str) -> std::tuple<std::unique_ptr<Operon::ErrorMetric>, bool>;
 
-auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const*) -> std::unique_ptr<OffspringGeneratorBase>;
+auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* cOpt) -> std::unique_ptr<OffspringGeneratorBase>;
 
 auto ParseOptimizer(std::string const& str, Problem const& problem, DefaultDispatch const& dtable) -> std::unique_ptr<OptimizerBase>;
 

--- a/cli/source/operator_factory.hpp
+++ b/cli/source/operator_factory.hpp
@@ -41,9 +41,9 @@ auto ParseEvaluator(std::string const& str, Problem& problem, DefaultDispatch& d
 
 auto ParseErrorMetric(std::string const& str) -> std::tuple<std::unique_ptr<Operon::ErrorMetric>, bool>;
 
-auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel) -> std::unique_ptr<OffspringGeneratorBase>;
+auto ParseGenerator(std::string const& str, EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const*) -> std::unique_ptr<OffspringGeneratorBase>;
 
-auto ParseOptimizer(std::string const& str, Problem const& problem, DefaultDispatch const& dtable) -> std::unique_ptr<OptimizerBase<DefaultDispatch>>;
+auto ParseOptimizer(std::string const& str, Problem const& problem, DefaultDispatch const& dtable) -> std::unique_ptr<OptimizerBase>;
 
 } // namespace Operon
 

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -223,6 +223,8 @@ auto main(int argc, char** argv) -> int
         auto optimizer = std::make_unique<Operon::LevenbergMarquardtOptimizer<decltype(dtable), Operon::OptimizerType::Eigen>>(dtable, problem);
         optimizer->SetIterations(config.Iterations);
 
+        Operon::CoefficientOptimizer cOpt{*optimizer, config.LamarckianProbability};
+
         EXPECT(problem.TrainingRange().Size() > 0);
 
         auto comp = [](auto const& lhs, auto const& rhs) { return lhs[0] < rhs[0]; };
@@ -230,7 +232,7 @@ auto main(int argc, char** argv) -> int
         auto femaleSelector = Operon::ParseSelector(result["female-selector"].as<std::string>(), comp);
         auto maleSelector = Operon::ParseSelector(result["male-selector"].as<std::string>(), comp);
 
-        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), *evaluator, crossover, mutator, *femaleSelector, *maleSelector, optimizer.get());
+        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), *evaluator, crossover, mutator, *femaleSelector, *maleSelector, &cOpt);
         auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
 
         Operon::RandomGenerator random(config.Seed);

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -222,7 +222,6 @@ auto main(int argc, char** argv) -> int
 
         auto optimizer = std::make_unique<Operon::LevenbergMarquardtOptimizer<decltype(dtable), Operon::OptimizerType::Eigen>>(dtable, problem);
         optimizer->SetIterations(config.Iterations);
-        dynamic_cast<Operon::Evaluator<Operon::DefaultDispatch>*>(evaluator.get())->SetOptimizer(optimizer.get());
 
         EXPECT(problem.TrainingRange().Size() > 0);
 
@@ -231,7 +230,7 @@ auto main(int argc, char** argv) -> int
         auto femaleSelector = Operon::ParseSelector(result["female-selector"].as<std::string>(), comp);
         auto maleSelector = Operon::ParseSelector(result["male-selector"].as<std::string>(), comp);
 
-        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), *evaluator, crossover, mutator, *femaleSelector, *maleSelector);
+        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), *evaluator, crossover, mutator, *femaleSelector, *maleSelector, optimizer.get());
         auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
 
         Operon::RandomGenerator random(config.Seed);

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -244,8 +244,9 @@ auto main(int argc, char** argv) -> int
 
         auto femaleSelector = Operon::ParseSelector(result["female-selector"].as<std::string>(), comp);
         auto maleSelector = Operon::ParseSelector(result["male-selector"].as<std::string>(), comp);
+        Operon::CoefficientOptimizer cOpt{*optimizer, config.LamarckianProbability};
 
-        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), evaluator, crossover, mutator, *femaleSelector, *maleSelector, optimizer.get());
+        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), evaluator, crossover, mutator, *femaleSelector, *maleSelector, &cOpt);
         auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
 
         Operon::RandomGenerator random(config.Seed);

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -51,6 +51,8 @@ auto main(int argc, char** argv) -> int
     config.Iterations = result["iterations"].as<size_t>();
     config.CrossoverProbability = result["crossover-probability"].as<Operon::Scalar>();
     config.MutationProbability = result["mutation-probability"].as<Operon::Scalar>();
+    config.LocalSearchProbability = result["local-search-probability"].as<Operon::Scalar>();
+    config.LamarckianProbability = result["lamarckian-probability"].as<Operon::Scalar>();
     config.TimeLimit = result["timelimit"].as<size_t>();
     config.Seed = std::random_device {}();
 
@@ -229,7 +231,6 @@ auto main(int argc, char** argv) -> int
 
         auto optimizer = std::make_unique<Operon::LevenbergMarquardtOptimizer<decltype(dtable), Operon::OptimizerType::Eigen>>(dtable, problem);
         optimizer->SetIterations(config.Iterations);
-        dynamic_cast<Operon::Evaluator<Operon::DefaultDispatch>*>(errorEvaluator.get())->SetOptimizer(optimizer.get());
         Operon::LengthEvaluator lengthEvaluator(problem, maxLength);
 
         Operon::MultiEvaluator evaluator(problem);
@@ -244,7 +245,7 @@ auto main(int argc, char** argv) -> int
         auto femaleSelector = Operon::ParseSelector(result["female-selector"].as<std::string>(), comp);
         auto maleSelector = Operon::ParseSelector(result["male-selector"].as<std::string>(), comp);
 
-        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), evaluator, crossover, mutator, *femaleSelector, *maleSelector);
+        auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), evaluator, crossover, mutator, *femaleSelector, *maleSelector, optimizer.get());
         auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
 
         Operon::RandomGenerator random(config.Seed);
@@ -373,6 +374,8 @@ auto main(int argc, char** argv) -> int
 
             using T = std::tuple<std::string, double, std::string>;
             auto const* format = ":>#8.3g"; // see https://fmt.dev/latest/syntax.html
+
+            auto [resEval, jacEval, callCount, cfTime ] = evaluator.Stats();
             std::array stats {
                 T{ "iteration", gp.Generation(), ":>" },
                 T{ "r2_tr", r2Train, format },
@@ -383,10 +386,10 @@ auto main(int argc, char** argv) -> int
                 T{ "nmse_te", nmseTest, format },
                 T{ "avg_fit", avgQuality, format },
                 T{ "avg_len", avgLength, format },
-                T{ "eval_cnt", evaluator.CallCount , ":>" },
-                T{ "res_eval", evaluator.ResidualEvaluations, ":>" },
-                T{ "jac_eval", evaluator.JacobianEvaluations, ":>" },
-                T{ "opt_time", evaluator.CostFunctionTime,    ":>" },
+                T{ "eval_cnt", callCount, ":>" },
+                T{ "res_eval", resEval, ":>" },
+                T{ "jac_eval", jacEval, ":>" },
+                T{ "opt_time", cfTime, ":>" },
                 T{ "seed", config.Seed, ":>" },
                 T{ "elapsed", elapsed, ":>"},
             };

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -192,6 +192,8 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("offspring-generator", "OffspringGenerator operator, with optional parameters separated by : (eg --offspring-generator brood:10:10)", cxxopts::value<std::string>()->default_value("basic"))
         ("reinserter", "Reinsertion operator merging offspring in the recombination pool back into the population", cxxopts::value<std::string>()->default_value("keep-best"))
         ("enable-symbols", "Comma-separated list of enabled symbols ("+symbols+")", cxxopts::value<std::string>())
+        ("local-search-probability", "Probability for local search", cxxopts::value<Operon::Scalar>()->default_value("1.0"))
+        ("lamarckian-probability", "Probability that the local search improvements are saved back into the chromosome", cxxopts::value<Operon::Scalar>()->default_value("1.0"))
         ("disable-symbols", "Comma-separated list of disabled symbols ("+symbols+")", cxxopts::value<std::string>())
         ("symbolic", "Operate in symbolic mode - no coefficient tuning or coefficient mutation", cxxopts::value<bool>()->default_value("false"))
         ("show-primitives", "Display the primitive set used by the algorithm")

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build/compile_commands.json

--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713257704,
-        "narHash": "sha256-z/nj/UyyE1ipqHhFAnGsY+8Sj2VB2DJ7nBBLCOI7xCc=",
+        "lastModified": 1714463628,
+        "narHash": "sha256-58N7PhmMvArtOXurpGLa2QtDJCfE9v5YvEnz7gPf3wo=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "69c19f4deef8a291a4f61aa166898e6de12aede2",
+        "rev": "eae6690e3cf1f5866ed0713b82b0d0d2b5575bcb",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713257704,
-        "narHash": "sha256-z/nj/UyyE1ipqHhFAnGsY+8Sj2VB2DJ7nBBLCOI7xCc=",
+        "lastModified": 1714463628,
+        "narHash": "sha256-58N7PhmMvArtOXurpGLa2QtDJCfE9v5YvEnz7gPf3wo=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "69c19f4deef8a291a4f61aa166898e6de12aede2",
+        "rev": "eae6690e3cf1f5866ed0713b82b0d0d2b5575bcb",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1713257704,
-        "narHash": "sha256-z/nj/UyyE1ipqHhFAnGsY+8Sj2VB2DJ7nBBLCOI7xCc=",
+        "lastModified": 1714463628,
+        "narHash": "sha256-58N7PhmMvArtOXurpGLa2QtDJCfE9v5YvEnz7gPf3wo=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "69c19f4deef8a291a4f61aa166898e6de12aede2",
+        "rev": "eae6690e3cf1f5866ed0713b82b0d0d2b5575bcb",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1713257704,
-        "narHash": "sha256-z/nj/UyyE1ipqHhFAnGsY+8Sj2VB2DJ7nBBLCOI7xCc=",
+        "lastModified": 1714463628,
+        "narHash": "sha256-58N7PhmMvArtOXurpGLa2QtDJCfE9v5YvEnz7gPf3wo=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "69c19f4deef8a291a4f61aa166898e6de12aede2",
+        "rev": "eae6690e3cf1f5866ed0713b82b0d0d2b5575bcb",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713863185,
-        "narHash": "sha256-5sSgCOFJdx5W2srxfQ9T61a8lrGbzIE+/4sQyNyU3io=",
+        "lastModified": 1714463833,
+        "narHash": "sha256-2QTF0WufldsBDkB7dl0WkaxN+V1svbgfRQlXVGayolQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "68a917dc6480b8ab79c57df265916d35ab9c01c2",
+        "rev": "38cc39329a91a925aba2fb32db33fd759a5306fa",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713863185,
-        "narHash": "sha256-5sSgCOFJdx5W2srxfQ9T61a8lrGbzIE+/4sQyNyU3io=",
+        "lastModified": 1714463833,
+        "narHash": "sha256-2QTF0WufldsBDkB7dl0WkaxN+V1svbgfRQlXVGayolQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a917dc6480b8ab79c57df265916d35ab9c01c2",
+        "rev": "38cc39329a91a925aba2fb32db33fd759a5306fa",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1713863185,
-        "narHash": "sha256-5sSgCOFJdx5W2srxfQ9T61a8lrGbzIE+/4sQyNyU3io=",
+        "lastModified": 1714463833,
+        "narHash": "sha256-2QTF0WufldsBDkB7dl0WkaxN+V1svbgfRQlXVGayolQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a917dc6480b8ab79c57df265916d35ab9c01c2",
+        "rev": "38cc39329a91a925aba2fb32db33fd759a5306fa",
         "type": "github"
       },
       "original": {

--- a/include/operon/algorithms/config.hpp
+++ b/include/operon/algorithms/config.hpp
@@ -14,10 +14,12 @@ struct GeneticAlgorithmConfig {
     size_t PopulationSize;
     size_t PoolSize;
     size_t Seed;        // random seed
-    size_t TimeLimit;   // time limit
-    double CrossoverProbability;
-    double MutationProbability;
-    double Epsilon;     // used when comparing fitness values
+    size_t TimeLimit{~std::size_t{0}}; // time limit
+    double CrossoverProbability{1.0};
+    double MutationProbability{0.25};
+    double LocalSearchProbability{1.0};
+    double LamarckianProbability{1.0};
+    double Epsilon{0};     // used when comparing fitness values
 };
 } // namespace Operon
 

--- a/include/operon/interpreter/dispatch_table.hpp
+++ b/include/operon/interpreter/dispatch_table.hpp
@@ -185,6 +185,8 @@ private:
     }(Ext{});
 
 public:
+    using SupportedTypes = Tup;
+
     template<typename T>
     static constexpr typename Ext::value_type BatchSize = Sizes[TypeIndex<T>];
 

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -9,6 +9,7 @@
 #include "operon/operators/evaluator.hpp"
 #include "operon/operators/mutation.hpp"
 #include "operon/operators/selector.hpp"
+#include "operon/operators/local_search.hpp"
 
 namespace Operon {
 
@@ -20,15 +21,15 @@ struct RecombinationResult {
     explicit operator bool() const { return Child.has_value(); }
 };
 
-class OffspringGeneratorBase : public OperatorBase<std::optional<Individual>, /* crossover prob. */ double, /* mutation prob. */ double, /* local search prob. */ double, /* lamarckian prob. */ double, /* memory buffer */ Operon::Span<Operon::Scalar>> {
+class OffspringGeneratorBase : public OperatorBase<std::optional<Individual>, /* crossover prob. */ double, /* mutation prob. */ double, /* local search prob. */ double, /* memory buffer */ Operon::Span<Operon::Scalar>> {
 public:
-    OffspringGeneratorBase(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
+    OffspringGeneratorBase(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr)
         : evaluator_(eval)
         , crossover_(cx)
         , mutator_(mut)
         , femaleSelector_(femSel)
         , maleSelector_(maleSel)
-        , optimizer_{opt}
+        , coeffOptimizer_{coeffOptimizer}
     {
     }
 
@@ -37,7 +38,7 @@ public:
     [[nodiscard]] auto Crossover() const -> CrossoverBase& { return crossover_.get(); }
     [[nodiscard]] auto Mutator() const -> MutatorBase& { return mutator_.get(); }
     [[nodiscard]] auto Evaluator() const -> EvaluatorBase& { return evaluator_.get(); }
-    [[nodiscard]] auto Optimizer() const -> OptimizerBase const* { return optimizer_; }
+    [[nodiscard]] auto Optimizer() const -> CoefficientOptimizer const* { return coeffOptimizer_; }
 
     virtual auto Prepare(Operon::Span<Individual const> pop) const -> void
     {
@@ -48,66 +49,45 @@ public:
 
     [[nodiscard]] virtual auto Terminate() const -> bool { return evaluator_.get().BudgetExhausted(); }
 
-    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf, RecombinationResult& res) const -> void {
-        auto doCrossover   = std::bernoulli_distribution(pCrossover)(random);
-        auto doMutation    = std::bernoulli_distribution(pMutation)(random);
-        auto doLocalSearch = std::bernoulli_distribution(pLocal)(random);
-        auto keepChanges   = std::bernoulli_distribution(pLamarck)(random);
-
-        if (!(doCrossover || doMutation)) {
-            return;
-        }
-
+    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf, RecombinationResult& res) const -> void {
         auto pop = FemaleSelector().Population();
-
         if (!res.Parent1) {
             res.Parent1 = pop[ FemaleSelector()(random) ];
         }
 
-        if (doCrossover) {
+        using BernoulliTrial = std::bernoulli_distribution;
+        if (BernoulliTrial{pCrossover}(random)) {
             if (!res.Parent2) {
                 res.Parent2 = pop[ MaleSelector()(random) ];
             }
             res.Child = Individual{};
-            ENSURE(res.Parent1->Genotype.Length() > 0);
-            ENSURE(res.Parent2->Genotype.Length() > 0);
-            res.Child->Genotype = this->Crossover()(random, res.Parent1->Genotype, res.Parent2->Genotype);
+            res.Child->Genotype = Crossover()(random, res.Parent1->Genotype, res.Parent2->Genotype);
         }
 
-        if (doMutation) {
-            if (!res) { res.Child = Individual{}; }
-            res.Child->Genotype = doCrossover
-                ? this->Mutator()(random, std::move(res.Child->Genotype))
-                : this->Mutator()(random, res.Parent1->Genotype);
+        if (BernoulliTrial{pMutation}(random)) {
+            if (res.Child) {
+                res.Child->Genotype = Mutator()(random, std::move(res.Child->Genotype));
+            } else {
+                res.Child = Individual{};
+                res.Child->Genotype = Mutator()(random, res.Parent1->Genotype);
+            }
         }
 
-        auto coefficients = res.Child->Genotype.GetCoefficients();
-
-        auto const* opt = Optimizer();
-        if (doLocalSearch && (opt != nullptr && opt->Iterations() > 0)) {
-            auto summary = opt->Optimize(random, res.Child->Genotype);
-            // update budget counts in the evaluator
+        if (BernoulliTrial{pLocal}(random)) {
+            auto summary = (*coeffOptimizer_)(random, res.Child->Genotype);
             Evaluator().ResidualEvaluations += summary.FunctionEvaluations;
             Evaluator().JacobianEvaluations += summary.JacobianEvaluations;
-            if (summary.Success) {
-                res.Child->Genotype.SetCoefficients(summary.FinalParameters);
-            }
         }
 
         res.Child->Fitness = Evaluator()(random, res.Child.value(), buf);
         for (auto& v : res.Child->Fitness) {
             if (!std::isfinite(v)) { v = std::numeric_limits<Operon::Scalar>::max(); }
         }
-
-        if (!keepChanges) {
-            // revert tree coefficients to the previous values
-            res.Child->Genotype.SetCoefficients(coefficients);
-        }
     }
 
-    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> RecombinationResult {
+    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> RecombinationResult {
         RecombinationResult res;
-        Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf, res);
+        Generate(random, pCrossover, pMutation, pLocal, buf, res);
         return res;
     }
 
@@ -117,28 +97,28 @@ private:
     std::reference_wrapper<MutatorBase>   mutator_;
     std::reference_wrapper<SelectorBase>  femaleSelector_;
     std::reference_wrapper<SelectorBase>  maleSelector_;
-    OptimizerBase const* optimizer_{nullptr};
+    CoefficientOptimizer const*           coeffOptimizer_;
 };
 
 class OPERON_EXPORT BasicOffspringGenerator final : public OffspringGeneratorBase {
 public:
-    explicit BasicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
+    explicit BasicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, coeffOptimizer)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 };
 
 class OPERON_EXPORT BroodOffspringGenerator : public OffspringGeneratorBase {
 public:
-    explicit BroodOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
+    explicit BroodOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, coeffOptimizer)
         , broodSize_(DefaultBroodSize)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void BroodSize(size_t value) { broodSize_ = value; }
     [[nodiscard]] auto BroodSize() const -> size_t { return broodSize_; }
@@ -151,13 +131,13 @@ private:
 
 class OPERON_EXPORT PolygenicOffspringGenerator : public OffspringGeneratorBase {
 public:
-    explicit PolygenicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
+    explicit PolygenicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, coeffOptimizer)
         , broodSize_(DefaultBroodSize)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void PolygenicSize(size_t value) { broodSize_ = value; }
     [[nodiscard]] auto PolygenicSize() const -> size_t { return broodSize_; }
@@ -170,12 +150,12 @@ private:
 
 class OPERON_EXPORT OffspringSelectionGenerator : public OffspringGeneratorBase {
 public:
-    explicit OffspringSelectionGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
+    explicit OffspringSelectionGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, CoefficientOptimizer const* coeffOptimizer = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, coeffOptimizer)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void MaxSelectionPressure(size_t value) { maxSelectionPressure_ = value; }
     auto MaxSelectionPressure() const -> size_t { return maxSelectionPressure_; }

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -12,14 +12,23 @@
 
 namespace Operon {
 
-class OffspringGeneratorBase : public OperatorBase<std::optional<Individual>, /* crossover prob. */ double, /* mutation prob. */ double, /* memory buffer */ Operon::Span<Operon::Scalar>> {
+struct RecombinationResult {
+    std::optional<Operon::Individual> Child;
+    std::optional<Operon::Individual> Parent1;
+    std::optional<Operon::Individual> Parent2;
+
+    explicit operator bool() const { return Child.has_value(); }
+};
+
+class OffspringGeneratorBase : public OperatorBase<std::optional<Individual>, /* crossover prob. */ double, /* mutation prob. */ double, /* local search prob. */ double, /* lamarckian prob. */ double, /* memory buffer */ Operon::Span<Operon::Scalar>> {
 public:
-    OffspringGeneratorBase(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel)
+    OffspringGeneratorBase(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
         : evaluator_(eval)
         , crossover_(cx)
         , mutator_(mut)
         , femaleSelector_(femSel)
         , maleSelector_(maleSel)
+        , optimizer_{opt}
     {
     }
 
@@ -28,19 +37,7 @@ public:
     [[nodiscard]] auto Crossover() const -> CrossoverBase& { return crossover_.get(); }
     [[nodiscard]] auto Mutator() const -> MutatorBase& { return mutator_.get(); }
     [[nodiscard]] auto Evaluator() const -> EvaluatorBase& { return evaluator_.get(); }
-
-    // this method is necessary in order to avoid a code smell (default function arguments of virtual method)
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation) const -> std::optional<Individual>
-    {
-        const auto* base = static_cast<OperatorBase<std::optional<Individual>, double, double, Operon::Span<Operon::Scalar>> const*>(this);
-        return (*base)(random, pCrossover, pMutation, Operon::Span<Operon::Scalar> {});
-    }
-
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> override
-    {
-        const auto* base = static_cast<OperatorBase<std::optional<Individual>, double, double, Operon::Span<Operon::Scalar>> const*>(this);
-        return (*base)(random, pCrossover, pMutation, buf);
-    };
+    [[nodiscard]] auto Optimizer() const -> OptimizerBase const* { return optimizer_; }
 
     virtual auto Prepare(Operon::Span<Individual const> pop) const -> void
     {
@@ -48,35 +45,100 @@ public:
         this->MaleSelector().Prepare(pop);
         this->Evaluator().Prepare(pop);
     }
+
     [[nodiscard]] virtual auto Terminate() const -> bool { return evaluator_.get().BudgetExhausted(); }
+
+    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf, RecombinationResult& res) const -> void {
+        auto doCrossover   = std::bernoulli_distribution(pCrossover)(random);
+        auto doMutation    = std::bernoulli_distribution(pMutation)(random);
+        auto doLocalSearch = std::bernoulli_distribution(pLocal)(random);
+        auto keepChanges   = std::bernoulli_distribution(pLamarck)(random);
+
+        if (!(doCrossover || doMutation)) {
+            return;
+        }
+
+        auto pop = FemaleSelector().Population();
+
+        if (!res.Parent1) {
+            res.Parent1 = pop[ FemaleSelector()(random) ];
+        }
+
+        if (doCrossover) {
+            if (!res.Parent2) {
+                res.Parent2 = pop[ MaleSelector()(random) ];
+            }
+            res.Child = Individual{};
+            ENSURE(res.Parent1->Genotype.Length() > 0);
+            ENSURE(res.Parent2->Genotype.Length() > 0);
+            res.Child->Genotype = this->Crossover()(random, res.Parent1->Genotype, res.Parent2->Genotype);
+        }
+
+        if (doMutation) {
+            if (!res) { res.Child = Individual{}; }
+            res.Child->Genotype = doCrossover
+                ? this->Mutator()(random, std::move(res.Child->Genotype))
+                : this->Mutator()(random, res.Parent1->Genotype);
+        }
+
+        auto coefficients = res.Child->Genotype.GetCoefficients();
+
+        auto const* opt = Optimizer();
+        if (doLocalSearch && (opt != nullptr && opt->Iterations() > 0)) {
+            auto summary = opt->Optimize(random, res.Child->Genotype);
+            // update budget counts in the evaluator
+            Evaluator().ResidualEvaluations += summary.FunctionEvaluations;
+            Evaluator().JacobianEvaluations += summary.JacobianEvaluations;
+            if (summary.Success) {
+                res.Child->Genotype.SetCoefficients(summary.FinalParameters);
+            }
+        }
+
+        res.Child->Fitness = Evaluator()(random, res.Child.value(), buf);
+        for (auto& v : res.Child->Fitness) {
+            if (!std::isfinite(v)) { v = std::numeric_limits<Operon::Scalar>::max(); }
+        }
+
+        if (!keepChanges) {
+            // revert tree coefficients to the previous values
+            res.Child->Genotype.SetCoefficients(coefficients);
+        }
+    }
+
+    auto Generate(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> RecombinationResult {
+        RecombinationResult res;
+        Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf, res);
+        return res;
+    }
 
 private:
     std::reference_wrapper<EvaluatorBase> evaluator_;
     std::reference_wrapper<CrossoverBase> crossover_;
-    std::reference_wrapper<MutatorBase> mutator_;
-    std::reference_wrapper<SelectorBase> femaleSelector_;
-    std::reference_wrapper<SelectorBase> maleSelector_;
+    std::reference_wrapper<MutatorBase>   mutator_;
+    std::reference_wrapper<SelectorBase>  femaleSelector_;
+    std::reference_wrapper<SelectorBase>  maleSelector_;
+    OptimizerBase const* optimizer_{nullptr};
 };
 
 class OPERON_EXPORT BasicOffspringGenerator final : public OffspringGeneratorBase {
 public:
-    explicit BasicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel)
+    explicit BasicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> override;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 };
 
 class OPERON_EXPORT BroodOffspringGenerator : public OffspringGeneratorBase {
 public:
-    explicit BroodOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel)
+    explicit BroodOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
         , broodSize_(DefaultBroodSize)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> override;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void BroodSize(size_t value) { broodSize_ = value; }
     [[nodiscard]] auto BroodSize() const -> size_t { return broodSize_; }
@@ -89,13 +151,13 @@ private:
 
 class OPERON_EXPORT PolygenicOffspringGenerator : public OffspringGeneratorBase {
 public:
-    explicit PolygenicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel)
+    explicit PolygenicOffspringGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
         , broodSize_(DefaultBroodSize)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> override;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void PolygenicSize(size_t value) { broodSize_ = value; }
     [[nodiscard]] auto PolygenicSize() const -> size_t { return broodSize_; }
@@ -108,12 +170,12 @@ private:
 
 class OPERON_EXPORT OffspringSelectionGenerator : public OffspringGeneratorBase {
 public:
-    explicit OffspringSelectionGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel)
-        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel)
+    explicit OffspringSelectionGenerator(EvaluatorBase& eval, CrossoverBase& cx, MutatorBase& mut, SelectorBase& femSel, SelectorBase& maleSel, OptimizerBase const* opt = nullptr)
+        : OffspringGeneratorBase(eval, cx, mut, femSel, maleSel, opt)
     {
     }
 
-    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> override;
+    auto operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual> final;
 
     void MaxSelectionPressure(size_t value) { maxSelectionPressure_ = value; }
     auto MaxSelectionPressure() const -> size_t { return maxSelectionPressure_; }

--- a/include/operon/operators/initializer.hpp
+++ b/include/operon/operators/initializer.hpp
@@ -4,9 +4,11 @@
 #ifndef OPERON_INITIALIZER_HPP
 #define OPERON_INITIALIZER_HPP
 
+#include "operon/core/tree.hpp"
 #include "operon/operators/creator.hpp"
 
 namespace Operon {
+
 struct CoefficientInitializerBase : public OperatorBase<void, Tree&> {
 };
 

--- a/include/operon/operators/local_search.hpp
+++ b/include/operon/operators/local_search.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2024 Heal Research
+
+#ifndef OPERON_LOCAL_SEARCH_HPP
+#define OPERON_LOCAL_SEARCH_HPP
+
+#include "operon/core/operator.hpp"
+#include "operon/operon_export.hpp"
+
+
+namespace Operon {
+
+// forward declarations
+class Tree;
+class OptimizerBase;
+struct OptimizerSummary;
+
+class OPERON_EXPORT CoefficientOptimizer : public OperatorBase<OptimizerSummary, Operon::Tree&> {
+public:
+    explicit CoefficientOptimizer(OptimizerBase const& optimizer, double lmProb = 1.0)
+        : optimizer_(optimizer)
+        , lamarckianProbability_(lmProb)
+    { }
+
+    // convenience
+    auto operator()(Operon::RandomGenerator& rng, Operon::Tree& tree) const -> OptimizerSummary override;
+
+private:
+
+    std::reference_wrapper<Operon::OptimizerBase const> optimizer_;
+    double lamarckianProbability_{1.0};
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/optimizer/likelihood/likelihood_base.hpp
+++ b/include/operon/optimizer/likelihood/likelihood_base.hpp
@@ -5,10 +5,10 @@
 #define OPERON_LIKELIHOOD_BASE_HPP
 
 #include <Eigen/Core>
+#include <vstat/vstat.hpp>
 
 #include "operon/core/types.hpp"
 #include "operon/interpreter/interpreter.hpp"
-#include <vstat/vstat.hpp>
 
 namespace Operon {
 
@@ -29,8 +29,8 @@ struct LikelihoodBase {
     using Scalar = T;
     using Matrix = Eigen::Matrix<Scalar, -1, -1>;
     using Vector = Eigen::Matrix<Scalar, -1, 1>;
-    using Ref = Eigen::Ref<Vector>;
-    using Cref = Eigen::Ref<Vector const> const&;
+    using Ref    = Eigen::Ref<Vector>;
+    using Cref   = Eigen::Ref<Vector const> const&;
 
     using scalar_t = T; // for lbfgs solver NOLINT
 

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -92,7 +92,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto generateOffspring = subflow.for_each_index(size_t{1}, offspring.size(), size_t{1}, [&](size_t i) {
                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);
                 while (!stop()) {
-                    if (auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, config.LamarckianProbability, buf); result.has_value()) {
+                    if (auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, buf); result.has_value()) {
                         offspring[i] = std::move(result.value());
                         return;
                     }

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -92,7 +92,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto generateOffspring = subflow.for_each_index(size_t{1}, offspring.size(), size_t{1}, [&](size_t i) {
                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);
                 while (!stop()) {
-                    if (auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, buf); result.has_value()) {
+                    if (auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, config.LamarckianProbability, buf); result.has_value()) {
                         offspring[i] = std::move(result.value());
                         return;
                     }

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -166,7 +166,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             auto generateOffspring = subflow.for_each_index(size_t{0}, offspring.size(), size_t{1}, [&](size_t i) {
                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);
                 while (!stop()) {
-                    auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, config.LamarckianProbability, buf);
+                    auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, buf);
                     if (result) {
                         offspring[i] = std::move(*result);
                         ENSURE(offspring[i].Genotype.Length() > 0);

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -166,7 +166,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             auto generateOffspring = subflow.for_each_index(size_t{0}, offspring.size(), size_t{1}, [&](size_t i) {
                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);
                 while (!stop()) {
-                    auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, buf);
+                    auto result = generator(rngs[i], config.CrossoverProbability, config.MutationProbability, config.LocalSearchProbability, config.LamarckianProbability, buf);
                     if (result) {
                         offspring[i] = std::move(*result);
                         ENSURE(offspring[i].Genotype.Length() > 0);

--- a/source/operators/crossover.cpp
+++ b/source/operators/crossover.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
 
+#include <fmt/core.h>
 #include <random>
 
 #include "operon/core/contracts.hpp"
@@ -78,11 +79,13 @@ auto SubtreeCrossover::FindCompatibleSwapLocations(Operon::RandomGenerator& rand
 auto SubtreeCrossover::operator()(Operon::RandomGenerator& random, const Tree& lhs, const Tree& rhs) const -> Tree
 {
     auto [i, j] = FindCompatibleSwapLocations(random, lhs, rhs);
-
     auto child = Cross(lhs, rhs, i, j);
 
-    ENSURE(child.Depth() <= std::max(maxDepth_, lhs.Depth()));
-    ENSURE(child.Length() <= std::max(maxLength_, lhs.Length()));
+    auto maxDepth{std::max(maxDepth_, lhs.Depth())};
+    auto maxLength{std::max(maxLength_, lhs.Length())};
+
+    ENSURE(child.Depth() <= maxDepth);
+    ENSURE(child.Length() <= maxLength);
 
     return child;
 }

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -38,7 +38,7 @@ namespace Operon {
     }
 
     template<> auto OPERON_EXPORT
-    Evaluator<DefaultDispatch>::operator()(Operon::RandomGenerator& rng, Individual& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType
+    Evaluator<DefaultDispatch>::operator()(Operon::RandomGenerator& /*rng*/, Individual& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType
     {
         ++CallCount;
         auto const& problem = GetProblem();
@@ -67,16 +67,6 @@ namespace Operon {
             ENSURE(buf.size() >= targetValues.size());
             return error_(buf, targetValues);
         };
-
-        if (optimizer_ != nullptr && optimizer_->Iterations() > 0) {
-            auto t0 = std::chrono::steady_clock::now();
-            auto summary = optimizer_->Optimize(rng, tree);
-            ResidualEvaluations += summary.FunctionEvaluations;
-            JacobianEvaluations += summary.JacobianEvaluations;
-            if (summary.Success) { tree.SetCoefficients(summary.FinalParameters); }
-            auto t1 = std::chrono::steady_clock::now();
-            CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1-t0).count();
-        }
 
         auto fit = static_cast<Operon::Scalar>(computeFitness());
         if (!std::isfinite(fit)) {
@@ -153,108 +143,6 @@ namespace Operon {
                 throw std::runtime_error("Unknown AggregateType");
             }
         }
-    }
-
-    template<> auto OPERON_EXPORT
-    MinimumDescriptionLengthEvaluator<DefaultDispatch>::operator()(Operon::RandomGenerator& rng, Individual& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType {
-        ++CallCount;
-
-        auto const& problem = Evaluator::GetProblem();
-        auto const range = problem.TrainingRange();
-        auto const& dataset = problem.GetDataset();
-        auto const& nodes = ind.Genotype.Nodes();
-        auto const& dtable = Evaluator::GetDispatchTable();
-        auto const* optimizer = Evaluator::GetOptimizer();
-        EXPECT(optimizer != nullptr);
-
-        // this call will optimize the tree coefficients and compute the SSE
-        auto& tree = ind.Genotype;
-        Operon::Interpreter<Operon::Scalar, DefaultDispatch> interpreter{dtable, dataset, ind.Genotype};
-        auto parameters = tree.GetCoefficients();
-
-        if (optimizer != nullptr && optimizer->Iterations() > 0) {
-            auto summary = optimizer->Optimize(rng, tree);
-            ResidualEvaluations += summary.FunctionEvaluations;
-            JacobianEvaluations += summary.JacobianEvaluations;
-            if (summary.Success) {
-                parameters = summary.FinalParameters;
-                tree.SetCoefficients(parameters);
-            }
-        }
-
-        auto const p { static_cast<double>(parameters.size()) };
-
-        std::vector<Operon::Scalar> buffer;
-        if (buf.size() < range.Size()) {
-            buffer.resize(range.Size());
-            buf = Operon::Span<Operon::Scalar>(buffer);
-        }
-
-        ++ResidualEvaluations;
-        interpreter.Evaluate(parameters, range, buf);
-
-        auto estimatedValues = buf;
-        auto targetValues    = problem.TargetValues(range);
-
-        // codelength of the complexity
-        // count number of unique functions
-        // - count weight * variable as three nodes
-        // - compute complexity c of the remaining numerical values
-        //   (that are not part of the coefficients that are optimized)
-        Operon::Set<Operon::Hash> uniqueFunctions; // to count the number of unique functions
-        auto k{0.0}; // number of nodes
-        auto cComplexity { 0.0 };
-
-        // codelength of the parameters
-        ++JacobianEvaluations;
-        Eigen::Matrix<Operon::Scalar, -1, -1> j = interpreter.JacRev(parameters, range); // jacobian
-        auto fm = optimizer->ComputeFisherMatrix(estimatedValues, {j.data(), static_cast<std::size_t>(j.size())}, sigma_);
-        auto ii = fm.diagonal().array();
-        ENSURE(ii.size() == p);
-
-        auto cParameters { 0.0 };
-        auto constexpr eps = std::numeric_limits<Operon::Scalar>::epsilon(); // machine epsilon for zero comparison
-
-        for (auto i = 0, j = 0; i < std::ssize(nodes); ++i) {
-            auto const& n = nodes[i];
-
-            // count the number of nodes and the number of unique operators
-            k += n.IsVariable() ? 3 : 1;
-            uniqueFunctions.insert(n.HashValue);
-
-            if (n.Optimize) {
-                // this branch computes the description length of the parameters to be optimized
-                auto const di = std::sqrt(12 / ii(j));
-                auto const ci = std::abs(parameters[j]);
-
-                if (!(std::isfinite(ci) && std::isfinite(di)) || ci / di < 1) {
-                    //ind.Genotype[i].Optimize = false;
-                    //auto const v = ind.Genotype[i].Value;
-                    //ind.Genotype[i].Value = 0;
-                    //auto fit = (*this)(rng, ind, buf);
-                    //ind.Genotype[i].Optimize = true;
-                    //ind.Genotype[i].Value = v;
-                    //return fit;
-                } else {
-                    cParameters += 0.5 * std::log(ii(j)) + std::log(ci);
-                }
-                ++j;
-            } else {
-                // this branch computes the description length of the remaining tree structure
-                if (std::abs(n.Value) < eps) { continue; }
-                cComplexity += std::log(std::abs(n.Value));
-            }
-        }
-
-        auto q { static_cast<double>(uniqueFunctions.size()) };
-        if (q > 0) { cComplexity += static_cast<double>(k) * std::log(q); }
-
-        cParameters -= p/2 * std::log(3);
-
-        auto cLikelihood = optimizer->ComputeLikelihood(estimatedValues, targetValues, sigma_);
-        auto mdl = cComplexity + cParameters + cLikelihood;
-        if (!std::isfinite(mdl)) { mdl = EvaluatorBase::ErrMax; }
-        return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(mdl) };
     }
 
     template<> auto OPERON_EXPORT

--- a/source/operators/generator/basic.cpp
+++ b/source/operators/generator/basic.cpp
@@ -4,9 +4,9 @@
 #include "operon/operators/generator.hpp"
 
 namespace Operon {
-    auto BasicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto BasicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
-        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf);
+        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, buf);
         return res.Child;
     }
 } // namespace Operon

--- a/source/operators/generator/basic.cpp
+++ b/source/operators/generator/basic.cpp
@@ -4,36 +4,9 @@
 #include "operon/operators/generator.hpp"
 
 namespace Operon {
-    auto BasicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto BasicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
-        std::uniform_real_distribution<double> uniformReal;
-        bool doCrossover = std::bernoulli_distribution(pCrossover)(random);
-        bool doMutation = std::bernoulli_distribution(pMutation)(random);
-
-        if (!(doCrossover || doMutation)) {
-            return std::nullopt;
-        }
-
-        auto population = this->FemaleSelector().Population();
-
-        auto first = this->FemaleSelector()(random);
-        Individual child;
-
-        if (doCrossover) {
-            auto second = this->MaleSelector()(random);
-            child.Genotype = this->Crossover()(random, population[first].Genotype, population[second].Genotype);
-        }
-
-        if (doMutation) {
-            child.Genotype = doCrossover
-                ? this->Mutator()(random, std::move(child.Genotype))
-                : this->Mutator()(random, population[first].Genotype);
-        }
-
-        child.Fitness = this->Evaluator()(random, child, buf);
-        for (auto& v : child.Fitness) {
-            if (!std::isfinite(v)) { v = std::numeric_limits<Operon::Scalar>::max(); }
-        }
-        return std::make_optional(child);
+        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf);
+        return res.Child;
     }
 } // namespace Operon

--- a/source/operators/generator/brood.cpp
+++ b/source/operators/generator/brood.cpp
@@ -5,7 +5,7 @@
 #include "operon/operators/non_dominated_sorter.hpp"
 
 namespace Operon {
-    auto BroodOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto BroodOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
         auto pop = this->FemaleSelector().Population();
 
@@ -15,7 +15,7 @@ namespace Operon {
         // the brood offspring generator creates a brood of offspring from the same two parents
         auto makeOffspring = [&]() {
             RecombinationResult res{ {}, p1, p2 };
-            OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf, res);
+            OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, buf, res);
             return res ? res.Child.value() : res.Parent1.value();
         };
 

--- a/source/operators/generator/brood.cpp
+++ b/source/operators/generator/brood.cpp
@@ -5,43 +5,25 @@
 #include "operon/operators/non_dominated_sorter.hpp"
 
 namespace Operon {
-    auto BroodOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto BroodOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
-        std::uniform_real_distribution<double> uniformReal;
+        auto pop = this->FemaleSelector().Population();
 
-        auto population = this->FemaleSelector().Population();
+        auto const& p1 = pop[ FemaleSelector()(random) ];
+        auto const& p2 = pop[ MaleSelector()(random) ];
 
-        auto first = FemaleSelector()(random);
-        auto second = MaleSelector()(random);
-
-        // assuming the basic generator never fails
+        // the brood offspring generator creates a brood of offspring from the same two parents
         auto makeOffspring = [&]() {
-            Individual child(population[first].Fitness.size());
-            bool doCrossover = std::bernoulli_distribution(pCrossover)(random);
-            bool doMutation = std::bernoulli_distribution(pMutation)(random);
-
-            if (doCrossover) {
-                child.Genotype = Crossover()(random, population[first].Genotype, population[second].Genotype);
-            }
-
-            if (doMutation) {
-                child.Genotype = doCrossover
-                    ? Mutator()(random, std::move(child.Genotype))
-                    : Mutator()(random, population[first].Genotype);
-            }
-
-            auto f = Evaluator()(random, child, buf);
-            for (size_t i = 0; i < f.size(); ++i) {
-                child[i] = std::isfinite(f[i]) ? f[i] : std::numeric_limits<Operon::Scalar>::max();
-            }
-            return child;
+            RecombinationResult res{ {}, p1, p2 };
+            OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf, res);
+            return res ? res.Child.value() : res.Parent1.value();
         };
 
         std::vector<Individual> offspring(broodSize_);
         std::generate(offspring.begin(), offspring.end(), makeOffspring);
         SingleObjectiveComparison comp{0};
 
-        if (population.front().Size() > 1) {
+        if (pop.front().Size() > 1) {
             std::stable_sort(offspring.begin(), offspring.end(), LexicographicalComparison{});
             auto fronts = RankIntersectSorter{}(offspring);
             auto best = *std::min_element(fronts[0].begin(), fronts[0].end(), [&](auto i, auto j) { return comp(offspring[i], offspring[j]); });

--- a/source/operators/generator/os.cpp
+++ b/source/operators/generator/os.cpp
@@ -6,51 +6,22 @@
 
 namespace Operon {
 
-    auto OffspringSelectionGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto OffspringSelectionGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
-        std::uniform_real_distribution<double> uniformReal;
-        bool doCrossover = uniformReal(random) < pCrossover;
-        bool doMutation = uniformReal(random) < pMutation;
-
-        if (!(doCrossover || doMutation)) {
-            return std::nullopt;
-        }
-
-        auto population = FemaleSelector().Population();
-
-        size_t first = FemaleSelector()(random);
-
-        std::optional<Individual> p1{ population[first] };
-        std::optional<Individual> p2;
-
-        Individual child(p1->Size());
-
-        if (doCrossover) {
-            p2 = population[ MaleSelector()(random) ];
-            child.Genotype = Crossover()(random, p1->Genotype, p2->Genotype);
-        }
-
-        if (doMutation) {
-            child.Genotype = doCrossover
-                ? Mutator()(random, std::move(child.Genotype))
-                : Mutator()(random, p1->Genotype);
-        }
-
-        child.Fitness = Evaluator()(random, child, buf);
+        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf);
         bool accept{false};
-
-        if (p2) {
-            Individual q(child.Size());
-            for (size_t i = 0; i < child.Size(); ++i) {
-                auto f1 = (*p1)[i];
-                auto f2 = (*p2)[i];
+        if (res.Parent2) {
+            Individual q(res.Child->Size());
+            for (size_t i = 0; i < q.Size(); ++i) {
+                auto f1 = (*res.Parent1)[i];
+                auto f2 = (*res.Parent2)[i];
                 q[i] = std::max(f1, f2) - static_cast<Operon::Scalar>(comparisonFactor_) * std::abs(f1 - f2);
-                accept = Operon::ParetoDominance{}(child.Fitness, q.Fitness) != Dominance::Right;
+                accept = Operon::ParetoDominance{}(res.Child->Fitness, q.Fitness) != Dominance::Right;
             }
         } else {
-            accept = Operon::ParetoDominance{}(child.Fitness, p1->Fitness) != Dominance::Right;
+            accept = Operon::ParetoDominance{}(res.Child->Fitness, res.Parent1->Fitness) != Dominance::Right;
         }
-        return accept ? std::make_optional(child) : std::nullopt;
+        return accept ? res.Child : std::nullopt;
     }
 
 } // namespace Operon

--- a/source/operators/generator/os.cpp
+++ b/source/operators/generator/os.cpp
@@ -6,9 +6,9 @@
 
 namespace Operon {
 
-    auto OffspringSelectionGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto OffspringSelectionGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
-        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf);
+        auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, buf);
         bool accept{false};
         if (res.Parent2) {
             Individual q(res.Child->Size());

--- a/source/operators/generator/poly.cpp
+++ b/source/operators/generator/poly.cpp
@@ -5,14 +5,14 @@
 #include "operon/operators/non_dominated_sorter.hpp"
 
 namespace Operon {
-    auto PolygenicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
+    auto PolygenicOffspringGenerator::operator()(Operon::RandomGenerator& random, double pCrossover, double pMutation, double pLocal, Operon::Span<Operon::Scalar> buf) const -> std::optional<Individual>
     {
         std::uniform_real_distribution<double> uniformReal;
         auto pop = this->FemaleSelector().Population();
 
         // assuming the basic generator never fails
         auto makeOffspring = [&]() {
-            auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, pLamarck, buf);
+            auto res = OffspringGeneratorBase::Generate(random, pCrossover, pMutation, pLocal, buf);
             return res ? res.Child.value() : res.Parent1.value();
         };
 

--- a/source/operators/local_search.cpp
+++ b/source/operators/local_search.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2024 Heal Research
+
+#include "operon/operators//local_search.hpp"
+
+#include "operon/core/tree.hpp"
+#include "operon/optimizer/optimizer.hpp"
+
+namespace Operon {
+
+auto CoefficientOptimizer::operator()(Operon::RandomGenerator& rng, Operon::Tree& tree) const -> OptimizerSummary {
+    OptimizerSummary summary;
+    auto const& optimizer = optimizer_.get();
+    if (optimizer.Iterations() > 0) {
+        summary = optimizer.Optimize(rng, tree);
+
+        if (std::bernoulli_distribution(lamarckianProbability_)(rng) && summary.Success) {
+            tree.SetCoefficients(summary.FinalParameters);
+        }
+    }
+    return summary;
+}
+} // namespace Operon

--- a/test/source/implementation/evaluation.cpp
+++ b/test/source/implementation/evaluation.cpp
@@ -306,7 +306,7 @@ TEST_CASE("parameter optimization")
     rules.emplace_back(new UpdateRule::AmsGrad<Operon::Scalar>(dim));
     rules.emplace_back(new UpdateRule::Yogi<Operon::Scalar>(dim));
 
-    auto testOptimizer = [&](OptimizerBase<DTable>& optimizer, std::string const& name) {
+    auto testOptimizer = [&](OptimizerBase& optimizer, std::string const& name) {
         fmt::print(fmt::fg(fmt::color::orange), "=== {} Solver ===\n", name);
         auto summary = optimizer.Optimize(rng, tree);
         fmt::print("batch size: {}\n", batchSize);

--- a/test/source/implementation/poisson_regression.cpp
+++ b/test/source/implementation/poisson_regression.cpp
@@ -104,8 +104,9 @@ namespace Operon::Test {
 
         Operon::CrowdedComparison cc;
         Operon::TournamentSelector selector{cc};
+        Operon::CoefficientOptimizer co{optimizer};
 
-        Operon::BasicOffspringGenerator gen{evaluator, crossover, mutator, selector, selector, &optimizer};
+        Operon::BasicOffspringGenerator gen{evaluator, crossover, mutator, selector, selector, &co};
         Operon::RankIntersectSorter rankSorter;
         Operon::KeepBestReinserter reinserter{cc};
 

--- a/test/source/implementation/poisson_regression.cpp
+++ b/test/source/implementation/poisson_regression.cpp
@@ -101,12 +101,11 @@ namespace Operon::Test {
         Operon::SGDOptimizer<decltype(dt), Likelihood> optimizer{dt, problem};
         // Operon::LBFGSOptimizer<decltype(dt), Operon::PoissonLikelihood<>> optimizer{dt, problem};
         optimizer.SetIterations(100);
-        poissonEvaluator.SetOptimizer(&optimizer);
 
         Operon::CrowdedComparison cc;
         Operon::TournamentSelector selector{cc};
 
-        Operon::BasicOffspringGenerator gen{evaluator, crossover, mutator, selector, selector};
+        Operon::BasicOffspringGenerator gen{evaluator, crossover, mutator, selector, selector, &optimizer};
         Operon::RankIntersectSorter rankSorter;
         Operon::KeepBestReinserter reinserter{cc};
 


### PR DESCRIPTION
The motivation for this PR is to decouple the evaluator operator from local search. The evaluator should have no side effects, it should just produce fitness values.

For now, local search functionality has been moved into the offspring generator, but it would probably be a good idea to make it into an independent `LocalSearchOperator`.

Two new CLI parameters are introduced:
- `local_search_probability`: allows local search to be applied with a probability
- `lamarckian_probability`: specifies the probability that the optimized coefficients are written back to the tree individual.