### PR TITLE
fix: correct RankTournamentSelector to use rank-sorted indices

### DIFF
--- a/source/operators/selector/tournament.cpp
+++ b/source/operators/selector/tournament.cpp
@@ -32,16 +32,17 @@ auto TournamentSelector::operator()(Operon::RandomGenerator& random) const -> si
 
 auto RankTournamentSelector::operator()(Operon::RandomGenerator& random) const -> size_t
 {
-    auto population = Population();
-    std::uniform_int_distribution<size_t> uniformInt(0, population.size() - 1);
+    std::uniform_int_distribution<size_t> uniformInt(0, indices_.size() - 1);
     auto best = uniformInt(random);
     auto tournamentSize = GetTournamentSize();
 
     for (size_t i = 1; i < tournamentSize; ++i) {
         auto curr = uniformInt(random);
-        best = std::max(best, curr);
+        if (curr < best) {
+            best = curr;
+        }
     }
-    return best;
+    return indices_[best];
 }
 
 void RankTournamentSelector::Prepare(const Operon::Span<const Individual> pop) const


### PR DESCRIPTION
## Summary

Fixes two interrelated bugs in [`RankTournamentSelector::operator()`](source/operators/selector/tournament.cpp:35) that produce **suboptimal rank-based tournament selection**. The rank-sorted `indices_` array prepared by `Prepare()` was not used in selection, and the tournament logic was inverted, resulting in biased-but-structured selection rather than proper rank-based pressure.

## Bugs Fixed

### Bug 1: Rank-sorted `indices_` array never used

**Before:**
```cpp
auto population = Population();
std::uniform_int_distribution<size_t> uniformInt(0, population.size() - 1);
auto best = uniformInt(random);
```

**After:**
```cpp
std::uniform_int_distribution<size_t> uniformInt(0, indices_.size() - 1);
auto best = uniformInt(random);
```

[`Prepare()`](source/operators/selector/tournament.cpp:52) sorts `indices_` by fitness rank in O(N log N), but `operator()` drew random indices from the raw population instead of from the rank-sorted index array. The sort was effectively dead code.

### Bug 2: Selection chose largest random index, not best rank

**Before:**
```cpp
best = std::max(best, curr);
// ...
return best;
```

**After:**
```cpp
if (curr < best) {   // lower position in indices_ = better rank
    best = curr;
}
// ...
return indices_[best];   // map rank position → population index
```

Three issues in two lines:
1. `std::max(best, curr)` selects the **largest** random index, producing a distribution biased towards higher positional indices — not towards better fitness.
2. No comparison function (`Compare()`) was called, so fitness was never considered.
3. The raw index `best` was returned instead of `indices_[best]`, so there was no mapping from rank position back to the actual population index.

## Impact

The combination of these bugs means:
- The O(N log N) sort in `Prepare()` is wasted computation (dead code)
- Selection has no fitness-based selective pressure via rank
- The returned individual is `max(tournamentSize)` uniform random indices from the **unsorted** population, biased towards higher positional indices
- `std::max` on uniform random indices produces a biased-but-structured distribution (higher indices favored), not random selection

Note: The default operon_gp configuration uses `TournamentSelector` (not `RankTournamentSelector`), so this bug does not affect standard GP runs. It only affects configurations that explicitly opt for rank-based tournament selection.

## Benchmark Results

`tools/compare_operon.py` with Mann-Whitney U (α=0.01, 10 seeds) shows this fix (combined with the crowding distance fix from PR #68) produces statistically significant quality improvements in 6/24 operon_nsgp configurations, with no significant degradation in any configuration. See PR #68 for detailed results.