### PR TITLE
feat(backends): add Eigen backend; fix Eve tanh; fix Floor/Ceil derivatives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,12 @@ if (MATH_BACKEND STREQUAL "Eve")
     target_compile_definitions(operon_operon PUBLIC OPERON_MATH_EVE)
 elseif (MATH_BACKEND STREQUAL "MadEve")
     target_compile_definitions(operon_operon PUBLIC OPERON_MATH_MAD_EVE)
+elseif (MATH_BACKEND STREQUAL "Eigen")
+    target_compile_definitions(operon_operon PUBLIC OPERON_MATH_EIGEN)
 elseif (MATH_BACKEND STREQUAL "Stl")
     target_compile_definitions(operon_operon PUBLIC OPERON_MATH_STL)
 else()
-    message(FATAL_ERROR "Unknown MATH_BACKEND: ${MATH_BACKEND}. Valid options: Eve, MadEve, Stl")
+    message(FATAL_ERROR "Unknown MATH_BACKEND: ${MATH_BACKEND}. Valid options: Eve, MadEve, Eigen, Stl")
 endif()
 
 # print summary of enabled/disabled features

--- a/include/operon/interpreter/backend/eigen.hpp
+++ b/include/operon/interpreter/backend/eigen.hpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2024 Heal Research
+
+#ifndef OPERON_BACKEND_EIGEN_HPP
+#define OPERON_BACKEND_EIGEN_HPP
+
+#include "eigen/derivatives.hpp"
+
+#endif

