### PR TITLE
refactor(concepts): move Likelihood to concepts.hpp; split HasFisherMatrix

### DIFF
--- a/include/operon/core/concepts.hpp
+++ b/include/operon/core/concepts.hpp
@@ -82,6 +82,15 @@ concept EvaluatorCallable = requires(T const& t, Operon::RandomGenerator& rng,
     { t(rng, ind, buf) } -> std::same_as<Operon::Vector<Operon::Scalar>>;
 };
 
+// Static struct providing a scalar negative log-likelihood over three value spans.
+// The third span is overloaded: sigma (Gaussian) or weights (Poisson); may be empty.
+template<typename T>
+concept Likelihood = requires(Operon::Span<Operon::Scalar const> x,
+    Operon::Span<Operon::Scalar const> y,
+    Operon::Span<Operon::Scalar const> z) {
+    { T::ComputeLikelihood(x, y, z) } -> std::same_as<Operon::Scalar>;
+};
+
 } // namespace Operon::Concepts
 
 #endif

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -357,6 +357,7 @@ private:
 };
 
 template <typename DTable, Concepts::Likelihood Lik>
+requires Concepts::HasFisherMatrix<Lik>
 class OPERON_EXPORT MinimumDescriptionLengthEvaluator final : public Evaluator<DTable> {
     using Base = Evaluator<DTable>;
 
@@ -477,6 +478,7 @@ private:
 };
 
 template <typename DTable, Concepts::Likelihood Lik>
+requires Concepts::HasFisherMatrix<Lik>
 class OPERON_EXPORT FractionalBayesFactorEvaluator final : public Evaluator<DTable> {
     using Base = Evaluator<DTable>;
 

--- a/include/operon/optimizer/likelihood/likelihood_base.hpp
+++ b/include/operon/optimizer/likelihood/likelihood_base.hpp
@@ -9,22 +9,23 @@
 #include <gsl/pointers>
 #include <vstat/vstat.hpp>
 
+#include "operon/core/concepts.hpp"
 #include "operon/core/types.hpp"
 #include "operon/interpreter/interpreter.hpp"
 
 namespace Operon {
 
 namespace Concepts {
+    // Types satisfying Likelihood that also provide ComputeFisherMatrix.
+    // Used by MDL/FBF evaluators and the Levenberg-Marquardt optimizer.
     template<typename T>
-    concept Likelihood = requires(
+    concept HasFisherMatrix = requires(
         Operon::Span<Operon::Scalar const> x,
         Operon::Span<Operon::Scalar const> y,
         Operon::Span<Operon::Scalar const> z
     ) {
-        { T::ComputeLikelihood(x, y, z) } -> std::same_as<Operon::Scalar>;
-        { T::ComputeFisherMatrix(z, y, z) } -> std::convertible_to<Eigen::template Matrix<Operon::Scalar, -1, -1>>;
+        { T::ComputeFisherMatrix(x, y, z) } -> std::convertible_to<Eigen::Matrix<Operon::Scalar, -1, -1>>;
     };
-
 } // namespace Concepts
 
 template <typename T = Operon::Scalar>
@@ -64,7 +65,7 @@ namespace Concepts {
     // Prevents confusing template errors when a static-only *Likelihood struct
     // is mistakenly passed to LBFGSOptimizer or SGDOptimizer.
     template<typename T>
-    concept OptimizerLoss = Likelihood<T> && std::derived_from<T, LikelihoodBase<typename T::Scalar>>;
+    concept OptimizerLoss = Likelihood<T> && HasFisherMatrix<T> && std::derived_from<T, LikelihoodBase<typename T::Scalar>>;
 } // namespace Concepts
 
 } // namespace Operon


### PR DESCRIPTION
## Summary

- Moves `Concepts::Likelihood` from `likelihood_base.hpp` to `concepts.hpp`, removing the Eigen dependency from the concept itself — code that only needs to check the loss interface no longer transitively pulls in `<Eigen/Core>`
- Splits off `Concepts::HasFisherMatrix` into `likelihood_base.hpp` (where Eigen is already required for `LikelihoodBase`'s matrix types)
- `Concepts::OptimizerLoss` now requires `Likelihood && HasFisherMatrix` — loss types passed to gradient-based optimizers must provide both interfaces
- `MinimumDescriptionLengthEvaluator` and `FractionalBayesFactorEvaluator` gain an explicit `requires HasFisherMatrix<Lik>` constraint, surfacing missing implementations at the template boundary rather than deep in the body
- `LikelihoodEvaluator` (which never calls `ComputeFisherMatrix`) correctly uses the looser `Concepts::Likelihood` constraint unchanged

## Test plan

- [ ] Full build passes with no errors
- [ ] Existing tests pass