### PR TITLE
Adds a warm start mechanism to the Run method to allow for online/batch training

### DIFF
--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -60,6 +60,9 @@ public:
     [[nodiscard]] auto Elapsed() const -> double { return elapsed_; }
     auto Elapsed() -> double& { return elapsed_; }
 
+    [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
+    auto IsFitted() -> bool& { return isFitted_; }
+
     auto Reset() -> void
     {
         generation_ = 0;
@@ -67,6 +70,15 @@ public:
         GetGenerator()->Evaluator()->Reset();
     }
 
+    auto RestoreIndividuals(std::vector<Individual> inds) -> void
+    {
+        EXPECT(inds.size() == config_.PoolSize + config_.PopulationSize,
+                "Mismatched number of individuals (must match pool/population sizes)");
+        individuals_ = std::move(inds);
+        parents_ = Operon::Span<Individual>(individuals_.data(), config_.PoolSize);
+        offspring_ = Operon::Span<Individual>(individuals_.data() + config_.PoolSize, config_.PopulationSize);
+    }
+    
 private:
     GeneticAlgorithmConfig config_;
 
@@ -82,6 +94,7 @@ private:
 
     size_t generation_{0};
     double elapsed_{0}; // elapsed time in microseconds
+    bool isFitted_{false};
 };
 
 } // namespace Operon

--- a/include/operon/algorithms/gp.hpp
+++ b/include/operon/algorithms/gp.hpp
@@ -34,8 +34,8 @@ public:
     {
     }
 
-    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr) -> void;
-    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0) -> void;
+    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
+    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0, /*warmStart*/ bool = false) -> void;
 };
 } // namespace Operon
 

--- a/include/operon/algorithms/nsga2.hpp
+++ b/include/operon/algorithms/nsga2.hpp
@@ -48,8 +48,8 @@ public:
 
     [[nodiscard]] auto Best() const -> Operon::Span<Individual const> { return { best_.data(), best_.size() }; }
 
-    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr) -> void;
-    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0) -> void;
+    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
+    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0, /*warmStart*/ bool = false) -> void;
 };
 } // namespace Operon
 

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -20,8 +20,10 @@
 #include "operon/operators/reinserter.hpp"   // for ReinserterBase
 
 namespace Operon {
-auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report) -> void
+auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report, bool warmStart) -> void
 {
+    Reset();
+
     const auto config = GetConfig();
     const auto& treeInit = GetTreeInitializer();
     const auto& coeffInit = GetCoefficientInitializer();
@@ -65,10 +67,6 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     tf::Taskflow taskflow;
     auto [init, cond, body, back, done] = taskflow.emplace(
         [&](tf::Subflow& subflow) {
-            auto init = subflow.for_each_index(size_t{0}, parents.size(), size_t{1}, [&](size_t i) {
-                parents[i].Genotype = (*treeInit)(rngs[i]);
-                (*coeffInit)(rngs[i], parents[i].Genotype);
-            }).name("initialize population");
             auto prepareEval = subflow.emplace([&]() { evaluator->Prepare(parents); }).name("prepare evaluator");
             auto eval = subflow.for_each_index(size_t{0}, parents.size(), size_t{1}, [&](size_t i) {
                 auto id = executor.this_worker_id();
@@ -79,9 +77,17 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                 parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
             }).name("evaluate population");
             auto reportProgress = subflow.emplace([&](){ if (report) { std::invoke(report); } }).name("report progress");
-            init.precede(prepareEval);
             prepareEval.precede(eval);
             eval.precede(reportProgress);
+
+            if (!(IsFitted() && warmStart)) {
+                auto init = subflow.for_each_index(size_t{0}, parents.size(), size_t{1}, [&](size_t i) {
+                    parents[i].Genotype = (*treeInit)(rngs[i]);
+                    (*coeffInit)(rngs[i], parents[i].Genotype);
+                }).name("initialize population");
+
+                init.precede(prepareEval);
+            }
         }, // init
         stop, // loop condition
         [&](tf::Subflow& subflow) {
@@ -111,7 +117,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             incrementGeneration.precede(reportProgress);
         }, // loop body (evolutionary main loop)
         [&]() { return 0; }, // jump back to the next iteration
-        [&]() { /* all done */ }  // work done, report last gen and stop
+        [&]() { IsFitted() = true; /* all done */ }  // work done, report last gen and stop
     ); // evolutionary loop
 
     init.name("init");
@@ -130,11 +136,11 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     executor.wait_for_all();
 }
 
-auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads) -> void {
+auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads, bool warmStart) -> void {
     if (threads == 0) {
         threads = std::thread::hardware_concurrency();
     }
     tf::Executor executor(threads);
-    Run(executor, random, std::move(report));
+    Run(executor, random, std::move(report), warmStart);
 }
 } // namespace Operon


### PR DESCRIPTION
This update introduces a warm start mechanism to the GeneticProgrammingAlgorithm::Run method, enabling incremental or online updates. This enhancement aligns Operon with established frameworks such as PySR and Scikit-learn, significantly improving its flexibility and usability in iterative training workflows.

The addition of warm starting has immediate benefits for the PyOperon scikit-learn bindings, as it allows users to call .fit() incrementally.  This eliminates reliance on the callback interface and reduces associated limitations, making it much easier to use.

This feature is critical for my own research, where a single experiment may span up to 20 days without batching. With warm start and horizontal batching, the same experiment can be completed in a fraction of the time. The recent study ["A Survey on Batch Training in Genetic Programming" by Liah Rosenfeld and Leonardo Vanneschi](https://link.springer.com/article/10.1007/s10710-024-09501-6) highlights the promise of horizontal batching as a powerful strategy for scaling genetic programming.

[Moreover, warm start support is a requested feature in PyOperon](https://github.com/heal-research/pyoperon/issues/22), and a corresponding pull request has been opened in the PyOperon repository to integrate this functionality into the Python bindings.