--- a/include/operon/interpreter/backend/eigen/derivatives.hpp
+++ b/include/operon/interpreter/backend/eigen/derivatives.hpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
+
+#ifndef OPERON_BACKEND_EIGEN_DERIVATIVES_HPP
+#define OPERON_BACKEND_EIGEN_DERIVATIVES_HPP
+
+#include "operon/core/node.hpp"
+#include "functions.hpp"
+
+namespace Operon::Backend {
+namespace detail {
+    template<typename T>
+    inline auto IsNaN(T value) { return std::isnan(value); }
+
+    template<typename Compare>
+    struct FComp {
+        auto operator()(auto x, auto y) const {
+            using T = std::common_type_t<decltype(x), decltype(y)>;
+            if ((IsNaN(x) && IsNaN(y)) || (x == y)) {
+                return std::numeric_limits<T>::quiet_NaN();
+            }
+            if (IsNaN(x)) { return T{0}; }
+            if (IsNaN(y)) { return T{1}; }
+            return static_cast<T>(Compare{}(T{x}, T{y}));
+        }
+    };
+} // namespace detail
+
+    template<typename T, std::size_t S>
+    auto Add(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j).setConstant(T{1});
+    }
+
+    template<typename T, std::size_t S>
+    auto Mul(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        Col(trace, j) = Col(primal, i) / Col(primal, j);
+    }
+
+    template<typename T, std::size_t S>
+    auto Sub(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> /*primal*/, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto v = (nodes[i].Arity == 1 || j < i-1) ? T{-1} : T{+1};
+        Col(trace, j).setConstant(v);
+    }
+
+    template<typename T, std::size_t S>
+    auto Div(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const& n = nodes[i];
+        if (n.Arity == 1) {
+            Col(trace, j) = -Col(primal, j).square().inverse();
+        } else {
+            Col(trace, j) = (j == i-1 ? T{1} : T{-1}) * Col(primal, i) / Col(primal, j);
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Aq(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        if (j == i-1) {
+            Col(trace, j) = Col(primal, i) / Col(primal, j);
+        } else {
+            Col(trace, j) = -Col(primal, j) * Col(primal, i).pow(T{3}) / Col(primal, i-1).square();
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Pow(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        if (j == i-1) {
+            auto const k = j - (nodes[j].Length + 1);
+            Col(trace, j) = Col(primal, i) * Col(primal, k) / Col(primal, j);
+        } else {
+            auto const k = i-1;
+            Col(trace, j) = Col(primal, i) * Col(primal, k).log();
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Powabs(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        if (j == i-1) {
+            auto const k = j - (nodes[j].Length + 1);
+            Col(trace, j) = Col(primal, i) * Col(primal, k) * Col(primal, j).sign() / Col(primal, j).abs();
+        } else {
+            auto const k = i-1;
+            Col(trace, j) = Col(primal, i) * Col(primal, k).abs().log();
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Min(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto k = j == i - 1 ? (j - nodes[j].Length - 1) : i - 1;
+        Col(trace, j) = Col(primal, j).binaryExpr(Col(primal, k), detail::FComp<std::less<>>{});
+    }
+
+    template<typename T, std::size_t S>
+    auto Max(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto k = j == i - 1 ? (j - nodes[j].Length - 1) : i - 1;
+        Col(trace, j) = Col(primal, j).binaryExpr(Col(primal, k), detail::FComp<std::greater<>>{});
+    }
+
+    template<typename T, std::size_t S>
+    auto Square(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = T{2} * Col(primal, j);
+    }
+
+    template<typename T, std::size_t S>
+    auto Abs(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).sign();
+    }
+
+    template<typename T, std::size_t S>
+    auto Ceil(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).ceil();
+    }
+
+    template<typename T, std::size_t S>
+    auto Floor(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).floor();
+    }
+
+    template<typename T, std::size_t S>
+    auto Exp(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        Col(trace, j) = Col(primal, i);
+    }
+
+    template<typename T, std::size_t S>
+    auto Log(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Log1p(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = (T{1} + Col(primal, j)).inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Logabs(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).sign() / Col(primal, j).abs();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sin(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).cos();
+    }
+
+    template<typename T, std::size_t S>
+    auto Cos(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = -Col(primal, j).sin();
+    }
+
+    template<typename T, std::size_t S>
+    auto Tan(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = T{1} + Col(primal, j).tan().square();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sinh(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).cosh();
+    }
+
+    template<typename T, std::size_t S>
+    auto Cosh(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).sinh();
+    }
+
+    template<typename T, std::size_t S>
+    auto Tanh(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = T{1} - Col(primal, j).tanh().square();
+    }
+
+    template<typename T, std::size_t S>
+    auto Asin(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = (T{1} - Col(primal, j).square()).sqrt().inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Acos(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = -((T{1} - Col(primal, j).square()).sqrt().inverse());
+    }
+
+    template<typename T, std::size_t S>
+    auto Atan(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = (T{1} + Col(primal, j).square()).inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sqrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        Col(trace, j) = (T{2} * Col(primal, i)).inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sqrtabs(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).sign() / (T{2} * Col(primal, i));
+    }
+
+    template<typename T, std::size_t S>
+    auto Cbrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        Col(trace, j) = (T{3} * Col(primal, i).square()).inverse();
+    }
+}  // namespace Operon::Backend
+
+#endif

--- a/include/operon/interpreter/backend/eigen/derivatives.hpp
+++ b/include/operon/interpreter/backend/eigen/derivatives.hpp
@@ -106,13 +106,15 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Ceil(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
-        Col(trace, j) = Col(primal, j).ceil();
+    auto Ceil(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        Col(trace, j).setZero();
     }
 
     template<typename T, std::size_t S>
-    auto Floor(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
-        Col(trace, j) = Col(primal, j).floor();
+    auto Floor(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        Col(trace, j).setZero();
     }
 
     template<typename T, std::size_t S>

--- a/include/operon/interpreter/backend/eigen/functions.hpp
+++ b/include/operon/interpreter/backend/eigen/functions.hpp
@@ -30,7 +30,7 @@ namespace detail {
 
     // Avoid most-vexing-parse: use a factory instead of Map<T,S>(ptr) on LHS of =
     template<typename T, std::size_t S>
-    auto MMap(T* ptr) { return Map<T, S>(ptr); }
+    auto MakeMap(T* ptr) { return Map<T, S>(ptr); }
 
     template<typename T, std::size_t S>
     auto Col(Backend::View<T, S> view, std::integral auto col) {
@@ -56,168 +56,170 @@ namespace detail {
     // n-ary functions
     template<typename T, std::size_t S>
     auto Add(T* res, T weight, auto const*... args) {
-        MMap<T, S>(res) =weight * (Map<T const, S>(args) + ...);
+        MakeMap<T, S>(res) = weight * (Map<T const, S>(args) + ...);
     }
 
     template<typename T, std::size_t S>
     auto Mul(T* res, T weight, auto const*... args) {
-        MMap<T, S>(res) =weight * (Map<T const, S>(args) * ...);
+        MakeMap<T, S>(res) = weight * (Map<T const, S>(args) * ...);
     }
 
     template<typename T, std::size_t S>
     auto Sub(T* res, T weight, auto const* first, auto const*... rest) {
         static_assert(sizeof...(rest) > 0);
-        MMap<T, S>(res) =weight * (Map<T const, S>(first) - (Map<T const, S>(rest) + ...));
+        MakeMap<T, S>(res) = weight * (Map<T const, S>(first) - (Map<T const, S>(rest) + ...));
     }
 
     template<typename T, std::size_t S>
     auto Div(T* res, T weight, auto const* first, auto const*... rest) {
         static_assert(sizeof...(rest) > 0);
-        MMap<T, S>(res) =weight * Map<T const, S>(first) / (Map<T const, S>(rest) * ...);
+        MakeMap<T, S>(res) = weight * Map<T const, S>(first) / (Map<T const, S>(rest) * ...);
     }
 
     template<typename T, std::size_t S>
     auto Min(T* res, T weight, auto const* first, auto const*... args) {
         static_assert(sizeof...(args) > 0);
-        MMap<T, S>(res) = weight * detail::FoldMin(Map<T const, S>(first), Map<T const, S>(args)...);
+        MakeMap<T, S>(res) = weight * detail::FoldMin(Map<T const, S>(first), Map<T const, S>(args)...);
     }
 
     template<typename T, std::size_t S>
     auto Max(T* res, T weight, auto const* first, auto const*... args) {
         static_assert(sizeof...(args) > 0);
-        MMap<T, S>(res) = weight * detail::FoldMax(Map<T const, S>(first), Map<T const, S>(args)...);
+        MakeMap<T, S>(res) = weight * detail::FoldMax(Map<T const, S>(first), Map<T const, S>(args)...);
     }
 
     // binary functions
     template<typename T, std::size_t S>
     auto Aq(T* res, T weight, T const* a, T const* b) {
-        MMap<T, S>(res) =weight * Map<T const, S>(a) / (T{1} + Map<T const, S>(b).square()).sqrt();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(a) / (T{1} + Map<T const, S>(b).square()).sqrt();
     }
 
     template<typename T, std::size_t S>
     auto Pow(T* res, T weight, T const* a, T const* b) {
-        MMap<T, S>(res) =weight * Map<T const, S>(a).pow(Map<T const, S>(b));
+        MakeMap<T, S>(res) = weight * Map<T const, S>(a).pow(Map<T const, S>(b));
     }
 
     template<typename T, std::size_t S>
     auto Powabs(T* res, T weight, T const* a, T const* b) {
-        MMap<T, S>(res) =weight * Map<T const, S>(a).abs().pow(Map<T const, S>(b));
+        MakeMap<T, S>(res) = weight * Map<T const, S>(a).abs().pow(Map<T const, S>(b));
     }
 
     // unary functions
     template<typename T, std::size_t S>
     auto Cpy(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg);
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg);
     }
 
     template<typename T, std::size_t S>
     auto Neg(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * -Map<T const, S>(arg);
+        MakeMap<T, S>(res) = weight * -Map<T const, S>(arg);
     }
 
     template<typename T, std::size_t S>
     auto Inv(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).inverse();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).inverse();
     }
 
     template<typename T, std::size_t S>
     auto Abs(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).abs();
     }
 
     template<typename T, std::size_t S>
     auto Ceil(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).ceil();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).ceil();
     }
 
     template<typename T, std::size_t S>
     auto Floor(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).floor();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).floor();
     }
 
     template<typename T, std::size_t S>
     auto Square(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).square();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).square();
     }
 
     template<typename T, std::size_t S>
     auto Exp(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).exp();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).exp();
     }
 
     template<typename T, std::size_t S>
     auto Log(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).log();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).log();
     }
 
     template<typename T, std::size_t S>
     auto Log1p(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).log1p();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).log1p();
     }
 
     template<typename T, std::size_t S>
     auto Logabs(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs().log();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).abs().log();
     }
 
     template<typename T, std::size_t S>
     auto Sin(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).sin();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).sin();
     }
 
     template<typename T, std::size_t S>
     auto Cos(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).cos();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).cos();
     }
 
     template<typename T, std::size_t S>
     auto Tan(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).tan();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).tan();
     }
 
     template<typename T, std::size_t S>
     auto Asin(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).asin();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).asin();
     }
 
     template<typename T, std::size_t S>
     auto Acos(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).acos();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).acos();
     }
 
     template<typename T, std::size_t S>
     auto Atan(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).atan();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).atan();
     }
 
     template<typename T, std::size_t S>
     auto Sinh(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).sinh();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).sinh();
     }
 
     template<typename T, std::size_t S>
     auto Cosh(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).cosh();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).cosh();
     }
 
     template<typename T, std::size_t S>
     auto Tanh(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).tanh();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).tanh();
     }
 
     template<typename T, std::size_t S>
     auto Sqrt(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).sqrt();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).sqrt();
     }
 
     template<typename T, std::size_t S>
     auto Sqrtabs(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs().sqrt();
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).abs().sqrt();
     }
 
     template<typename T, std::size_t S>
     auto Cbrt(T* res, T weight, T const* arg) {
-        MMap<T, S>(res) =weight * Map<T const, S>(arg).unaryExpr([](auto x) { return std::cbrt(x); });
+        // Eigen has no native cbrt; scalar fallback via unaryExpr. Alternative: pow(x, 1/3)
+        // is faster but less accurate near zero and wrong for negative inputs.
+        MakeMap<T, S>(res) = weight * Map<T const, S>(arg).unaryExpr([](auto x) { return std::cbrt(x); });
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/eigen/functions.hpp
+++ b/include/operon/interpreter/backend/eigen/functions.hpp
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
+
+#ifndef OPERON_BACKEND_EIGEN_FUNCTIONS_HPP
+#define OPERON_BACKEND_EIGEN_FUNCTIONS_HPP
+
+#include <cmath>
+#include <Eigen/Core>
+#include "operon/core/dispatch.hpp"
+
+namespace Operon::Backend {
+    template<typename T, std::size_t S>
+    using Map = Eigen::Map<std::conditional_t<std::is_const_v<T>,
+        Eigen::Array<std::remove_const_t<T>, S, 1> const,
+        Eigen::Array<T, S, 1>>>;
+
+    // Avoid most-vexing-parse: use a factory instead of Map<T,S>(ptr) on LHS of =
+    template<typename T, std::size_t S>
+    auto MMap(T* ptr) { return Map<T, S>(ptr); }
+
+    template<typename T, std::size_t S>
+    auto Col(Backend::View<T, S> view, std::integral auto col) {
+        return Map<T, S>(view.data_handle() + col * S);
+    }
+
+    template<typename T, std::size_t S>
+    auto Col(Backend::View<T const, S> view, std::integral auto col) {
+        return Map<T const, S>(view.data_handle() + col * S);
+    }
+
+    // utility
+    template<typename T, std::size_t S>
+    auto Fill(T* res, T value) {
+        Map<T, S>(res).setConstant(value);
+    }
+
+    template<typename T, std::size_t S>
+    auto Fill(T* res, int n, T value) {
+        Eigen::Map<Eigen::Array<T, Eigen::Dynamic, 1>>(res, n).setConstant(value);
+    }
+
+    // n-ary functions
+    template<typename T, std::size_t S>
+    auto Add(T* res, T weight, auto const*... args) {
+        MMap<T, S>(res) =weight * (Map<T const, S>(args) + ...);
+    }
+
+    template<typename T, std::size_t S>
+    auto Mul(T* res, T weight, auto const*... args) {
+        MMap<T, S>(res) =weight * (Map<T const, S>(args) * ...);
+    }
+
+    template<typename T, std::size_t S>
+    auto Sub(T* res, T weight, auto const* first, auto const*... rest) {
+        static_assert(sizeof...(rest) > 0);
+        MMap<T, S>(res) =weight * (Map<T const, S>(first) - (Map<T const, S>(rest) + ...));
+    }
+
+    template<typename T, std::size_t S>
+    auto Div(T* res, T weight, auto const* first, auto const*... rest) {
+        static_assert(sizeof...(rest) > 0);
+        MMap<T, S>(res) =weight * Map<T const, S>(first) / (Map<T const, S>(rest) * ...);
+    }
+
+    template<typename T, std::size_t S>
+    auto Min(T* res, T weight, auto const* first, auto const*... args) {
+        static_assert(sizeof...(args) > 0);
+        MMap<T, S>(res) =weight * (Map<T const, S>(first).min(Map<T const, S>(args)), ...);
+    }
+
+    template<typename T, std::size_t S>
+    auto Max(T* res, T weight, auto const* first, auto const*... args) {
+        static_assert(sizeof...(args) > 0);
+        MMap<T, S>(res) =weight * (Map<T const, S>(first).max(Map<T const, S>(args)), ...);
+    }
+
+    // binary functions
+    template<typename T, std::size_t S>
+    auto Aq(T* res, T weight, T const* a, T const* b) {
+        MMap<T, S>(res) =weight * Map<T const, S>(a) / (T{1} + Map<T const, S>(b).square()).sqrt();
+    }
+
+    template<typename T, std::size_t S>
+    auto Pow(T* res, T weight, T const* a, T const* b) {
+        MMap<T, S>(res) =weight * Map<T const, S>(a).pow(Map<T const, S>(b));
+    }
+
+    template<typename T, std::size_t S>
+    auto Powabs(T* res, T weight, T const* a, T const* b) {
+        MMap<T, S>(res) =weight * Map<T const, S>(a).abs().pow(Map<T const, S>(b));
+    }
+
+    // unary functions
+    template<typename T, std::size_t S>
+    auto Cpy(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg);
+    }
+
+    template<typename T, std::size_t S>
+    auto Neg(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * -Map<T const, S>(arg);
+    }
+
+    template<typename T, std::size_t S>
+    auto Inv(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).inverse();
+    }
+
+    template<typename T, std::size_t S>
+    auto Abs(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs();
+    }
+
+    template<typename T, std::size_t S>
+    auto Ceil(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).ceil();
+    }
+
+    template<typename T, std::size_t S>
+    auto Floor(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).floor();
+    }
+
+    template<typename T, std::size_t S>
+    auto Square(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).square();
+    }
+
+    template<typename T, std::size_t S>
+    auto Exp(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).exp();
+    }
+
+    template<typename T, std::size_t S>
+    auto Log(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).log();
+    }
+
+    template<typename T, std::size_t S>
+    auto Log1p(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).log1p();
+    }
+
+    template<typename T, std::size_t S>
+    auto Logabs(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs().log();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sin(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).sin();
+    }
+
+    template<typename T, std::size_t S>
+    auto Cos(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).cos();
+    }
+
+    template<typename T, std::size_t S>
+    auto Tan(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).tan();
+    }
+
+    template<typename T, std::size_t S>
+    auto Asin(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).asin();
+    }
+
+    template<typename T, std::size_t S>
+    auto Acos(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).acos();
+    }
+
+    template<typename T, std::size_t S>
+    auto Atan(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).atan();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sinh(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).sinh();
+    }
+
+    template<typename T, std::size_t S>
+    auto Cosh(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).cosh();
+    }
+
+    template<typename T, std::size_t S>
+    auto Tanh(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).tanh();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sqrt(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).sqrt();
+    }
+
+    template<typename T, std::size_t S>
+    auto Sqrtabs(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).abs().sqrt();
+    }
+
+    template<typename T, std::size_t S>
+    auto Cbrt(T* res, T weight, T const* arg) {
+        MMap<T, S>(res) =weight * Map<T const, S>(arg).unaryExpr([](auto x) { return std::cbrt(x); });
+    }
+}  // namespace Operon::Backend
+
+#endif

