### PR TITLE
refactor(dataset): replace Eigen matrix with mdspan/mdarray storage

### DIFF
--- a/include/operon/core/dataset.hpp
+++ b/include/operon/core/dataset.hpp
@@ -4,10 +4,11 @@
 #ifndef DATASET_H
 #define DATASET_H
 
-#include <Eigen/Core>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include <gsl/pointers>
-#include <optional>
 
 #include "operon/operon_export.hpp"
 #include "contracts.hpp"
@@ -17,134 +18,81 @@
 
 namespace Operon {
 
-// a dataset variable described by: name, hash value (for hashing), data column index
-
 class OPERON_EXPORT Dataset {
 public:
-    // some useful aliases
     using Variables = Operon::Map<Operon::Hash, Operon::Variable>;
-    using Matrix = Eigen::Array<Operon::Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
-    using Map = Eigen::Map<Matrix const>;
+    using Extents   = std::dextents<int, 2>;
+    using Storage   = MDArray<Scalar, Extents>;
+    using View      = MDSpan<Scalar const, Extents>;
 
 private:
     Variables variables_;
-    Matrix values_;
-    Map map_;
+    Storage   storage_;
+    View      view_;
 
-    Dataset();
+    std::optional<Vector<Scalar>> weights_;
 
-    // read data from a csv file and return a map (view of the data)
-    auto ReadCsv(std::string const& path, bool hasHeader) -> Matrix;
-
-    // this method ensures the same ordering of variables in the variables vector
-    // based on index, name, hash value
+    auto ReadCsv(std::string const& path, bool hasHeader) -> Storage;
     void InitializeVariables(std::vector<std::string> const&);
 
+    [[nodiscard]] auto ColSpan(int idx) const noexcept -> Span<Scalar const> {
+        return { view_.data_handle() + (static_cast<ptrdiff_t>(idx) * view_.extent(0)), static_cast<size_t>(view_.extent(0)) };
+    }
+
 public:
-    explicit Dataset(const std::string& path, bool hasHeader = false);
+    explicit Dataset(std::string const& path, bool hasHeader = false);
+    Dataset(std::vector<std::string> const& vars, std::vector<std::vector<Scalar>> const& vals);
+    explicit Dataset(std::vector<std::vector<Scalar>> const& vals);
+    Dataset(gsl::not_null<Scalar const*> data, int rows, int cols);
 
-    Dataset(Dataset const& rhs)
-        : variables_(rhs.variables_)
-        , values_(rhs.values_)
-        , map_(values_.data(), values_.rows(), values_.cols())
-    {
-    }
-
-    Dataset(Dataset&& rhs) noexcept
-        : variables_(std::move(rhs.variables_))
-        , values_(std::move(rhs.values_))
-        , map_(rhs.map_)
-    {
-    }
-
-    Dataset(std::vector<std::string> const& vars, std::vector<std::vector<Operon::Scalar>> const& vals);
-
-    explicit Dataset(std::vector<std::vector<Operon::Scalar>> const& vals);
-
-    //explicit Dataset(Eigen::Ref<Matrix const> ref);
-    Dataset(gsl::not_null<Matrix::Scalar const*> data, Eigen::Index rows, Eigen::Index cols);
-
-    explicit Dataset(Matrix vals);
+    Dataset(Dataset const& rhs);
+    Dataset(Dataset&& rhs) noexcept;
 
     ~Dataset() = default;
 
-    auto operator=(Dataset rhs) -> Dataset&
-    {
-        Swap(rhs);
-        return *this;
-    }
+    auto operator=(Dataset rhs) -> Dataset& { Swap(rhs); return *this; }
+    auto operator=(Dataset&& rhs) noexcept -> Dataset&;
 
-    auto operator=(Dataset&& rhs) noexcept -> Dataset&
-    {
-        if (this != &rhs) {
-            variables_ = std::move(rhs.variables_);
-            values_ = std::move(rhs.values_);
-            new (&map_) Map(rhs.map_.data(), rhs.map_.rows(), rhs.map_.cols()); // we use placement new (no allocation)
-        }
-        return *this;
-    }
+    void Swap(Dataset& rhs) noexcept;
 
-    void Swap(Dataset& rhs) noexcept
-    {
-        variables_.swap(rhs.variables_);
-        values_.swap(rhs.values_);
-        new (&map_) Map(values_.data(), values_.rows(), values_.cols()); // we use placement new (no allocation)
-    }
+    auto operator==(Dataset const& rhs) const noexcept -> bool;
 
-    auto operator==(Dataset const& rhs) const noexcept -> bool
-    {
-        return
-            Rows() == rhs.Rows() &&
-            Cols() == rhs.Cols() &&
-            variables_.size() == rhs.variables_.size() &&
-            std::equal(variables_.begin(), variables_.end(), rhs.variables_.begin()) &&
-            values_.isApprox(rhs.values_);
-    }
+    [[nodiscard]] auto IsView() const noexcept -> bool { return storage_.size() == 0; }
 
-    // check if we own the data or if we are a view over someone else's data
-    [[nodiscard]] auto IsView() const noexcept -> bool { return values_.data() != map_.data(); }
+    template<std::integral T = int>
+    [[nodiscard]] auto Rows() const -> T { return static_cast<T>(view_.extent(0)); }
 
-    template<std::integral T = Eigen::Index>
-    [[nodiscard]] auto Rows() const -> T { return static_cast<T>(map_.rows()); }
+    template<std::integral T = int>
+    [[nodiscard]] auto Cols() const -> T { return static_cast<T>(view_.extent(1)); }
 
-    template<std::integral T = Eigen::Index>
-    [[nodiscard]] auto Cols() const -> T { return static_cast<T>(map_.cols()); }
-
-    template<std::integral T = Eigen::Index>
+    template<std::integral T = int>
     [[nodiscard]] auto Dimensions() const -> std::pair<T, T> { return { Rows<T>(), Cols<T>() }; }
 
-    [[nodiscard]] auto Values() const -> Eigen::Ref<Matrix const> { return map_; }
+    [[nodiscard]] auto Data() const noexcept -> View { return view_; }
 
     [[nodiscard]] auto VariableNames() const -> std::vector<std::string>;
     void SetVariableNames(std::vector<std::string> const& names);
-
     [[nodiscard]] auto VariableHashes() const -> std::vector<Operon::Hash>;
     [[nodiscard]] auto VariableIndices() const -> std::vector<std::size_t>;
 
-    [[nodiscard]] auto GetValues(std::string const& name) const noexcept -> Operon::Span<const Operon::Scalar>;
-    [[nodiscard]] auto GetValues(Operon::Hash hash) const noexcept -> Operon::Span<const Operon::Scalar>;
-    [[nodiscard]] auto GetValues(int64_t index) const noexcept -> Operon::Span<const Operon::Scalar>;
-    [[nodiscard]] auto GetValues(Variable const& variable) const noexcept -> Operon::Span<const Operon::Scalar> { return GetValues(variable.Hash); }
+    [[nodiscard]] auto GetValues(std::string const& name) const noexcept -> Span<Scalar const>;
+    [[nodiscard]] auto GetValues(Operon::Hash hash) const noexcept -> Span<Scalar const>;
+    [[nodiscard]] auto GetValues(int64_t index) const noexcept -> Span<Scalar const>;
+    [[nodiscard]] auto GetValues(Variable const& var) const noexcept -> Span<Scalar const> { return GetValues(var.Hash); }
 
-    [[nodiscard]] auto GetVariable(const std::string& name) const noexcept -> std::optional<Variable>;
+    [[nodiscard]] auto GetVariable(std::string const& name) const noexcept -> std::optional<Variable>;
     [[nodiscard]] auto GetVariable(Operon::Hash hash) const noexcept -> std::optional<Variable>;
+    [[nodiscard]] auto GetVariables() const noexcept -> std::vector<Operon::Variable>;
 
-    [[nodiscard]] auto GetVariables() const noexcept -> std::vector<Operon::Variable> {
-        std::vector<Operon::Variable> variables; variables.reserve(variables_.size());
-        auto const& values = variables_.values();
-        std::transform(values.begin(), values.end(), std::back_inserter(variables), [](auto const& p) { return p.second; });
-        return variables;
-    }
+    void SetWeights(Span<Scalar const> w);
+    [[nodiscard]] auto Weights() const noexcept -> std::optional<Span<Scalar const>>;
 
     void Shuffle(Operon::RandomGenerator& random);
-
     void Normalize(size_t i, Range range);
-
-    void PermuteRows(std::vector<Eigen::Index> const& indices);
-
-    // standardize column i using mean and stddev calculated over the specified range
     void Standardize(size_t i, Range range);
+    void PermuteRows(std::vector<int> const& perm);
 };
+
 } // namespace Operon
 
 #endif

