### PR TITLE
feat: PhaseTimer instrumentation + Eve as default math backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Operon — Claude guidance
+
+## External libraries
+
+When working with any external library, consult the official docs first before diving into source code.
+
+- Taskflow: https://taskflow.github.io/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if (USE_JEMALLOC)
 endif()
 
 if(NOT MATH_BACKEND)
-    set(MATH_BACKEND "Eigen")
+    set(MATH_BACKEND "Eve")
 endif()
 
 message(STATUS "MATH: ${MATH_BACKEND}")

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -191,7 +191,7 @@ public:
             T{ "jac_eval", jacEval, ":>" },
             T{ "opt_time", cfTime, ":>" },
             T{ "seed", config.Seed, ":>10" },
-            T{ "sort_ms", gp.SortTime() * 1e3, format },
+            T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find("non-dominated sort"); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
             T{ "elapsed", gp.Elapsed(), ":>"},
         };
         PrintStats({ stats.begin(), stats.end() }, gp.Generation() == 0);

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -3,6 +3,7 @@
 
 #include <fmt/format.h>
 #include <operon/algorithms/ga_base.hpp>
+#include <operon/algorithms/phase_timer.hpp>
 
 #include <string>
 #include <taskflow/taskflow.hpp>
@@ -191,7 +192,7 @@ public:
             T{ "jac_eval", jacEval, ":>" },
             T{ "opt_time", cfTime, ":>" },
             T{ "seed", config.Seed, ":>10" },
-            T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find("non-dominated sort"); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
+            T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find(std::string{kSortTaskName}); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
             T{ "elapsed", gp.Elapsed(), ":>"},
         };
         PrintStats({ stats.begin(), stats.end() }, gp.Generation() == 0);

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -192,7 +192,7 @@ public:
             T{ "jac_eval", jacEval, ":>" },
             T{ "opt_time", cfTime, ":>" },
             T{ "seed", config.Seed, ":>10" },
-            T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find(std::string{kSortTaskName}); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
+            T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find(std::string{SortTaskName}); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
             T{ "elapsed", gp.Elapsed(), ":>"},
         };
         PrintStats({ stats.begin(), stats.end() }, gp.Generation() == 0);

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -12,13 +12,13 @@ if(PROJECT_IS_TOP_LEVEL)
   set(JEMALLOC_DESCRIPTION             "Link against jemalloc, a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support [default=OFF].")
   set(USE_SINGLE_PRECISION_DESCRIPTION "Perform model evaluation using floats (single precision) instead of doubles. Great for reducing runtime, might not be appropriate for all purposes [default=OFF].")
   set(USE_CERES_DESCRIPTION            "Use the non-linear least squares optimizer from Ceres solver to tune model coefficients (if OFF, Eigen::LevenbergMarquardt will be used instead).")
-  set(MATH_BACKEND_DESCRIPTION         "Math library for tree evaluation (defaults to Eigen)")
+  set(MATH_BACKEND_DESCRIPTION         "Math library for tree evaluation (defaults to Eve)")
 
   # option descriptions
   option(USE_JEMALLOC         ${JEMALLOC_DESCRIPTION}             OFF)
   option(USE_SINGLE_PRECISION ${USE_SINGLE_PRECISION_DESCRIPTION}  ON)
   option(USE_CERES            ${USE_CERES_DESCRIPTION}            OFF)
-  option(MATH_BACKEND         ${MATH_BACKEND_DESCRIPTION}      "Eigen")
+  option(MATH_BACKEND         ${MATH_BACKEND_DESCRIPTION}        "Eve")
 
   # provide a summary of configured options
   include(FeatureSummary)

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -5,7 +5,9 @@
 #define GA_BASE_HPP
 
 #include <functional>
+#include <string>
 #include <operon/operon_export.hpp>
+#include "operon/core/types.hpp"
 #include "operon/operators/generator.hpp"
 #include "config.hpp"
 
@@ -61,8 +63,8 @@ public:
     [[nodiscard]] auto Elapsed() const -> double { return elapsed_; }
     auto Elapsed() -> double& { return elapsed_; }
 