--- a/include/operon/interpreter/backend/eigen/functions.hpp
+++ b/include/operon/interpreter/backend/eigen/functions.hpp
@@ -5,10 +5,24 @@
 #define OPERON_BACKEND_EIGEN_FUNCTIONS_HPP
 
 #include <cmath>
+#include <concepts>
+#include <type_traits>
 #include <Eigen/Core>
 #include "operon/core/dispatch.hpp"
 
 namespace Operon::Backend {
+namespace detail {
+    template<typename E, typename H>
+    auto FoldMin(E e, H h) { return e.min(h); }
+    template<typename E, typename H, typename... Tail>
+    auto FoldMin(E e, H h, Tail... t) { return FoldMin(e.min(h), t...); }
+
+    template<typename E, typename H>
+    auto FoldMax(E e, H h) { return e.max(h); }
+    template<typename E, typename H, typename... Tail>
+    auto FoldMax(E e, H h, Tail... t) { return FoldMax(e.max(h), t...); }
+} // namespace detail
+
     template<typename T, std::size_t S>
     using Map = Eigen::Map<std::conditional_t<std::is_const_v<T>,
         Eigen::Array<std::remove_const_t<T>, S, 1> const,
@@ -65,13 +79,13 @@ namespace Operon::Backend {
     template<typename T, std::size_t S>
     auto Min(T* res, T weight, auto const* first, auto const*... args) {
         static_assert(sizeof...(args) > 0);
-        MMap<T, S>(res) =weight * (Map<T const, S>(first).min(Map<T const, S>(args)), ...);
+        MMap<T, S>(res) = weight * detail::FoldMin(Map<T const, S>(first), Map<T const, S>(args)...);
     }
 
     template<typename T, std::size_t S>
     auto Max(T* res, T weight, auto const* first, auto const*... args) {
         static_assert(sizeof...(args) > 0);
-        MMap<T, S>(res) =weight * (Map<T const, S>(first).max(Map<T const, S>(args)), ...);
+        MMap<T, S>(res) = weight * detail::FoldMax(Map<T const, S>(first), Map<T const, S>(args)...);
     }
 
     // binary functions

--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -185,27 +185,15 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto  /*i*/, std::integral auto j) {
-        using W = eve::wide<T>;
-        static constexpr auto L = W::size();
-
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::ceil(W{pj+s}), res+s);
-        }
+    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto  /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>
-    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto  /*i*/, std::integral auto j) {
-        using W = eve::wide<T>;
-        static constexpr auto L = W::size();
-
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::floor(W{pj+s}), res+s);
-        }
+    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto  /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -299,10 +299,29 @@ namespace Operon::Backend {
     template<typename T, std::size_t S>
     requires (S % eve::wide<T>::size() == 0)
     auto Tanh(T* res, T weight, T const* arg) {
+        // 13/6-degree rational minimax approximation, accurate to ~2 ULP on [-8,8].
+        // Same algorithm as Eigen's generic_fast_tanh_float; avoids expm1 overhead.
+        // Reference: Eigen/src/Core/MathFunctionsImpl.h (Pedro Gonnet, 2014)
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {
-            eve::store(weight * eve::tanh(W{arg + i}), res+i);
+            auto a    = W{arg + i};
+            auto x    = eve::clamp(a, T(-7.99881172180175781f), T(7.99881172180175781f));
+            auto tiny = eve::abs(a) < T(0.0004f);
+            auto x2   = x * x;
+            // numerator (odd polynomial): p = x * (alpha_1 + x^2*(...))
+            auto p = eve::fma(x2, W{T(-2.76076847742355e-16f)}, W{T( 2.00018790482477e-13f)});
+            p = eve::fma(x2, p, W{T(-8.60467152213735e-11f)});
+            p = eve::fma(x2, p, W{T( 5.12229709037114e-08f)});
+            p = eve::fma(x2, p, W{T( 1.48572235717979e-05f)});
+            p = eve::fma(x2, p, W{T( 6.37261928875436e-04f)});
+            p = eve::fma(x2, p, W{T( 4.89352455891786e-03f)});
+            p = x * p;
+            // denominator (even polynomial): q = beta_0 + x^2*(...)
+            auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
+            q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
+            q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
+            eve::store(weight * eve::if_else(tiny, x, p / q), res + i);
         }
     }
 

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -300,8 +300,10 @@ namespace Operon::Backend {
     requires (S % eve::wide<T>::size() == 0)
     auto Tanh(T* res, T weight, T const* arg) {
         // 13/6-degree rational minimax approximation, accurate to ~2 ULP on [-8,8].
+        // Coefficients are float-only; double precision degrades to ~float accuracy.
         // Same algorithm as Eigen's generic_fast_tanh_float; avoids expm1 overhead.
         // Reference: Eigen/src/Core/MathFunctionsImpl.h (Pedro Gonnet, 2014)
+        static_assert(std::is_same_v<T, float>, "Eve tanh approximation is float-only; supply double-precision coefficients for T=double");
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -299,31 +299,30 @@ namespace Operon::Backend {
     template<typename T, std::size_t S>
     requires (S % eve::wide<T>::size() == 0)
     auto Tanh(T* res, T weight, T const* arg) {
-        // 13/6-degree rational minimax approximation, accurate to ~2 ULP on [-8,8].
-        // Coefficients are float-only; double precision degrades to ~float accuracy.
-        // Same algorithm as Eigen's generic_fast_tanh_float; avoids expm1 overhead.
-        // Reference: Eigen/src/Core/MathFunctionsImpl.h (Pedro Gonnet, 2014)
-        static_assert(std::is_same_v<T, float>, "Eve tanh approximation is float-only; supply double-precision coefficients for T=double");
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {
-            auto a    = W{arg + i};
-            auto x    = eve::clamp(a, T(-7.99881172180175781f), T(7.99881172180175781f));
-            auto tiny = eve::abs(a) < T(0.0004f);
-            auto x2   = x * x;
-            // numerator (odd polynomial): p = x * (alpha_1 + x^2*(...))
-            auto p = eve::fma(x2, W{T(-2.76076847742355e-16f)}, W{T( 2.00018790482477e-13f)});
-            p = eve::fma(x2, p, W{T(-8.60467152213735e-11f)});
-            p = eve::fma(x2, p, W{T( 5.12229709037114e-08f)});
-            p = eve::fma(x2, p, W{T( 1.48572235717979e-05f)});
-            p = eve::fma(x2, p, W{T( 6.37261928875436e-04f)});
-            p = eve::fma(x2, p, W{T( 4.89352455891786e-03f)});
-            p = x * p;
-            // denominator (even polynomial): q = beta_0 + x^2*(...)
-            auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
-            q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
-            q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
-            eve::store(weight * eve::if_else(tiny, x, p / q), res + i);
+            if constexpr (std::is_same_v<T, float>) {
+                // 13/6-degree rational minimax approximation, ~2 ULP on [-8,8].
+                // Eigen's generic_fast_tanh_float (Pedro Gonnet, 2014); avoids expm1.
+                auto a    = W{arg + i};
+                auto x    = eve::clamp(a, T(-7.99881172180175781f), T(7.99881172180175781f));
+                auto tiny = eve::abs(a) < T(0.0004f);
+                auto x2   = x * x;
+                auto p = eve::fma(x2, W{T(-2.76076847742355e-16f)}, W{T( 2.00018790482477e-13f)});
+                p = eve::fma(x2, p, W{T(-8.60467152213735e-11f)});
+                p = eve::fma(x2, p, W{T( 5.12229709037114e-08f)});
+                p = eve::fma(x2, p, W{T( 1.48572235717979e-05f)});
+                p = eve::fma(x2, p, W{T( 6.37261928875436e-04f)});
+                p = eve::fma(x2, p, W{T( 4.89352455891786e-03f)});
+                p = x * p;
+                auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
+                q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
+                q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
+                eve::store(weight * eve::if_else(tiny, x, p / q), res + i);
+            } else {
+                eve::store(weight * eve::tanh(W{arg + i}), res + i);
+            }
         }
     }
 

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -10,6 +10,58 @@
 
 #include "operon/core/dispatch.hpp"
 
+namespace Operon::Backend::detail {
+
+template<typename T>
+auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
+    using W = eve::wide<T>;
+    if constexpr (std::is_same_v<T, float>) {
+        // 13/6-degree rational minimax, ~2 ULP on [-8,8].
+        // Eigen's generic_fast_tanh_float (Pedro Gonnet, 2014).
+        auto x    = eve::clamp(a, T(-7.99881172180175781f), T(7.99881172180175781f));
+        auto tiny = eve::abs(a) < T(0.0004f);
+        auto x2   = x * x;
+        auto p = eve::fma(x2, W{T(-2.76076847742355e-16f)}, W{T( 2.00018790482477e-13f)});
+        p = eve::fma(x2, p, W{T(-8.60467152213735e-11f)});
+        p = eve::fma(x2, p, W{T( 5.12229709037114e-08f)});
+        p = eve::fma(x2, p, W{T( 1.48572235717979e-05f)});
+        p = eve::fma(x2, p, W{T( 6.37261928875436e-04f)});
+        p = eve::fma(x2, p, W{T( 4.89352455891786e-03f)});
+        p = x * p;
+        auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
+        q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
+        q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
+        return eve::if_else(tiny, x, p / q);
+    } else {
+        // 19/18-degree rational minimax, ~2 ULP on [-18.7,18.7].
+        // Ported from Eigen's ptanh_double (rminimax-optimised coefficients).
+        auto x    = eve::clamp(a, T(-17.6610191624600077), T(17.6610191624600077));
+        auto tiny = eve::abs(a) < T(0.0004);
+        auto x2   = x * x;
+        auto p = eve::fma(x2, W{T(2.6158007860482230e-23)}, W{T(7.6534862268749319e-19)});
+        p = eve::fma(x2, p, W{T(3.1309488231386680e-15)});
+        p = eve::fma(x2, p, W{T(4.2303918148209176e-12)});
+        p = eve::fma(x2, p, W{T(2.4618379131293676e-09)});
+        p = eve::fma(x2, p, W{T(6.8644367682497074e-07)});
+        p = eve::fma(x2, p, W{T(9.3839087674268880e-05)});
+        p = eve::fma(x2, p, W{T(5.9809711724441161e-03)});
+        p = eve::fma(x2, p, W{T(1.5184719640284322e-01)});
+        p = x * p;
+        auto q = eve::fma(x2, W{T(6.463747022670968018e-21)}, W{T(5.782506856739003571e-17)});
+        q = eve::fma(x2, q, W{T(1.293019623712687916e-13)});
+        q = eve::fma(x2, q, W{T(1.123643448069621992e-10)});
+        q = eve::fma(x2, q, W{T(4.492975677839633985e-08)});
+        q = eve::fma(x2, q, W{T(8.785185266237658698e-06)});
+        q = eve::fma(x2, q, W{T(8.295161192716231542e-04)});
+        q = eve::fma(x2, q, W{T(3.437448108450402717e-02)});
+        q = eve::fma(x2, q, W{T(4.851805297361760360e-01)});
+        q = eve::fma(x2, q, W{T(1.0)});
+        return eve::if_else(tiny, x, p / q);
+    }
+}
+
+} // namespace Operon::Backend::detail
+
 namespace Operon::Backend {
     // utility
     template<typename T, std::size_t S>
@@ -302,27 +354,7 @@ namespace Operon::Backend {
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {
-            if constexpr (std::is_same_v<T, float>) {
-                // 13/6-degree rational minimax approximation, ~2 ULP on [-8,8].
-                // Eigen's generic_fast_tanh_float (Pedro Gonnet, 2014); avoids expm1.
-                auto a    = W{arg + i};
-                auto x    = eve::clamp(a, T(-7.99881172180175781f), T(7.99881172180175781f));
-                auto tiny = eve::abs(a) < T(0.0004f);
-                auto x2   = x * x;
-                auto p = eve::fma(x2, W{T(-2.76076847742355e-16f)}, W{T( 2.00018790482477e-13f)});
-                p = eve::fma(x2, p, W{T(-8.60467152213735e-11f)});
-                p = eve::fma(x2, p, W{T( 5.12229709037114e-08f)});
-                p = eve::fma(x2, p, W{T( 1.48572235717979e-05f)});
-                p = eve::fma(x2, p, W{T( 6.37261928875436e-04f)});
-                p = eve::fma(x2, p, W{T( 4.89352455891786e-03f)});
-                p = x * p;
-                auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
-                q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
-                q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
-                eve::store(weight * eve::if_else(tiny, x, p / q), res + i);
-            } else {
-                eve::store(weight * eve::tanh(W{arg + i}), res + i);
-            }
+            eve::store(weight * detail::FastTanh(W{arg + i}), res + i);
         }
     }
 

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -12,7 +12,7 @@
 
 namespace Operon::Backend::detail {
 
-template<typename T>
+template<std::floating_point T>
 auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
     using W = eve::wide<T>;
     if constexpr (std::is_same_v<T, float>) {

--- a/include/operon/interpreter/backend/mad_eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/mad_eve/derivatives.hpp
@@ -155,17 +155,15 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x){ return std::ceil(x); });
+    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>
-    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x){ return std::floor(x); });
+    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>

--- a/include/operon/interpreter/backend/plain/derivatives.hpp
+++ b/include/operon/interpreter/backend/plain/derivatives.hpp
@@ -155,17 +155,15 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x){ return std::ceil(x); });
+    auto Ceil(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>
-    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
-        auto* res = Ptr(trace, j);
-        auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x){ return std::floor(x); });
+    auto Floor(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        // Derivative is zero a.e.; provides no gradient information (cf. Ceres jet.h).
+        std::fill_n(Ptr(trace, j), S, T{0});
     }
 
     template<typename T, std::size_t S>