--- a/include/operon/core/types.hpp
+++ b/include/operon/core/types.hpp
@@ -29,7 +29,7 @@ using Span = std::span<T>;
 template<typename T, typename Extents, typename LayoutPolicy = std::layout_left, typename AccessorPolicy = std::default_accessor<T>>
 using MDSpan = std::mdspan<T, Extents, LayoutPolicy, AccessorPolicy>;
 
-template<typename T, typename Extents, typename LayoutPolicy = std::layout_left, typename Container = std::vector<T>>
+template<typename T, typename Extents, typename LayoutPolicy = std::layout_left, typename Container = std::vector<T, AlignedAllocator<T, 32>>>
 using MDArray = std::experimental::mdarray<T, Extents, LayoutPolicy, Container>;
 
 template <class Key,

--- a/source/core/dataset.cpp
+++ b/source/core/dataset.cpp
@@ -1,146 +1,195 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
 
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+
 #include <vstat/vstat.hpp>
 #include <parser.hpp>
 #include <fast_float/fast_float.h>
 #include <fmt/format.h>
 
-#include "operon/core/constants.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/types.hpp"
 #include "operon/hash/hash.hpp"
 
 namespace Operon {
 
-// internal implementation details
 namespace {
-    auto VariablesFromNames(auto const& names) {
+    auto VariablesFromNames(auto const& names) -> Dataset::Variables {
         Hasher const hasher;
         Dataset::Variables vars;
         for (auto i = 0; i < std::ssize(names); ++i) {
             auto const& name = names[i];
-            auto hash = hasher(name);
-            auto index = i;
-            vars.insert({hash, {name, hash, index}});
+            auto const hash = hasher(name);
+            vars.insert({hash, {name, hash, i}});
         }
         return vars;
     }
 
-    auto DefaultVariables(size_t count) {
+    auto DefaultVariables(int count) -> Dataset::Variables {
         std::vector<std::string> names(count);
-        for (auto i = 0UL; i < count; ++i) {
-            names[i] = fmt::format("X{}", i+1);
-        }
+        for (auto i = 0; i < count; ++i) { names[i] = fmt::format("X{}", i + 1); }
         return VariablesFromNames(names);
     }
 
-    auto MatrixFromValues(auto const& values) {
-        Dataset::Matrix m(std::ssize(values.front()), std::ssize(values));
-        using M = Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1> const>;
-        for (auto i = 0; i < m.cols(); ++i) {
-            m.col(i) = M(values[i].data(), m.rows());
+    auto StorageFromCols(std::vector<std::vector<Operon::Scalar>> const& cols) -> Dataset::Storage {
+        auto const ncols = static_cast<int>(cols.size());
+        auto const nrows = static_cast<int>(cols.front().size());
+        Dataset::Storage s(nrows, ncols);
+        auto* dst = s.container().data();
+        for (auto j = 0; j < ncols; ++j) {
+            std::copy_n(cols[j].data(), nrows, dst + (static_cast<ptrdiff_t>(j) * nrows));
         }
-        return m;
+        return s;
+    }
+
+    auto MakeView(Dataset::Storage const& s) -> Dataset::View {
+        return s.to_mdspan();
     }
 } // namespace
 
-auto Dataset::ReadCsv(std::string const& path, bool hasHeader) -> Dataset::Matrix
+auto Dataset::ReadCsv(std::string const& path, bool hasHeader) -> Dataset::Storage
 {
     std::ifstream f(path);
     aria::csv::CsvParser parser(f);
 
-    auto nrow = std::count(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), '\n');
-    // rewind the ifstream
+    auto nrow = static_cast<int>(std::count(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), '\n'));
     f.clear();
     f.seekg(0);
 
-    auto ncol{0L};
-
-    Hasher const hash;
-    Matrix m;
+    auto ncol{0};
 
     if (hasHeader) {
-        --nrow; // for matrix allocation, don't care about column names
+        --nrow;
         for (auto const& row : parser) {
-            for (auto const& f : row) {
-                auto h = hash(f);
-                variables_.insert({ h, { .Name = f, .Hash = h, .Index = ncol++ } });
+            for (auto const& field : row) {
+                Hasher const hash;
+                auto h = hash(field);
+                variables_.insert({ h, { .Name = field, .Hash = h, .Index = ncol++ } });
             }
-            break; // read only the first row
+            break;
         }
-        m.resize(nrow, static_cast<Eigen::Index>(ncol));
     }
 
-    std::vector<Operon::Scalar> vec;
-    Eigen::Index rowIdx = 0;
+    // flat column-major buffer: buf[col * nrow + row]
+    std::vector<Operon::Scalar> buf;
+    if (ncol > 0) { buf.resize(static_cast<size_t>(nrow) * ncol); }
+    std::vector<Operon::Scalar> rowBuf;
+    auto rowIdx = 0;
 
     for (auto const& row : parser) {
-        size_t fieldIdx = 0;
+        rowBuf.clear();
         for (auto const& field : row) {
             Operon::Scalar v{0};
-            auto status = fast_float::from_chars(field.data(), field.data() + field.size(), v);
-            if(status.ec != std::errc()) {
-                throw std::runtime_error(fmt::format("failed to parse field {} at line {}\n", fieldIdx, rowIdx));
+            auto const status = fast_float::from_chars(field.data(), field.data() + field.size(), v);
+            if (status.ec != std::errc()) {
+                throw std::runtime_error(fmt::format("failed to parse field at line {}\n", rowIdx));
             }
-            vec.push_back(v);
-            ++fieldIdx;
+            rowBuf.push_back(v);
         }
+
         if (ncol == 0) {
             ENSURE(!hasHeader);
-            ncol = static_cast<int64_t>(vec.size());
-            m.resize(nrow, ncol);
+            ncol = static_cast<int>(rowBuf.size());
+            buf.resize(static_cast<size_t>(nrow) * ncol);
             variables_ = DefaultVariables(ncol);
         }
-        m.row(rowIdx) = Eigen::Map<Eigen::Array<Operon::Scalar, Eigen::Dynamic, 1>>(vec.data(), static_cast<Eigen::Index>(vec.size()));
-        vec.clear();
+
+        for (auto j = 0; j < ncol; ++j) {
+            buf[(static_cast<size_t>(j) * nrow) + rowIdx] = rowBuf[j];
+        }
         ++rowIdx;
     }
-    return m;
-}
 
-Dataset::Dataset(std::vector<std::vector<Operon::Scalar>> const& vals)
-    : variables_(DefaultVariables(vals.size()))
-    , values_(MatrixFromValues(vals))
-    , map_(values_.data(), values_.rows(), values_.cols())
-{
+    Storage s(nrow, ncol);
+    std::copy(buf.begin(), buf.end(), s.container().data());
+    return s;
 }
 
 Dataset::Dataset(std::string const& path, bool hasHeader)
-    : values_(ReadCsv(path, hasHeader))
-    , map_(values_.data(), values_.rows(), values_.cols())
+    : storage_(ReadCsv(path, hasHeader))
+    , view_(MakeView(storage_))
 {
 }
 
-Dataset::Dataset(Matrix vals)
-    : variables_(DefaultVariables(static_cast<size_t>(vals.cols())))
-    , values_(std::move(vals))
-    , map_(values_.data(), values_.rows(), values_.cols())
+Dataset::Dataset(std::vector<std::string> const& vars, std::vector<std::vector<Scalar>> const& vals)
+    : variables_(VariablesFromNames(vars))
+    , storage_(StorageFromCols(vals))
+    , view_(MakeView(storage_))
 {
 }
 
-Dataset::Dataset(std::vector<std::string> const& vars, std::vector<std::vector<Operon::Scalar>> const& vals)
-    : values_(MatrixFromValues(vals))
-    , map_(values_.data(), values_.rows(), values_.cols())
+Dataset::Dataset(std::vector<std::vector<Scalar>> const& vals)
+    : variables_(DefaultVariables(static_cast<int>(vals.size())))
+    , storage_(StorageFromCols(vals))
+    , view_(MakeView(storage_))
 {
-    Hasher const hasher;
-    for (auto i = 0; i < map_.cols(); ++i) {
-        auto h = hasher(vars[i]);
-        variables_.insert({h, { .Name = vars[i], .Hash = h, .Index = i } });
+}
+
+Dataset::Dataset(gsl::not_null<Scalar const*> data, int rows, int cols)
+    : variables_(DefaultVariables(cols))
+    , view_(data, rows, cols)
+{
+}
+
+Dataset::Dataset(Dataset const& rhs)
+    : variables_(rhs.variables_)
+    , weights_(rhs.weights_)
+{
+    auto const nrows = rhs.view_.extent(0);
+    auto const ncols = rhs.view_.extent(1);
+    storage_ = Storage(nrows, ncols);
+    auto const n = static_cast<size_t>(nrows) * static_cast<size_t>(ncols);
+    std::copy_n(rhs.view_.data_handle(), n, storage_.container().data());
+    view_ = MakeView(storage_);
+}
+
+Dataset::Dataset(Dataset&& rhs) noexcept
+    : variables_(std::move(rhs.variables_))
+    , storage_(std::move(rhs.storage_))
+    , view_(rhs.view_)
+    , weights_(std::move(rhs.weights_))
+{
+}
+
+auto Dataset::operator=(Dataset&& rhs) noexcept -> Dataset&
+{
+    if (this != &rhs) {
+        variables_ = std::move(rhs.variables_);
+        storage_   = std::move(rhs.storage_);
+        view_      = rhs.view_;
+        weights_   = std::move(rhs.weights_);
     }
+    return *this;
 }
 
-Dataset::Dataset(gsl::not_null<Matrix::Scalar const*> data, Eigen::Index rows, Eigen::Index cols) // NOLINT
-    : variables_(DefaultVariables(static_cast<size_t>(cols)))
-    , map_(data, rows, cols)
+void Dataset::Swap(Dataset& rhs) noexcept
 {
+    variables_.swap(rhs.variables_);
+    std::swap(storage_, rhs.storage_);
+    std::swap(view_, rhs.view_);
+    std::swap(weights_, rhs.weights_);
+}
+
+auto Dataset::operator==(Dataset const& rhs) const noexcept -> bool
+{
+    if (Rows() != rhs.Rows() || Cols() != rhs.Cols()) { return false; }
+    if (variables_.size() != rhs.variables_.size()) { return false; }
+    if (!std::equal(variables_.begin(), variables_.end(), rhs.variables_.begin())) { return false; }
+    auto const n = static_cast<size_t>(Rows()) * static_cast<size_t>(Cols());
+    return std::equal(view_.data_handle(), view_.data_handle() + n, rhs.view_.data_handle(),
+                      [](auto a, auto b) -> bool { return std::abs(a - b) < static_cast<Scalar>(1e-6); });
 }
 
 void Dataset::SetVariableNames(std::vector<std::string> const& names)
 {
-    if (names.size() != static_cast<size_t>(map_.cols())) {
-        auto msg = fmt::format("The number of columns ({}) does not match the number of column names ({}).", map_.cols(), names.size());
-        throw std::runtime_error(msg);
+    if (std::ssize(names) != Cols()) {
+        throw std::runtime_error(fmt::format(
+            "The number of columns ({}) does not match the number of column names ({}).",
+            Cols(), names.size()));
     }
     variables_ = VariablesFromNames(names);
 }
@@ -149,7 +198,8 @@ auto Dataset::VariableNames() const -> std::vector<std::string>
 {
     std::vector<std::string> names;
     names.reserve(variables_.size());
-    std::transform(variables_.begin(), variables_.end(), std::back_inserter(names), [](auto const& p) -> auto { return p.second.Name; });
+    std::transform(variables_.begin(), variables_.end(), std::back_inserter(names),
+                   [](auto const& p) -> auto { return p.second.Name; });
     return names;
 }
 
@@ -157,7 +207,8 @@ auto Dataset::VariableHashes() const -> std::vector<Operon::Hash>
 {
     std::vector<Operon::Hash> hashes;
     hashes.reserve(variables_.size());
-    std::transform(variables_.begin(), variables_.end(), std::back_inserter(hashes), [](auto const& p) -> auto { return p.second.Hash; });
+    std::transform(variables_.begin(), variables_.end(), std::back_inserter(hashes),
+                   [](auto const& p) -> auto { return p.second.Hash; });
     return hashes;
 }
 
@@ -165,29 +216,29 @@ auto Dataset::VariableIndices() const -> std::vector<std::size_t>
 {
     std::vector<std::size_t> indices;
     indices.reserve(variables_.size());
-    std::transform(variables_.begin(), variables_.end(), std::back_inserter(indices), [](auto const& p) -> auto { return p.second.Index; });
+    std::transform(variables_.begin(), variables_.end(), std::back_inserter(indices),
+                   [](auto const& p) -> auto { return static_cast<std::size_t>(p.second.Index); });
     return indices;
 }
 
-auto Dataset::GetValues(std::string const& name) const noexcept -> Operon::Span<const Operon::Scalar>
+auto Dataset::GetValues(std::string const& name) const noexcept -> Span<Scalar const>
 {
     return GetValues(Hasher{}(name));
 }
 
-auto Dataset::GetValues(Operon::Hash hash) const noexcept -> Operon::Span<const Operon::Scalar>
+auto Dataset::GetValues(Operon::Hash hash) const noexcept -> Span<Scalar const>
 {
     auto it = variables_.find(hash);
     if (it == variables_.end()) {
         fmt::print(stderr, "GetValues: cannot find variable with hash value {}", hash);
         std::abort();
     }
-    return {map_.col(it->second.Index).data(), static_cast<size_t>(map_.rows())};
+    return ColSpan(it->second.Index);
 }
 
-// this method needs to take an int argument to differentiate it from GetValues(Operon::Hash)
-auto Dataset::GetValues(int64_t index) const noexcept -> Operon::Span<const Operon::Scalar>
+auto Dataset::GetValues(int64_t index) const noexcept -> Span<Scalar const>
 {
-    return {map_.col(index).data(), static_cast<size_t>(map_.rows())};
+    return ColSpan(static_cast<int>(index)); // NOLINT(cppcoreguidelines-narrowing-conversions)
 }
 
 auto Dataset::GetVariable(std::string const& name) const noexcept -> std::optional<Variable>
@@ -202,50 +253,80 @@ auto Dataset::GetVariable(Operon::Hash hash) const noexcept -> std::optional<Var
     return it->second;
 }
 
+auto Dataset::GetVariables() const noexcept -> std::vector<Operon::Variable>
+{
+    std::vector<Operon::Variable> variables;
+    variables.reserve(variables_.size());
+    auto const& vals = variables_.values();
+    std::transform(vals.begin(), vals.end(), std::back_inserter(variables),
+                   [](auto const& p) -> auto { return p.second; });
+    return variables;
+}
+
+void Dataset::SetWeights(Span<Scalar const> w)
+{
+    ENSURE(std::ssize(w) == Rows());
+    weights_.emplace(w.begin(), w.end());
+}
+
+auto Dataset::Weights() const noexcept -> std::optional<Span<Scalar const>>
+{
+    if (!weights_) { return std::nullopt; }
+    return Span<Scalar const>{ weights_->data(), weights_->size() };
+}
+
 void Dataset::Shuffle(Operon::RandomGenerator& random)
 {
-    if (IsView()) { throw std::runtime_error("Cannot shuffle. Dataset does not own the data.\n"); }
-    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> perm(values_.rows());
-    perm.setIdentity();
-    // generate a random permutation
-    Operon::Span<decltype(perm)::IndicesType::Scalar> const idx(perm.indices().data(), perm.indices().size());
-    std::shuffle(idx.begin(), idx.end(), random);
-    values_.matrix().applyOnTheLeft(perm); // permute rows
+    if (IsView()) { throw std::runtime_error("Cannot shuffle: dataset does not own the data.\n"); }
+    std::vector<int> perm(Rows());
+    std::iota(perm.begin(), perm.end(), 0);
+    std::shuffle(perm.begin(), perm.end(), random);
+    PermuteRows(perm);
+    if (weights_) {
+        Vector<Scalar> tmp(weights_->size());
+        for (auto i = 0; i < Rows(); ++i) { tmp[i] = (*weights_)[perm[i]]; }
+        *weights_ = std::move(tmp);
+    }
 }
 
 void Dataset::Normalize(size_t i, Range range)
 {
-    if (IsView()) { throw std::runtime_error("Cannot normalize. Dataset does not own the data.\n"); }
-    EXPECT(range.Start() + range.Size() <= static_cast<size_t>(values_.rows()));
-    auto j     = static_cast<Eigen::Index>(i);
-    auto start = static_cast<Eigen::Index>(range.Start());
-    auto size  = static_cast<Eigen::Index>(range.Size());
-    auto seg   = values_.col(j).segment(start, size);
-    auto min   = seg.minCoeff();
-    auto max   = seg.maxCoeff();
-    values_.col(j) = (values_.col(j).array() - min) / (max - min);
+    if (IsView()) { throw std::runtime_error("Cannot normalize: dataset does not own the data.\n"); }
+    EXPECT(range.Start() + range.Size() <= static_cast<size_t>(Rows()));
+    auto* col   = storage_.container().data() + (static_cast<ptrdiff_t>(i) * Rows()); // NOLINT(bugprone-implicit-widening-of-multiplication-result)
+    auto* begin = col + range.Start();
+    auto* end   = begin + range.Size();
+    auto [minIt, maxIt] = std::minmax_element(begin, end);
+    auto const min = *minIt;
+    auto const rng = *maxIt - min;
+    std::transform(col, col + Rows(), col, [min, rng](auto v) -> Scalar { return (v - min) / rng; });
 }
 
-void Dataset::PermuteRows(std::vector<Eigen::Index> const& indices)
-{
-    if (IsView()) { throw std::runtime_error("Cannot shuffle. Dataset does not own the data.\n"); }
-    ENSURE(values_.rows() == std::ssize(indices));
-    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic> perm(values_.rows());
-    std::copy(indices.begin(), indices.end(), perm.indices().begin());
-    values_.matrix().applyOnTheLeft(perm); // permute rows
-}
-
-// standardize column i using mean and stddev calculated over the specified range
 void Dataset::Standardize(size_t i, Range range)
 {
-    if (IsView()) { throw std::runtime_error("Cannot standardize. Dataset does not own the data.\n"); }
-    EXPECT(range.Start() + range.Size() <= static_cast<size_t>(values_.rows()));
-    auto j = static_cast<Eigen::Index>(i);
-    auto start = static_cast<Eigen::Index>(range.Start());
-    auto n = static_cast<Eigen::Index>(range.Size());
-    auto seg = values_.col(j).segment(start, n);
-    auto stats = vstat::univariate::accumulate<Matrix::Scalar>(seg.begin(), seg.end());
-    auto stddev = std::sqrt(stats.variance);
-    values_.col(j) = (values_.col(j).array() - stats.mean) / stddev;
+    if (IsView()) { throw std::runtime_error("Cannot standardize: dataset does not own the data.\n"); }
+    EXPECT(range.Start() + range.Size() <= static_cast<size_t>(Rows()));
+    auto* col   = storage_.container().data() + (static_cast<ptrdiff_t>(i) * Rows()); // NOLINT(bugprone-implicit-widening-of-multiplication-result)
+    auto* begin = col + range.Start();
+    auto const stats  = vstat::univariate::accumulate<Scalar>(begin, begin + range.Size());
+    auto const stddev = std::sqrt(stats.variance);
+    auto const mu     = stats.mean;
+    std::transform(col, col + Rows(), col, [mu, stddev](auto v) -> Scalar { return (v - mu) / stddev; });
 }
+
+void Dataset::PermuteRows(std::vector<int> const& perm)
+{
+    if (IsView()) { throw std::runtime_error("Cannot permute: dataset does not own the data.\n"); }
+    ENSURE(std::ssize(perm) == Rows());
+    auto const nrows = Rows();
+    auto const ncols = Cols();
+    auto* data = storage_.container().data();
+    std::vector<Scalar> tmp(nrows);
+    for (auto j = 0; j < ncols; ++j) {
+        auto* col = data + (static_cast<ptrdiff_t>(j) * nrows);
+        for (auto k = 0; k < nrows; ++k) { tmp[k] = col[perm[k]]; }
+        std::copy(tmp.begin(), tmp.end(), col);
+    }
+}
+
 } // namespace Operon

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -21,12 +21,9 @@ namespace Operon::Test {
 
 TEST_CASE("Autodiff specific expressions", "[autodiff]") // NOLINT(readability-function-cognitive-complexity)
 {
-    Operon::Dataset::Matrix values(1, 2);
-    values << 1, 1; // NOLINT
-
+    Operon::Dataset ds(std::vector<std::string>{"x", "y"},
+                       std::vector<std::vector<Operon::Scalar>>{{1}, {1}});
     Operon::RandomGenerator rng(0UL); // NOLINT(misc-const-correctness) — captured by ref in lambda, passed to non-const distribution calls
-    Operon::Dataset ds(values);
-    ds.SetVariableNames({"x", "y"});
     Operon::DispatchTable<Operon::Scalar> dtable;
     Operon::Range const range{0, ds.Rows<std::size_t>()};
 
@@ -76,12 +73,9 @@ TEST_CASE("Autodiff specific expressions", "[autodiff]") // NOLINT(readability-f
 
 TEST_CASE("Autodiff forward vs reverse consistency", "[autodiff]")
 {
-    Operon::Dataset::Matrix values(1, 2);
-    values << 1, 1; // NOLINT
-
+    Operon::Dataset ds(std::vector<std::string>{"x", "y"},
+                       std::vector<std::vector<Operon::Scalar>>{{1}, {1}});
     Operon::RandomGenerator rng(0UL);
-    Operon::Dataset ds(values);
-    ds.SetVariableNames({"x", "y"});
 
     Operon::DispatchTable<Operon::Scalar> dtable;
     Operon::Range const range{0, ds.Rows<std::size_t>()};

--- a/test/source/implementation/evaluation.cpp
+++ b/test/source/implementation/evaluation.cpp
@@ -23,7 +23,9 @@ TEST_CASE("Evaluation correctness", "[interpreter]")
     auto range = Range{0, ds.Rows<std::size_t>()};
 
     using DTable = DispatchTable<Operon::Scalar>;
-    auto const& X = ds.Values(); // NOLINT
+    auto const x0 = ds.GetValues(int64_t{0});
+    auto const x1 = ds.GetValues(int64_t{1});
+    auto const x2 = ds.GetValues(int64_t{2});
 
     Operon::Vector<size_t> indices(range.Size());
     std::iota(indices.begin(), indices.end(), 0);
@@ -35,22 +37,19 @@ TEST_CASE("Evaluation correctness", "[interpreter]")
         auto tree = InfixParser::Parse("X1 + X2 + X3", ds);
         auto coeff = tree.GetCoefficients();
         auto estimatedValues = Interpreter<Operon::Scalar, DTable>(&dtable, &ds, &tree).Evaluate(coeff, range);
-        Eigen::Array<Operon::Scalar, -1, 1> expected = X.col(0) + X.col(1) + X.col(2);
-        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - expected(i)) < eps; }));
+        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - (x0[i] + x1[i] + x2[i])) < eps; }));
     }
 
     SECTION("X1 - X2 + X3") {
         auto tree = InfixParser::Parse("X1 - X2 + X3", ds);
         auto estimatedValues = Interpreter<Operon::Scalar, DTable>(&dtable, &ds, &tree).Evaluate(tree.GetCoefficients(), range);
-        auto expected = X.col(0) - X.col(1) + X.col(2);
-        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - expected(i)) < eps; }));
+        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - (x0[i] - x1[i] + x2[i])) < eps; }));
     }
 
     SECTION("log(abs(X1))") {
         auto tree = InfixParser::Parse("log(abs(X1))", ds);
         auto estimatedValues = Interpreter<Operon::Scalar, DTable>(&dtable, &ds, &tree).Evaluate(tree.GetCoefficients(), range);
-        Eigen::Array<Operon::Scalar, -1, 1> expected = X.col(0).abs().log();
-        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - expected(i)) < eps; }));
+        CHECK(std::all_of(indices.begin(), indices.end(), [&](auto i) -> auto { return std::abs(estimatedValues[i] - std::log(std::abs(x0[i]))) < eps; }));
     }
 
     SECTION("log of constant") {

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -42,7 +42,7 @@ struct EvaluatorFixture {
                 std::generate(col.begin(), col.end(), [&]() -> float { return Operon::Random::Uniform(rng, -1.0F, +1.0F); });
             }
             data.col(Ncol - 1) = data.col(0) + data.col(1) + data.col(2);
-            return Operon::Dataset(data);
+            return Operon::Dataset(gsl::not_null{data.data()}, Nrow, Ncol);
         }())
         , tree([&]() -> Tree {
             auto t = InfixParser::Parse("X1 + X2 + X3", ds);

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include "../operon_test.hpp"
 #include "operon/hash/hash.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/formatter/formatter.hpp"
@@ -23,9 +24,7 @@ TEST_CASE("Parser roundtrip correctness", "[parser]")
 
     Operon::RandomGenerator rng(1234);
 
-    Eigen::Matrix<Operon::Scalar, -1, -1> values(nrow, ncol);
-    for (auto& v : values.reshaped()) { v = Operon::Random::Uniform(rng, -1.F, +1.F); }
-    Operon::Dataset ds(values);
+    Operon::Dataset ds = Operon::Test::Util::RandomDataset(rng, nrow, ncol);
 
     Operon::PrimitiveSet pset;
     pset.SetConfig(PrimitiveSet::Arithmetic | NodeType::Aq | NodeType::Exp | NodeType::Log | NodeType::Variable);

--- a/test/source/implementation/optimizer.cpp
+++ b/test/source/implementation/optimizer.cpp
@@ -42,7 +42,7 @@ struct OptimizerFixture {
                 std::generate(col.begin(), col.end(), [&]() -> float { return Operon::Random::Uniform(rng, -1.0F, +1.0F); });
             }
             data.col(Ncol - 1) = data.col(0) + data.col(1) + data.col(2);
-            return Operon::Dataset(data);
+            return Operon::Dataset(gsl::not_null{data.data()}, Nrow, Ncol);
         }())
         , tree([&]() -> Tree {
             auto t = InfixParser::Parse("X1 + X2 + X3", ds);

--- a/test/source/operon_test.hpp
+++ b/test/source/operon_test.hpp
@@ -20,11 +20,14 @@
 namespace Operon::Test::Util {
     inline auto RandomDataset(Operon::RandomGenerator& rng, int rows, int cols) -> Operon::Dataset {
         std::uniform_real_distribution<Operon::Scalar> dist(-1.F, +1.F);
+        std::vector<std::string> names(cols);
+        for (auto i = 0; i < cols - 1; ++i) { names[i] = fmt::format("X{}", i + 1); }
+        names.back() = "Y";
         std::vector<std::vector<Operon::Scalar>> data(cols, std::vector<Operon::Scalar>(rows));
         for (auto& col : data) {
             for (auto& v : col) { v = dist(rng); }
         }
-        return Operon::Dataset(data);
+        return Operon::Dataset(names, data);
     }
 
     template<typename T, std::size_t S = Backend::BatchSize<T>>

--- a/test/source/operon_test.hpp
+++ b/test/source/operon_test.hpp
@@ -19,11 +19,12 @@
 
 namespace Operon::Test::Util {
     inline auto RandomDataset(Operon::RandomGenerator& rng, int rows, int cols) -> Operon::Dataset {
-        std::uniform_real_distribution<Operon::Scalar> dist(-1.f, +1.f);
-        Eigen::Matrix<decltype(dist)::result_type, -1, -1> data(rows, cols);
-        for (auto& v : data.reshaped()) { v = dist(rng); }
-        Operon::Dataset ds(data);
-        return ds;
+        std::uniform_real_distribution<Operon::Scalar> dist(-1.F, +1.F);
+        std::vector<std::vector<Operon::Scalar>> data(cols, std::vector<Operon::Scalar>(rows));
+        for (auto& col : data) {
+            for (auto& v : col) { v = dist(rng); }
+        }
+        return Operon::Dataset(data);
     }
 
     template<typename T, std::size_t S = Backend::BatchSize<T>>


### PR DESCRIPTION
## Summary

- Replaces `Dataset`'s `Eigen::Array` + `Eigen::Map` storage with `MDArray<Scalar, dextents<int,2>>` (owned) and `MDSpan<Scalar const, dextents<int,2>>` (non-owning view), both of which are already dependencies
- Removes the Eigen dependency from `dataset.hpp` entirely — Eigen is now only used in the optimizer, interpreter backends, and cost functions where it belongs
- `IsView()` now checks `storage_.size() == 0` instead of comparing Eigen data pointers
- All downstream API (`GetValues`, `Rows()`, `Cols()`, `IsView()`, `Shuffle`, `Normalize`, `Standardize`) is preserved unchanged — no callers needed updating

## New additions

- `Data() -> View` — exposes the raw `MDSpan` view for callers that want direct 2D access
- `SetWeights(Span<Scalar const>)` / `Weights() -> optional<Span<Scalar const>>` — optional per-sample weight vector, laying the groundwork for weighted evaluation (PR #49)

## Test changes

- Replace `Dataset::Matrix values(r, c); values << ...; Dataset ds(values)` with the `vector<vector<Scalar>>` constructor or the raw-pointer view constructor
- Replace `ds.Values().col(j)` Eigen column expressions with `ds.GetValues(int64_t{j})` spans
- `RandomDataset` helper in `operon_test.hpp` updated to use `vector<vector<Scalar>>` columns

## Test plan

- [x] All tests pass (`ctest` 100%)