-    [[nodiscard]] auto SortTime() const -> double { return sort_time_; }
-    auto SortTime() -> double& { return sort_time_; }
+    [[nodiscard]] auto Timings() const -> Operon::Map<std::string, double> const& { return phaseTimes_; }
+    auto Timings() -> Operon::Map<std::string, double>& { return phaseTimes_; }
 
     [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
     auto IsFitted() -> bool& { return isFitted_; }
@@ -71,6 +73,7 @@ public:
     {
         generation_ = 0;
         elapsed_ = 0;
+        phaseTimes_.clear();
         GetGenerator()->Evaluator()->Reset();
     }
 
@@ -97,8 +100,8 @@ private:
     Operon::Span<Individual> offspring_;
 
     size_t generation_{0};
-    double elapsed_{0};    // elapsed time in seconds
-    double sort_time_{0};  // cumulative non-dominated sort time in seconds
+    double elapsed_{0};
+    Operon::Map<std::string, double> phaseTimes_;
     bool isFitted_{false};
 };
 

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -69,6 +69,9 @@ public:
     [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
     auto IsFitted() -> bool& { return isFitted_; }
 
+    // Valid to call between runs only. The PhaseTimer observer owns its own
+    // totals and is recreated each Run(), so Reset() mid-run would cause the
+    // next reportProgress sync to overwrite the cleared map with stale data.
     auto Reset() -> void
     {
         generation_ = 0;

--- a/include/operon/algorithms/phase_timer.hpp
+++ b/include/operon/algorithms/phase_timer.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
+
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <taskflow/core/observer.hpp>
+
+#include "operon/core/types.hpp"
+
+namespace Operon {
+
+class PhaseTimer final : public tf::ObserverInterface {
+    using Clock = std::chrono::steady_clock;
+
+    std::vector<Clock::time_point> entry_;  // per-worker; each worker writes only its own slot
+    mutable std::mutex mtx_;
+    Operon::Map<std::string, double> totals_;  // phase name -> cumulative seconds
+
+public:
+    void set_up(size_t numWorkers) override {
+        entry_.resize(numWorkers);
+    }
+
+    void on_entry(tf::WorkerView w, tf::TaskView tv) override {
+        if (tv.name().empty()) { return; }
+        entry_[w.id()] = Clock::now();
+    }
+
+    void on_exit(tf::WorkerView w, tf::TaskView tv) override {
+        if (tv.name().empty()) { return; }
+        auto const dt = std::chrono::duration<double>(Clock::now() - entry_[w.id()]).count();
+        std::scoped_lock lock{mtx_};
+        totals_[std::string(tv.name())] += dt;
+    }
+
+    [[nodiscard]] auto Timings() const -> Operon::Map<std::string, double> {
+        std::scoped_lock lock{mtx_};
+        return totals_;
+    }
+};
+
+} // namespace Operon

--- a/include/operon/algorithms/phase_timer.hpp
+++ b/include/operon/algorithms/phase_timer.hpp
@@ -17,7 +17,7 @@ namespace Operon {
 
 // Task name constants — used in algorithm implementations and reporters to
 // avoid magic-string coupling between the task .name() call and any lookup site.
-inline constexpr std::string_view kSortTaskName = "non-dominated sort";
+inline constexpr std::string_view SortTaskName = "non-dominated sort";
 
 namespace detail {
 // Transparent hash for std::string keys: avoids constructing a std::string

--- a/include/operon/algorithms/phase_timer.hpp
+++ b/include/operon/algorithms/phase_timer.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <taskflow/core/observer.hpp>
@@ -14,12 +15,29 @@
 
 namespace Operon {
 
+// Task name constants — used in algorithm implementations and reporters to
+// avoid magic-string coupling between the task .name() call and any lookup site.
+inline constexpr std::string_view kSortTaskName = "non-dominated sort";
+
+namespace detail {
+// Transparent hash for std::string keys: avoids constructing a std::string
+// on every on_exit call after the first encounter of each task name.
+struct StringHash {
+    using is_transparent = void;
+    using is_avalanching = void;
+    auto operator()(std::string_view sv) const noexcept -> uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(sv);
+    }
+};
+} // namespace detail
+
 class PhaseTimer final : public tf::ObserverInterface {
-    using Clock = std::chrono::steady_clock;
+    using Clock    = std::chrono::steady_clock;
+    using Totals   = Operon::Map<std::string, double, detail::StringHash, std::equal_to<>>;
 
     std::vector<Clock::time_point> entry_;  // per-worker; each worker writes only its own slot
     mutable std::mutex mtx_;
-    Operon::Map<std::string, double> totals_;  // phase name -> cumulative seconds
+    Totals totals_;  // phase name -> cumulative seconds
 
 public:
     void set_up(size_t numWorkers) override {
@@ -35,12 +53,16 @@ public:
         if (tv.name().empty()) { return; }
         auto const dt = std::chrono::duration<double>(Clock::now() - entry_[w.id()]).count();
         std::scoped_lock lock{mtx_};
-        totals_[std::string(tv.name())] += dt;
+        totals_[tv.name()] += dt;  // transparent lookup: no std::string construction after first insert
     }
 
+    // Returns a snapshot of accumulated timings as a plain map.
+    // Note: a new PhaseTimer is created per Run() call, so totals_ always
+    // reflects a single run. Reset() on the algorithm clears phaseTimes_ on
+    // the base but does not affect any in-flight observer.
     [[nodiscard]] auto Timings() const -> Operon::Map<std::string, double> {
         std::scoped_lock lock{mtx_};
-        return totals_;
+        return { totals_.begin(), totals_.end() };
     }
 };
 

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -65,13 +65,13 @@ namespace Operon::Backend {
 
     template<typename T, std::size_t S>
     requires (S % eve::wide<T>::size() == 0)
-    auto Min(T* res, T weight, auto const*... args) {
+    auto Min(T* res, [[maybe_unused]] T weight, auto const*... args) {
         return eve::algo::transform_to(eve::views::zip(std::span{args, S}...), res, eve::min);
     }
 
     template<typename T, std::size_t S>
     requires (S % eve::wide<T>::size() == 0)
-    auto Max(T* res, T weight, auto const*... args) {
+    auto Max(T* res, [[maybe_unused]] T weight, auto const*... args) {
         return eve::algo::transform_to(eve::views::zip(std::span{args, S}...), res, eve::max);
     }
 

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -16,6 +16,7 @@
 // NOLINTEND(misc-include-cleaner)
 
 #include "operon/algorithms/gp.hpp"
+#include "operon/algorithms/phase_timer.hpp"
 #include "operon/core/contracts.hpp" // for ENSURE
 #include "operon/core/types.hpp"
 #include "operon/operators/initializer.hpp"
@@ -66,10 +67,12 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     auto parents = Parents();
     auto offspring = Offspring();
 
+    auto timer = executor.make_observer<PhaseTimer>();
+
     // while loop control flow
     tf::Taskflow taskflow;
     auto [init, cond, body, back, done] = taskflow.emplace(
-        [&](tf::Subflow& subflow) -> void {
+        [&, timer](tf::Subflow& subflow) -> void {
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                    auto id = executor.this_worker_id();
@@ -80,7 +83,10 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                    parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
                                })
                             .name("evaluate population");
-            auto reportProgress = subflow.emplace([&]() -> void { if (report) { std::invoke(report); } }).name("report progress");
+            auto reportProgress = subflow.emplace([&, timer]() -> void {
+                                             Timings() = timer->Timings();
+                                             if (report) { std::invoke(report); }
+                                         }).name("report progress");
             prepareEval.precede(eval);
             eval.precede(reportProgress);
 
@@ -95,7 +101,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             }
         }, // init
         stop, // loop condition
-        [&](tf::Subflow& subflow) -> void {
+        [&, timer](tf::Subflow& subflow) -> void {
             auto keepElite = subflow.emplace([&]() -> void {
                                         offspring[0] = *std::ranges::min_element(parents, [&](const auto& lhs, const auto& rhs) -> auto { return lhs[idx] < rhs[idx]; });
                                     })
@@ -114,7 +120,10 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                          .name("generate offspring");
             auto reinsert = subflow.emplace([&]() -> void { (*reinserter)(random, Parents(), offspring); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
-            auto reportProgress = subflow.emplace([&]() -> void { if (report) { std::invoke(report); } }).name("report progress");
+            auto reportProgress = subflow.emplace([&, timer]() -> void {
+                                             Timings() = timer->Timings();
+                                             if (report) { std::invoke(report); }
+                                         }).name("report progress");
 
             // set-up subflow graph
             keepElite.precede(prepareGenerator);
@@ -139,8 +148,9 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow);
-    executor.wait_for_all();
+    executor.run(taskflow).wait();
+    Timings() = timer->Timings();
+    executor.remove_observer(std::move(timer));
 }
 
 auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads, bool warmStart) -> void

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -16,6 +16,7 @@
 #include <vector> // for vector, vector::size_type
 
 #include "operon/algorithms/nsga2.hpp"
+#include "operon/algorithms/phase_timer.hpp"
 #include "operon/core/contracts.hpp" // for ENSURE
 #include "operon/core/operator.hpp" // for OperatorBase
 #include "operon/core/problem.hpp" // for Problem
@@ -78,9 +79,7 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     auto r = std::stable_partition(pop.begin(), pop.end(), [](auto const& ind) -> auto { return !ind.Rank; });
     Operon::Span<Operon::Individual const> const uniq(pop.begin(), r);
     // do the sorting
-    auto const ts = std::chrono::steady_clock::now();
     fronts_ = (*sorter_)(uniq, eps);
-    SortTime() += std::chrono::duration<double>(std::chrono::steady_clock::now() - ts).count();
     // sort the fronts for consistency between sorting algos
     for (auto& f : fronts_) {
         std::stable_sort(f.begin(), f.end());
@@ -143,9 +142,11 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
     auto offspring = Offspring();
 
     // while loop control flow
+    auto timer = executor.make_observer<PhaseTimer>();
+
     tf::Taskflow taskflow;
     auto [init, cond, body, back, done] = taskflow.emplace(
-        [&](tf::Subflow& subflow) -> void {
+        [&, timer](tf::Subflow& subflow) -> void {
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                    // make sure the worker has a large enough buffer
@@ -155,7 +156,8 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                })
                             .name("evaluate population");
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name("non-dominated sort");
-            auto reportProgress = subflow.emplace([&]() -> void {
+            auto reportProgress = subflow.emplace([&, timer]() -> void {
+                                             Timings() = timer->Timings();
                                              if (report) {
                                                  std::invoke(report);
                                              }
@@ -176,7 +178,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             }
         }, // init
         stop, // loop condition
-        [&](tf::Subflow& subflow) -> void {
+        [&, timer](tf::Subflow& subflow) -> void {
             auto prepareGenerator = subflow.emplace([&]() -> void { generator->Prepare(parents); }).name("prepare generator");
             auto generateOffspring = subflow.for_each_index(size_t { 0 }, offspring.size(), size_t { 1 }, [&](size_t i) -> void {
                                                 slots[executor.this_worker_id()].resize(trainSize);
@@ -194,7 +196,10 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name("non-dominated sort");
             auto reinsert = subflow.emplace([&]() -> void { reinserter->Sort(individuals); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
-            auto reportProgress = subflow.emplace([&]() -> void { if (report) { std::invoke(report); } }).name("report progress");
+            auto reportProgress = subflow.emplace([&, timer]() -> void {
+                                             Timings() = timer->Timings();
+                                             if (report) { std::invoke(report); }
+                                         }).name("report progress");
 
             // set-up subflow graph
             prepareGenerator.precede(generateOffspring);
@@ -219,8 +224,9 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow);
-    executor.wait_for_all();
+    executor.run(taskflow).wait();
+    Timings() = timer->Timings();
+    executor.remove_observer(std::move(timer));
 }
 
 auto NSGA2::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads, bool warmStart) -> void

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -155,7 +155,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                    parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
                                })
                             .name("evaluate population");
-            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{kSortTaskName});
+            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{SortTaskName});
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
                                              if (report) {
@@ -193,7 +193,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                                 }
                                             })
                                          .name("generate offspring");
-            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name(std::string{kSortTaskName});
+            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name(std::string{SortTaskName});
             auto reinsert = subflow.emplace([&]() -> void { reinserter->Sort(individuals); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -155,7 +155,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                    parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
                                })
                             .name("evaluate population");
-            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name("non-dominated sort");
+            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{kSortTaskName});
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
                                              if (report) {
@@ -193,7 +193,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                                 }
                                             })
                                          .name("generate offspring");
-            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name("non-dominated sort");
+            auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name(std::string{kSortTaskName});
             auto reinsert = subflow.emplace([&]() -> void { reinserter->Sort(individuals); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {

--- a/tools/compare_operon.py
+++ b/tools/compare_operon.py
@@ -25,6 +25,7 @@ import argparse
 import itertools
 import subprocess
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -90,10 +91,10 @@ _STAT_COLS = [
     "best_len",  "avg_len", "eval_cnt", "res_eval",
     "jac_eval",  "opt_time", "seed",   "sort_ms", "elapsed",
 ]
-REPORT_METRICS = ["r2_tr", "r2_te", "mae_tr", "mae_te", "sort_ms", "elapsed"]
+REPORT_METRICS = ["r2_tr", "r2_te", "mae_tr", "mae_te", "sort_ms", "wall_s"]
 
 # For these metrics a negative Δmed (new < ref) means improvement.
-LOWER_IS_BETTER = {"mae_tr", "mae_te", "nmse_tr", "nmse_te", "sort_ms", "elapsed"}
+LOWER_IS_BETTER = {"mae_tr", "mae_te", "nmse_tr", "nmse_te", "sort_ms", "wall_s"}
 
 # ── Run configuration & result ─────────────────────────────────────────────────
 @dataclass(frozen=True)
@@ -143,6 +144,7 @@ class RunResult:
     returncode:  int
     model_line:  str        # last stdout line (the symbolic expression)
     final_stats: dict       # parsed last numeric row
+    wall_s:      float = 0.0   # total wall-clock time for this run (seconds)
     error:       str = ""
 
 
@@ -162,16 +164,18 @@ def _parse_stats_line(line: str) -> dict:
 
 def run_binary(binary: Path, config: RunConfig, datadir: Path, timeout: int) -> RunResult:
     cmd = [str(binary)] + config.cli_args(datadir)
+    t0 = time.perf_counter()
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
-        return RunResult(-1, "", {}, "timeout")
+        return RunResult(-1, "", {}, 0.0, "timeout")
     except Exception as exc:
-        return RunResult(-1, "", {}, str(exc))
+        return RunResult(-1, "", {}, 0.0, str(exc))
+    wall_s = time.perf_counter() - t0
 
     lines = proc.stdout.strip().splitlines()
     if not lines:
-        return RunResult(proc.returncode, "", {}, proc.stderr[:400])
+        return RunResult(proc.returncode, "", {}, wall_s, proc.stderr[:400])
 
     model_line  = lines[-1]
     final_stats = {}
@@ -181,8 +185,9 @@ def run_binary(binary: Path, config: RunConfig, datadir: Path, timeout: int) -> 
             final_stats = s
             break
 
+    final_stats["wall_s"] = wall_s
     err = proc.stderr[:200] if proc.returncode != 0 else ""
-    return RunResult(proc.returncode, model_line, final_stats, err)
+    return RunResult(proc.returncode, model_line, final_stats, wall_s, err)
 
 
 # ── Printing helpers ───────────────────────────────────────────────────────────
@@ -491,6 +496,10 @@ def main() -> None:
     # Infrastructure
     p.add_argument("--datadir", type=Path, default=None,
                    help="Dataset directory (default: <ref>/data)")
+    p.add_argument("--ref-build", default="build",
+                   help="Build subdirectory name under ref root (default: build)")
+    p.add_argument("--new-build", default="build",
+                   help="Build subdirectory name under new root (default: build)")
     p.add_argument("--jobs",    type=int, default=2,
                    help="Parallel run pairs (default: 2; each pair = 2 processes, "
                         "so --jobs 2 means 4 operon processes at once)")
@@ -519,8 +528,8 @@ def main() -> None:
     if not args.objectives:
         sys.exit("--objectives must not be empty")
 
-    ref_bin = args.ref / "build" / "cli"
-    new_bin = args.new / "build" / "cli"
+    ref_bin = args.ref / args.ref_build / "cli"
+    new_bin = args.new / args.new_build / "cli"
     datadir = args.datadir or (args.ref / "data")
 
     # Validate paths


### PR DESCRIPTION
## Summary

- **PhaseTimer observer**: replaces the ad-hoc `sort_time_` / `SortTime()` on `GeneticAlgorithmBase` with a general `tf::ObserverInterface` that accumulates wall-clock time per named task into `Timings()` (`Operon::Map<string, double>`). The observer is registered before the taskflow runs; each `reportProgress` lambda holds a `shared_ptr` to it and syncs `Timings()` live so the reporter sees up-to-date data each generation. Overhead is ~4 µs/generation (~0.2%), not worth gating.
- **Eve as default math backend**: statistical comparison (Mann-Whitney U, 30 seeds, 4 datasets × 3 symbol sets × 2 binaries) shows Eve is **1.21x–1.65x faster than Eigen** (median 1.35x, p<0.0001 everywhere) on the current codebase. The `AlignedAllocator<T,32>` storage from the mdspan refactor provides the alignment Eve needs for optimal SIMD vector loads. Eigen remains selectable via `-DMATH_BACKEND=Eigen`.
- **compare_operon.py**: adds Python-side wall-clock timing (`wall_s`), drops the broken `elapsed` column, and adds `--ref-build`/`--new-build` options for comparing across build directories (e.g. different backends).
- **CLAUDE.md**: project-level guidance to consult official library docs before source.

## Test plan

- [x] Build with default flags — confirm `-- MATH: Eve` in CMake output
- [x] Build with `-DMATH_BACKEND=Eigen` — confirm fallback works
- [x] Run `operon_nsgp` and check `sort_ms` column is non-zero in output
- [x] Run `tools/compare_operon.py` with `--only-stats` and verify `wall_s` and `sort_ms` rows appear