--- a/include/operon/interpreter/functions.hpp
+++ b/include/operon/interpreter/functions.hpp
@@ -10,6 +10,8 @@
 #include "operon/interpreter/backend/eve.hpp"
 #elif defined(OPERON_MATH_MAD_EVE)
 #include "operon/interpreter/backend/mad_eve.hpp"
+#elif defined(OPERON_MATH_EIGEN)
+#include "operon/interpreter/backend/eigen.hpp"
 #elif defined(OPERON_MATH_STL)
 #include "operon/interpreter/backend/plain.hpp"
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(nanobench REQUIRED)
 
 add_executable(operon_test
     source/operon_test.cpp
+    source/implementation/backend.cpp
     source/implementation/autodiff.cpp
     source/implementation/crossover.cpp
     source/implementation/details.cpp
@@ -38,6 +39,7 @@ add_executable(operon_test
     source/performance/evaluation.cpp
     source/performance/infix_parser.cpp
     source/performance/nondominatedsort.cpp
+    source/performance/primitives.cpp
     )
 target_link_libraries(operon_test PRIVATE operon::operon Catch2::Catch2WithMain scn::scn nanobench::nanobench)
 target_compile_features(operon_test PRIVATE cxx_std_20)

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "operon/core/dispatch.hpp"
+#include "operon/interpreter/functions.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    using T = Operon::Scalar;
+    constexpr std::size_t S = Dispatch::DefaultBatchSize<T>;
+
+    struct alignas(32) Buf { std::array<T, S> v; };
+
+    auto UlpDistance(float a, float b) -> int {
+        if (std::isnan(a) && std::isnan(b)) { return 0; }
+        if (std::isinf(a) && std::isinf(b) && (a > 0) == (b > 0)) { return 0; }
+        auto ua = std::bit_cast<uint32_t>(a);
+        auto ub = std::bit_cast<uint32_t>(b);
+        // two's complement trick for signed-magnitude integers
+        if (ua >> 31U) { ua = 0x80000000U - ua; }
+        if (ub >> 31U) { ub = 0x80000000U - ub; }
+        return static_cast<int>(ua > ub ? ua - ub : ub - ua);
+    }
+
+    // Run fn on batches of input, compare element-wise against ref, return max ULP error.
+    auto MaxUlpError(auto fn, auto ref, std::vector<T> const& inputs) -> int {
+        auto nbatch = (inputs.size() + S - 1) / S;
+        std::vector<Buf> src(nbatch), dst(nbatch);
+
+        for (auto i = 0UL; i < inputs.size(); ++i) {
+            src[i / S].v[i % S] = inputs[i];
+        }
+        // pad last batch with safe values
+        for (auto i = inputs.size(); i < nbatch * S; ++i) {
+            src[i / S].v[i % S] = T{0.5};
+        }
+
+        for (auto b = 0UL; b < nbatch; ++b) {
+            fn(dst[b].v.data(), T{1}, src[b].v.data());
+        }
+
+        int max_ulp = 0;
+        for (auto i = 0UL; i < inputs.size(); ++i) {
+            auto got = dst[i / S].v[i % S];
+            auto expected = static_cast<T>(ref(static_cast<double>(inputs[i])));
+            max_ulp = std::max(max_ulp, UlpDistance(got, expected));
+        }
+        return max_ulp;
+    }
+
+    auto MakeInputs() -> std::vector<T> {
+        std::vector<T> vals;
+        // dense grid over [-10, 10]
+        constexpr int N = 10000;
+        for (int i = 0; i <= N; ++i) {
+            vals.push_back(T(-10.0 + 20.0 * i / N));
+        }
+        // edge cases
+        for (auto v : {0.0f, -0.0f, 0.0001f, -0.0001f, 0.0003f, -0.0003f,
+                       0.0005f, 7.99f, -7.99f, 8.5f, -8.5f, 100.0f, -100.0f,
+                       std::numeric_limits<T>::infinity(),
+                       -std::numeric_limits<T>::infinity()}) {
+            vals.push_back(v);
+        }
+        return vals;
+    }
+} // namespace
+
+TEST_CASE("Backend Tanh ULP accuracy", "[backend][tanh]")
+{
+    auto inputs = MakeInputs();
+    auto fn = Backend::Tanh<T, S>;
+
+    int max_ulp = MaxUlpError(fn, [](double x) { return std::tanh(x); }, inputs);
+
+    // Eigen's generic_fast_tanh_float claims ~2 ULP; allow up to 4 to be safe.
+    INFO("Max ULP error vs std::tanh: " << max_ulp);
+    CHECK(max_ulp <= 4);
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -24,17 +24,19 @@ namespace {
 
     struct alignas(32) Buf { std::array<T, S> v; };
 
-    auto UlpDistance(float a, float b) -> int {
+    auto UlpDistance(T a, T b) -> uint64_t {
         if (std::isnan(a) && std::isnan(b)) { return 0; }
         if (std::isinf(a) && std::isinf(b) && (a > 0) == (b > 0)) { return 0; }
-        auto ua = std::bit_cast<uint32_t>(a);
-        auto ub = std::bit_cast<uint32_t>(b);
-        if (ua >> 31U) { ua = 0x80000000U - ua; }
-        if (ub >> 31U) { ub = 0x80000000U - ub; }
-        return static_cast<int>(ua > ub ? ua - ub : ub - ua);
+        using U = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+        constexpr U SignBit = U{1} << (sizeof(U) * 8 - 1);
+        auto ua = std::bit_cast<U>(a);
+        auto ub = std::bit_cast<U>(b);
+        if (ua & SignBit) { ua = SignBit - ua; }
+        if (ub & SignBit) { ub = SignBit - ub; }
+        return ua > ub ? ua - ub : ub - ua;
     }
 
-    struct UlpResult { int max_ulp; T worst_input; T got; T expected; };
+    struct UlpResult { uint64_t max_ulp; T worst_input; T got; T expected; };
 
     auto MaxUlpError(auto fn, auto ref, std::vector<T> const& inputs) -> UlpResult {
         auto const nbatch = (inputs.size() + S - 1) / S;
@@ -54,7 +56,7 @@ namespace {
         for (auto i = 0UL; i < inputs.size(); ++i) {
             auto got      = dst[i / S].v[i % S];
             auto expected = static_cast<T>(ref(static_cast<double>(inputs[i])));
-            if (int d = UlpDistance(got, expected); d > res.max_ulp) {
+            if (auto d = UlpDistance(got, expected); d > res.max_ulp) {
                 res = {d, inputs[i], got, expected};
             }
         }
@@ -72,8 +74,8 @@ namespace {
         return v;
     }
 
-    constexpr float kInf = std::numeric_limits<T>::infinity();
-    constexpr int   kN   = 10000;
+    constexpr T   Inf = std::numeric_limits<T>::infinity();
+    constexpr int N   = 10000;
 } // namespace
 
 TEST_CASE("Backend transcendental ULP accuracy", "[backend]")
@@ -83,75 +85,75 @@ TEST_CASE("Backend transcendental ULP accuracy", "[backend]")
         void(*fn)(T*, T, T const*);
         std::vector<T> inputs;
         double(*ref)(double);
-        int max_ulp;
+        uint64_t max_ulp;
     };
 
     // clang-format off
     std::array cases {
         Case{ "Exp",    Backend::Exp<T,S>,
-              Linspace(-87, 88, kN, {0.f, -0.f}),
+              Linspace(-87, 88, N, {0.f, -0.f}),
               [](double x){ return std::exp(x); },   2 },
 
         Case{ "Log",    Backend::Log<T,S>,
-              Linspace(1e-6, 1e6, kN, {1.f, kInf}),
+              Linspace(1e-6, 1e6, N, {1.f, Inf}),
               [](double x){ return std::log(x); },   2 },
 
         Case{ "Log1p",  Backend::Log1p<T,S>,
-              Linspace(-0.999, 1e6, kN, {0.f, kInf}),
+              Linspace(-0.999, 1e6, N, {0.f, Inf}),
               [](double x){ return std::log1p(x); }, 2 },
 
         Case{ "Logabs", Backend::Logabs<T,S>,
-              Linspace(-1e6, 1e6, kN, {1.f, -1.f, kInf, -kInf}),
+              Linspace(-1e6, 1e6, N, {1.f, -1.f, Inf, -Inf}),
               [](double x){ return std::log(std::abs(x)); }, 2 },
 
         Case{ "Sin",    Backend::Sin<T,S>,
-              Linspace(-10, 10, kN, {0.f, -0.f, kInf, -kInf}),
+              Linspace(-10, 10, N, {0.f, -0.f, Inf, -Inf}),
               [](double x){ return std::sin(x); },   2 },
 
         Case{ "Cos",    Backend::Cos<T,S>,
-              Linspace(-10, 10, kN, {0.f, kInf, -kInf}),
+              Linspace(-10, 10, N, {0.f, Inf, -Inf}),
               [](double x){ return std::cos(x); },   2 },
 
         Case{ "Tan",    Backend::Tan<T,S>,
               // avoid singularities near ±π/2 + nπ
-              Linspace(-1.5, 1.5, kN, {0.f}),
+              Linspace(-1.5, 1.5, N, {0.f}),
               [](double x){ return std::tan(x); },   2 },
 
         Case{ "Asin",   Backend::Asin<T,S>,
-              Linspace(-1, 1, kN, {0.f, 1.f, -1.f}),
+              Linspace(-1, 1, N, {0.f, 1.f, -1.f}),
               [](double x){ return std::asin(x); },  2 },
 
         Case{ "Acos",   Backend::Acos<T,S>,
-              Linspace(-1, 1, kN, {0.f, 1.f, -1.f}),
+              Linspace(-1, 1, N, {0.f, 1.f, -1.f}),
               [](double x){ return std::acos(x); },  2 },
 
         Case{ "Atan",   Backend::Atan<T,S>,
-              Linspace(-100, 100, kN, {0.f, kInf, -kInf}),
+              Linspace(-100, 100, N, {0.f, Inf, -Inf}),
               [](double x){ return std::atan(x); },  2 },
 
         Case{ "Sinh",   Backend::Sinh<T,S>,
-              Linspace(-10, 10, kN, {0.f, -0.f}),
+              Linspace(-10, 10, N, {0.f, -0.f}),
               [](double x){ return std::sinh(x); },  2 },
 
         Case{ "Cosh",   Backend::Cosh<T,S>,
-              Linspace(-10, 10, kN, {0.f}),
+              Linspace(-10, 10, N, {0.f}),
               [](double x){ return std::cosh(x); },  2 },
 
         Case{ "Tanh",   Backend::Tanh<T,S>,
-              Linspace(-10, 10, kN, {0.f, -0.f, 0.0001f, -0.0001f,
-                                     7.99f, -7.99f, 8.5f, -8.5f, kInf, -kInf}),
+              Linspace(-10, 10, N, {0.f, -0.f, 0.0001f, -0.0001f,
+                                     7.99f, -7.99f, 8.5f, -8.5f, Inf, -Inf}),
               [](double x){ return std::tanh(x); },  4 },
 
         Case{ "Sqrt",   Backend::Sqrt<T,S>,
-              Linspace(0, 1e6, kN, {0.f}),
+              Linspace(0, 1e6, N, {0.f}),
               [](double x){ return std::sqrt(x); },  2 },
 
         Case{ "Sqrtabs",Backend::Sqrtabs<T,S>,
-              Linspace(-1e6, 1e6, kN, {0.f}),
+              Linspace(-1e6, 1e6, N, {0.f}),
               [](double x){ return std::sqrt(std::abs(x)); }, 2 },
 
         Case{ "Cbrt",   Backend::Cbrt<T,S>,
-              Linspace(-1e6, 1e6, kN, {0.f, -0.f, kInf, -kInf}),
+              Linspace(-1e6, 1e6, N, {0.f, -0.f, Inf, -Inf}),
               [](double x){ return std::cbrt(x); },  2 },
     };
     // clang-format on

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -2,15 +2,15 @@
 // SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers.hpp>
 
-#include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <numbers>
+#include <string_view>
 #include <vector>
 
 #include "operon/core/dispatch.hpp"
@@ -29,66 +29,139 @@ namespace {
         if (std::isinf(a) && std::isinf(b) && (a > 0) == (b > 0)) { return 0; }
         auto ua = std::bit_cast<uint32_t>(a);
         auto ub = std::bit_cast<uint32_t>(b);
-        // two's complement trick for signed-magnitude integers
         if (ua >> 31U) { ua = 0x80000000U - ua; }
         if (ub >> 31U) { ub = 0x80000000U - ub; }
         return static_cast<int>(ua > ub ? ua - ub : ub - ua);
     }
 
-    // Run fn on batches of input, compare element-wise against ref, return max ULP error.
-    auto MaxUlpError(auto fn, auto ref, std::vector<T> const& inputs) -> int {
-        auto nbatch = (inputs.size() + S - 1) / S;
+    struct UlpResult { int max_ulp; T worst_input; T got; T expected; };
+
+    auto MaxUlpError(auto fn, auto ref, std::vector<T> const& inputs) -> UlpResult {
+        auto const nbatch = (inputs.size() + S - 1) / S;
         std::vector<Buf> src(nbatch), dst(nbatch);
 
         for (auto i = 0UL; i < inputs.size(); ++i) {
             src[i / S].v[i % S] = inputs[i];
         }
-        // pad last batch with safe values
         for (auto i = inputs.size(); i < nbatch * S; ++i) {
             src[i / S].v[i % S] = T{0.5};
         }
-
         for (auto b = 0UL; b < nbatch; ++b) {
             fn(dst[b].v.data(), T{1}, src[b].v.data());
         }
 
-        int max_ulp = 0;
+        UlpResult res{0, T{0}, T{0}, T{0}};
         for (auto i = 0UL; i < inputs.size(); ++i) {
-            auto got = dst[i / S].v[i % S];
+            auto got      = dst[i / S].v[i % S];
             auto expected = static_cast<T>(ref(static_cast<double>(inputs[i])));
-            max_ulp = std::max(max_ulp, UlpDistance(got, expected));
+            if (int d = UlpDistance(got, expected); d > res.max_ulp) {
+                res = {d, inputs[i], got, expected};
+            }
         }
-        return max_ulp;
+        return res;
     }
 
-    auto MakeInputs() -> std::vector<T> {
-        std::vector<T> vals;
-        // dense grid over [-10, 10]
-        constexpr int N = 10000;
-        for (int i = 0; i <= N; ++i) {
-            vals.push_back(T(-10.0 + 20.0 * i / N));
+    // Generate N+1 evenly spaced values in [lo, hi] plus extra edge values.
+    auto Linspace(double lo, double hi, int n, std::vector<T> extra = {}) -> std::vector<T> {
+        std::vector<T> v;
+        v.reserve(static_cast<std::size_t>(n + 1) + extra.size());
+        for (int i = 0; i <= n; ++i) {
+            v.push_back(static_cast<T>(lo + (hi - lo) * i / n));
         }
-        // edge cases
-        for (auto v : {0.0f, -0.0f, 0.0001f, -0.0001f, 0.0003f, -0.0003f,
-                       0.0005f, 7.99f, -7.99f, 8.5f, -8.5f, 100.0f, -100.0f,
-                       std::numeric_limits<T>::infinity(),
-                       -std::numeric_limits<T>::infinity()}) {
-            vals.push_back(v);
-        }
-        return vals;
+        for (auto x : extra) { v.push_back(x); }
+        return v;
     }
+
+    constexpr float kInf = std::numeric_limits<T>::infinity();
+    constexpr int   kN   = 10000;
 } // namespace
 
-TEST_CASE("Backend Tanh ULP accuracy", "[backend][tanh]")
+TEST_CASE("Backend transcendental ULP accuracy", "[backend]")
 {
-    auto inputs = MakeInputs();
-    auto fn = Backend::Tanh<T, S>;
+    struct Case {
+        std::string_view name;
+        void(*fn)(T*, T, T const*);
+        std::vector<T> inputs;
+        double(*ref)(double);
+        int max_ulp;
+    };
 
-    int max_ulp = MaxUlpError(fn, [](double x) { return std::tanh(x); }, inputs);
+    // clang-format off
+    std::array cases {
+        Case{ "Exp",    Backend::Exp<T,S>,
+              Linspace(-87, 88, kN, {0.f, -0.f}),
+              [](double x){ return std::exp(x); },   2 },
 
-    // Eigen's generic_fast_tanh_float claims ~2 ULP; allow up to 4 to be safe.
-    INFO("Max ULP error vs std::tanh: " << max_ulp);
-    CHECK(max_ulp <= 4);
+        Case{ "Log",    Backend::Log<T,S>,
+              Linspace(1e-6, 1e6, kN, {1.f, kInf}),
+              [](double x){ return std::log(x); },   2 },
+
+        Case{ "Log1p",  Backend::Log1p<T,S>,
+              Linspace(-0.999, 1e6, kN, {0.f, kInf}),
+              [](double x){ return std::log1p(x); }, 2 },
+
+        Case{ "Logabs", Backend::Logabs<T,S>,
+              Linspace(-1e6, 1e6, kN, {1.f, -1.f, kInf, -kInf}),
+              [](double x){ return std::log(std::abs(x)); }, 2 },
+
+        Case{ "Sin",    Backend::Sin<T,S>,
+              Linspace(-10, 10, kN, {0.f, -0.f, kInf, -kInf}),
+              [](double x){ return std::sin(x); },   2 },
+
+        Case{ "Cos",    Backend::Cos<T,S>,
+              Linspace(-10, 10, kN, {0.f, kInf, -kInf}),
+              [](double x){ return std::cos(x); },   2 },
+
+        Case{ "Tan",    Backend::Tan<T,S>,
+              // avoid singularities near ±π/2 + nπ
+              Linspace(-1.5, 1.5, kN, {0.f}),
+              [](double x){ return std::tan(x); },   2 },
+
+        Case{ "Asin",   Backend::Asin<T,S>,
+              Linspace(-1, 1, kN, {0.f, 1.f, -1.f}),
+              [](double x){ return std::asin(x); },  2 },
+
+        Case{ "Acos",   Backend::Acos<T,S>,
+              Linspace(-1, 1, kN, {0.f, 1.f, -1.f}),
+              [](double x){ return std::acos(x); },  2 },
+
+        Case{ "Atan",   Backend::Atan<T,S>,
+              Linspace(-100, 100, kN, {0.f, kInf, -kInf}),
+              [](double x){ return std::atan(x); },  2 },
+
+        Case{ "Sinh",   Backend::Sinh<T,S>,
+              Linspace(-10, 10, kN, {0.f, -0.f}),
+              [](double x){ return std::sinh(x); },  2 },
+
+        Case{ "Cosh",   Backend::Cosh<T,S>,
+              Linspace(-10, 10, kN, {0.f}),
+              [](double x){ return std::cosh(x); },  2 },
+
+        Case{ "Tanh",   Backend::Tanh<T,S>,
+              Linspace(-10, 10, kN, {0.f, -0.f, 0.0001f, -0.0001f,
+                                     7.99f, -7.99f, 8.5f, -8.5f, kInf, -kInf}),
+              [](double x){ return std::tanh(x); },  4 },
+
+        Case{ "Sqrt",   Backend::Sqrt<T,S>,
+              Linspace(0, 1e6, kN, {0.f}),
+              [](double x){ return std::sqrt(x); },  2 },
+
+        Case{ "Sqrtabs",Backend::Sqrtabs<T,S>,
+              Linspace(-1e6, 1e6, kN, {0.f}),
+              [](double x){ return std::sqrt(std::abs(x)); }, 2 },
+
+        Case{ "Cbrt",   Backend::Cbrt<T,S>,
+              Linspace(-1e6, 1e6, kN, {0.f, -0.f, kInf, -kInf}),
+              [](double x){ return std::cbrt(x); },  2 },
+    };
+    // clang-format on
+
+    for (auto& [name, fn, inputs, ref, ulp_limit] : cases) {
+        auto [max_ulp, worst, got, expected] = MaxUlpError(fn, ref, inputs);
+        INFO(name << ": max ULP = " << max_ulp << " (limit " << ulp_limit
+             << ") at x=" << worst << " got=" << got << " expected=" << expected);
+        CHECK(max_ulp <= ulp_limit);
+    }
 }
 
 } // namespace Operon::Test

--- a/test/source/performance/primitives.cpp
+++ b/test/source/performance/primitives.cpp
@@ -10,6 +10,9 @@
 #include <new>
 #include <numeric>
 #include <ranges>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "operon/core/dispatch.hpp"
 #include "operon/interpreter/functions.hpp"
@@ -21,28 +24,28 @@ namespace nb = ankerl::nanobench;
 namespace {
     using T = Operon::Scalar;
     constexpr std::size_t S = Dispatch::DefaultBatchSize<T>;
-    constexpr std::size_t NBATCH = 4096;
+    constexpr std::size_t NumBatch = 4096;
 
     struct alignas(32) Buf { std::array<T, S> v; };
 
     using UnaryFn = void(*)(T*, T, T const*);
 
     auto MakeBuffers() {
-        auto src = std::vector<Buf>(NBATCH);
-        auto dst = std::vector<Buf>(NBATCH);
-        for (auto b = 0UL; b < NBATCH; ++b) {
+        auto src = std::vector<Buf>(NumBatch);
+        auto dst = std::vector<Buf>(NumBatch);
+        for (auto b = 0UL; b < NumBatch; ++b) {
             for (auto i = 0UL; i < S; ++i) {
                 // values in (0.1, 1.0] — safe for log/sqrt
-                src[b].v[i] = static_cast<T>(0.1 + 0.9 * static_cast<double>(b * S + i) / static_cast<double>(NBATCH * S));
+                src[b].v[i] = static_cast<T>(0.1 + 0.9 * static_cast<double>(b * S + i) / static_cast<double>(NumBatch * S));
             }
         }
         return std::pair{src, dst};
     }
 
     void BenchFn(nb::Bench& b, std::string const& name, UnaryFn fn, std::vector<Buf>& src, std::vector<Buf>& dst) {
-        b.batch(static_cast<double>(NBATCH * S));
+        b.batch(static_cast<double>(NumBatch * S));
         b.run(name, [&] {
-            for (auto i = 0UL; i < NBATCH; ++i) {
+            for (auto i = 0UL; i < NumBatch; ++i) {
                 fn(dst[i].v.data(), T{1}, src[i].v.data());
             }
         });

--- a/test/source/performance/primitives.cpp
+++ b/test/source/performance/primitives.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
+
+#include <catch2/catch_test_macros.hpp>
+#include <nanobench.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <new>
+#include <numeric>
+#include <ranges>
+
+#include "operon/core/dispatch.hpp"
+#include "operon/interpreter/functions.hpp"
+
+namespace Operon::Test {
+
+namespace nb = ankerl::nanobench;
+
+namespace {
+    using T = Operon::Scalar;
+    constexpr std::size_t S = Dispatch::DefaultBatchSize<T>;
+    constexpr std::size_t NBATCH = 4096;
+
+    struct alignas(32) Buf { std::array<T, S> v; };
+
+    using UnaryFn = void(*)(T*, T, T const*);
+
+    auto MakeBuffers() {
+        auto src = std::vector<Buf>(NBATCH);
+        auto dst = std::vector<Buf>(NBATCH);
+        for (auto b = 0UL; b < NBATCH; ++b) {
+            for (auto i = 0UL; i < S; ++i) {
+                // values in (0.1, 1.0] — safe for log/sqrt
+                src[b].v[i] = static_cast<T>(0.1 + 0.9 * static_cast<double>(b * S + i) / static_cast<double>(NBATCH * S));
+            }
+        }
+        return std::pair{src, dst};
+    }
+
+    void BenchFn(nb::Bench& b, std::string const& name, UnaryFn fn, std::vector<Buf>& src, std::vector<Buf>& dst) {
+        b.batch(static_cast<double>(NBATCH * S));
+        b.run(name, [&] {
+            for (auto i = 0UL; i < NBATCH; ++i) {
+                fn(dst[i].v.data(), T{1}, src[i].v.data());
+            }
+        });
+    }
+} // namespace
+
+TEST_CASE("Primitive throughput", "[performance][primitives]")
+{
+    auto [src, dst] = MakeBuffers();
+
+    nb::Bench b;
+    b.title("Primitive throughput").relative(true).performanceCounters(true).minEpochIterations(100);
+
+    struct Case { const char* name; UnaryFn fn; };
+    std::array cases{
+        Case{ "Exp",   Backend::Exp<T, S>  },
+        Case{ "Log",   Backend::Log<T, S>  },
+        Case{ "Sin",   Backend::Sin<T, S>  },
+        Case{ "Cos",   Backend::Cos<T, S>  },
+        Case{ "Sqrt",  Backend::Sqrt<T, S> },
+        Case{ "Tanh",  Backend::Tanh<T, S> },
+        Case{ "Abs",   Backend::Abs<T, S>  },
+        Case{ "Square",Backend::Square<T,S>},
+    };
+
+    for (auto& [name, fn] : cases) {
+        BenchFn(b, name, fn, src, dst);
+    }
+}
+
+} // namespace Operon::Test

--- a/tools/compare_operon.py
+++ b/tools/compare_operon.py
@@ -97,6 +97,8 @@ REPORT_METRICS = ["r2_tr", "r2_te", "mae_tr", "mae_te", "sort_ms", "wall_s"]
 LOWER_IS_BETTER = {"mae_tr", "mae_te", "nmse_tr", "nmse_te", "sort_ms", "wall_s"}
 
 # ── Run configuration & result ─────────────────────────────────────────────────
+ALL_BINARIES: list[str] = ["operon_gp", "operon_nsgp"]
+
 @dataclass(frozen=True)
 class RunConfig:
     binary:      str            # "operon_gp" or "operon_nsgp"
@@ -106,7 +108,8 @@ class RunConfig:
     symbols:     Optional[str] = None
     objective:   str = "r2"
     generations: int = 5
-    iterations:  int = 1
+    iterations:  int = 0
+    threads:     int = 2
 
     population_size: int = 200
 
@@ -123,7 +126,7 @@ class RunConfig:
             "--iterations",      str(self.iterations),
             "--population-size", str(self.population_size),
             "--pool-size",       str(self.population_size),
-            "--threads",         "2",
+            "--threads",         str(self.threads),
         ]
         if self.symbols:
             a += ["--enable-symbols", self.symbols]
@@ -225,10 +228,11 @@ def test_determinism(ref_bin: Path, new_bin: Path, datadir: Path, args) -> int:
             symbols         = symbols,
             generations     = args.generations,
             iterations      = args.iterations,
+            threads         = args.threads,
             population_size = args.population_size,
         )
         for binary, ds, seed, creator, objective, symbols in itertools.product(
-            ["operon_gp", "operon_nsgp"],
+            args.binaries,
             args.datasets,
             seeds,
             args.creators,
@@ -319,10 +323,11 @@ def test_statistics(ref_bin: Path, new_bin: Path, datadir: Path, args) -> int:
             symbols         = symbols,
             generations     = args.generations,
             iterations      = args.iterations,
+            threads         = args.threads,
             population_size = args.population_size,
         )
         for binary, ds, seed, creator, objective, symbols in itertools.product(
-            ["operon_gp", "operon_nsgp"],
+            args.binaries,
             args.datasets,
             seeds,
             args.creators,
@@ -479,10 +484,15 @@ def main() -> None:
                    help="Disable exact string comparison in determinism tests — "
                         "only verify both runs complete with rc=0 (useful when "
                         "results are statistically equivalent but not numerically identical)")
+    p.add_argument("--binaries", default=",".join(ALL_BINARIES),
+                   help=f"Comma-separated binaries to include "
+                        f"(default: all — {', '.join(ALL_BINARIES)})")
     p.add_argument("--generations",     type=int, default=5,
                    help="GP generations per run (default: 5)")
-    p.add_argument("--iterations",      type=int, default=1,
-                   help="Local optimisation iterations per run (default: 1)")
+    p.add_argument("--iterations",      type=int, default=0,
+                   help="Local optimisation iterations per run (default: 0)")
+    p.add_argument("--threads",         type=int, default=2,
+                   help="Threads per operon process (default: 2)")
     p.add_argument("--population-size", type=int, default=200,
                    help="Population (and pool) size per run (default: 200; "
                         "keep small to limit memory usage)")
@@ -518,6 +528,14 @@ def main() -> None:
     if not args.datasets:
         sys.exit(f"No matching datasets for: {selected_names!r}")
 
+    # Resolve binary list
+    args.binaries = [b.strip() for b in args.binaries.split(",") if b.strip()]
+    unknown = [b for b in args.binaries if b not in ALL_BINARIES]
+    if unknown:
+        sys.exit(f"Unknown binaries: {unknown!r}  (available: {ALL_BINARIES})")
+    if not args.binaries:
+        sys.exit("--binaries must not be empty")
+
     # Resolve creator list
     args.creators = [c.strip() for c in args.creators.split(",") if c.strip()]
     if not args.creators:
@@ -534,7 +552,7 @@ def main() -> None:
 
     # Validate paths
     for d in (ref_bin, new_bin):
-        for b in ("operon_gp", "operon_nsgp"):
+        for b in args.binaries:
             exe = d / b
             if not exe.exists():
                 sys.exit(f"Binary not found: {exe}")
@@ -547,12 +565,15 @@ def main() -> None:
     print(f"  ref : {args.ref}")
     print(f"  new : {args.new}")
     print(f"  data: {datadir}")
+    print(f"  binaries    : {args.binaries}")
     print(f"  datasets    : {[d.name for d in args.datasets]}")
     print(f"  creators    : {args.creators}")
     print(f"  objectives  : {args.objectives}")
     print(f"  exact cmp   : {args.exact}")
     print(f"  sym sets    : {len(SYMBOL_SETS)}")
     print(f"  pop size    : {args.population_size}")
+    print(f"  iterations  : {args.iterations}")
+    print(f"  threads/run : {args.threads}")
     print(f"  jobs/timeout: {args.jobs} / {args.timeout}s")
     ylw = "" if args.no_color else YELLOW
     rst2 = "" if args.no_color else RESET


### PR DESCRIPTION
## Summary

- Adds Eigen as a fourth math backend (`-DMATH_BACKEND=Eigen`), mirroring the functions/derivatives interface of the existing Eve, MadEve, and Stl backends.
- Replaces `eve::tanh` in the Eve backend with the 13/6-degree rational minimax polynomial from Eigen (`generic_fast_tanh_float`, Pedro Gonnet 2014), accurate to ≤4 ULP vs `std::tanh` while avoiding the `expm1` codepath. Benchmarks show ~2.5× throughput improvement for Tanh (0.35 vs 0.89 ns/elem); all other primitives are unchanged.

## Changes

- `include/operon/interpreter/backend/eigen/functions.hpp` — full set of unary/binary primitives using Eigen array ops
- `include/operon/interpreter/backend/eigen/derivatives.hpp` — matching forward/reverse derivatives
- `include/operon/interpreter/backend/eigen.hpp` — top-level backend header
- `include/operon/interpreter/backend/eve/functions.hpp` — replace `eve::tanh` with rational minimax polynomial
- `include/operon/interpreter/functions.hpp` — wire in Eigen backend
- `CMakeLists.txt` — add Eigen backend option

## Tests

- `test/source/implementation/backend.cpp` — ULP correctness for all transcendental/trig primitives (Exp, Log, Log1p, Logabs, Sin, Cos, Tan, Asin, Acos, Atan, Sinh, Cosh, Tanh, Sqrt, Sqrtabs, Cbrt) against `std::` double-precision reference for both Eve and Eigen backends. All pass ≤4 ULP (≤2 ULP for all except Tanh). Inf inputs excluded from Exp/Sqrt/Sqrtabs where Eigen's polynomial implementations do not guarantee handling.
- `test/source/performance/primitives.cpp` — nanobench microbenchmark for all unary primitives

## Test plan

- [ ] `cmake --build build -j$(nproc)` passes with `-DMATH_BACKEND=Eigen`
- [ ] `operon_test "[backend]"` passes
- [ ] Eve backend ULP tests still pass