### PR TITLE
refactor(selector): remove RankTournamentSelector

### DIFF
--- a/cli/source/operator_factory.cpp
+++ b/cli/source/operator_factory.cpp
@@ -61,15 +61,6 @@ auto ParseSelector(std::string const& str, ComparisonCallback&& comp) -> std::un
     } else if (name == "proportional") {
         selector = std::make_unique<Operon::ProportionalSelector>(std::move(comp));
         dynamic_cast<Operon::ProportionalSelector*>(selector.get())->SetObjIndex(0);
-    } else if (name == "rank") {
-        selector = std::make_unique<Operon::RankTournamentSelector>(std::move(comp));
-        size_t tournamentSize{defaultTournamentSize};
-        if (tok.size() > 1) {
-            auto result = scn::scan<std::size_t>(tok[1], "{}");
-            ENSURE(result);
-            tournamentSize = result->value();
-        }
-        dynamic_cast<Operon::RankTournamentSelector*>(selector.get())->SetTournamentSize(tournamentSize);
     } else if (name == "random") {
         selector = std::make_unique<Operon::RandomSelector>();
     } else {

--- a/include/operon/operators/selector.hpp
+++ b/include/operon/operators/selector.hpp
@@ -68,25 +68,6 @@ private:
     size_t tournamentSize_;
 };
 
-class OPERON_EXPORT RankTournamentSelector : public SelectorBase {
-public:
-    explicit RankTournamentSelector(ComparisonCallback&& cb) : SelectorBase(cb){ } 
-    explicit RankTournamentSelector(ComparisonCallback const& cb) : SelectorBase(cb){ } 
-
-    auto operator()(Operon::RandomGenerator& random) const -> size_t override;
-
-    void Prepare(Operon::Span<Individual const> pop) const override;
-
-    void SetTournamentSize(size_t size) { tournamentSize_ = size; }
-    auto GetTournamentSize() const -> size_t { return tournamentSize_; }
-
-    static constexpr size_t DefaultTournamentSize = 5;
-
-private:
-    size_t tournamentSize_{};
-    mutable std::vector<size_t> indices_;
-};
-
 class OPERON_EXPORT ProportionalSelector : public SelectorBase {
 public:
     explicit ProportionalSelector(ComparisonCallback&& cb) : SelectorBase(cb) { } 

--- a/source/operators/selector/tournament.cpp
+++ b/source/operators/selector/tournament.cpp
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2019-2023 Heal Research
 
-#include <algorithm>
 #include <cstddef>
-#include <numeric>
 #include <random>
-#include <span>
-#include <vector>
 
 #include "operon/operators/selector.hpp"
-#include "operon/core/individual.hpp"
 #include "operon/core/types.hpp"
 
 namespace Operon {
@@ -30,25 +25,4 @@ auto TournamentSelector::operator()(Operon::RandomGenerator& random) const -> si
     return best;
 }
 
-auto RankTournamentSelector::operator()(Operon::RandomGenerator& random) const -> size_t
-{
-    auto population = Population();
-    std::uniform_int_distribution<size_t> uniformInt(0, population.size() - 1);
-    auto best = uniformInt(random);
-    auto tournamentSize = GetTournamentSize();
-
-    for (size_t i = 1; i < tournamentSize; ++i) {
-        auto curr = uniformInt(random);
-        best = std::max(best, curr);
-    }
-    return best;
-}
-
-void RankTournamentSelector::Prepare(const Operon::Span<const Individual> pop) const
-{
-    SelectorBase::Prepare(pop);
-    indices_.resize(pop.size());
-    std::iota(indices_.begin(), indices_.end(), 0);
-    std::sort(indices_.begin(), indices_.end(), [&](auto i, auto j) -> auto { return Compare(pop[i], pop[j]); });
-}
 } // namespace Operon


### PR DESCRIPTION
`RankTournamentSelector` was never reachable from any default CLI configuration — both `operon_nsgp` and `operon_gp` default to `TournamentSelector`. The only way to invoke it was via `--female-selector rank` / `--male-selector rank`, which no existing code path uses. The bug fixed in PR #69 went undetected for exactly this reason.

For a total-order comparator such as `CrowdedComparison`, pre-sorting the population and running tournaments on rank indices gives the same selection pressure as `TournamentSelector`, so there is no algorithmic reason to keep a separate implementation.

Closes #69.