### PR TITLE
Work in progress: Adding warm start mechanism

### DIFF
--- a/include/operon/algorithms/gp.hpp
+++ b/include/operon/algorithms/gp.hpp
@@ -34,8 +34,8 @@ public:
     {
     }
 
-    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr) -> void;
-    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0) -> void;
+    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr, bool /*warmStart*/ = false) -> void;
+    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0, bool /*warmStart*/ = false) -> void;
 };
 } // namespace Operon
 

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -62,8 +62,8 @@ namespace Operon {
     auto offspring = Offspring();
 
     if (warmStart) {
-	Reset();
-	t0 = std::chrono::steady_clock::now();
+        Reset();
+        t0 = std::chrono::steady_clock::now();
     }
 
     // while loop control flow
@@ -125,10 +125,8 @@ namespace Operon {
         [&]() { /* all done */ }  // work done, report last gen and stop
     ); // evolutionary loop
 
-    if (!warmStart) {
-        init.name("init");
-        init.precede(cond);
-    }
+    init.name("init");
+    init.precede(cond);
     
     cond.name("termination");
     body.name("main loop");

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -63,6 +63,7 @@ namespace Operon {
 
     if (warmStart) {
 	Reset();
+	t0 = std::chrono::steady_clock::now();
     }
 
     // while loop control flow

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -144,6 +144,11 @@ namespace Operon {
         threads = std::thread::hardware_concurrency();
     }
     tf::Executor executor(threads);
+
+    if (warmStart) {
+	Reset();
+    } 
+
     Run(executor, random, std::move(report), warmStart);
 }
 } // namespace Operon

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -55,11 +55,15 @@ namespace Operon {
 
     auto stop = [&]() {
         Elapsed() = computeElapsed();
-        return generator->Terminate() || Generation() == config.Generations || Elapsed() > static_cast<double>(config.TimeLimit);
+        return Generation() == config.Generations;
     };
 
     auto parents = Parents();
     auto offspring = Offspring();
+
+    if (warmStart) {
+	Reset();
+    }
 
     // while loop control flow
     tf::Taskflow taskflow;
@@ -144,10 +148,6 @@ namespace Operon {
         threads = std::thread::hardware_concurrency();
     }
     tf::Executor executor(threads);
-
-    if (warmStart) {
-	Reset();
-    } 
 
     Run(executor, random, std::move(report), warmStart);
 }


### PR DESCRIPTION
Hi Bogdan,

Any thoughts on this implementation of a warm start so far?
I'm using Operon for a dataset of 1,000,000 rows with 16 features and 6 outputs.
Each output needs to have its own GP so the computational cost is quite expensive.
I'm hoping to implement partial horizontal batching (i.e. sampling a data subset) and the best way I can think of approaching that is by implementing a warm start mechanism.

In my own test code this is what I'm seeing:

```
Running once
gen= 10 
fit= [0.3743118345737457]

(((sin(((-3.988398) * X3)) + (1.293287 + (0.268645 * X5))) * cos((-1.805155))) + (((exp((((-1.025611) / (-0.575239)) * (0.864358 * X3))) + (((-0.029093) * X7) + 0.075327)) + (0.074877 * X9)) + (cos(((((-3.975033) * X5) / (-3.071976)) * cos((((-3.551571) * X7) + (-4.110041))))) * sin((((-1.053369) * X3) * ((-0.803978) * X7))))))
Running twice
gen= 0 
fit= [0.3743118345737457]

(((sin(((-3.988398) * X3)) + (1.293287 + (0.268645 * X5))) * cos((-1.805155))) + (((exp((((-1.025611) / (-0.575239)) * (0.864358 * X3))) + (((-0.029093) * X7) + 0.075327)) + (0.074877 * X9)) + (cos(((((-3.975033) * X5) / (-3.071976)) * cos((((-3.551571) * X7) + (-4.110041))))) * sin((((-1.053369) * X3) * ((-0.803978) * X7))))))

```
So it looks like the second Run() call immediately ends at generation 0. Not quite sure why yet.

