### PR TITLE
feat(nsgp): add Pareto front model selection (MDL, BIC, AIC)

### DIFF
--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -28,6 +28,7 @@
 #include "operon/operators/reinserter.hpp"
 #include "operon/operators/selector.hpp"
 #include "operon/optimizer/likelihood/gaussian_likelihood.hpp"
+#include "operon/optimizer/likelihood/poisson_likelihood.hpp"
 #include "operon/optimizer/optimizer.hpp"
 #include "operon/optimizer/solvers/sgd.hpp"
 
@@ -35,6 +36,74 @@
 #include "pareto_front.hpp"
 #include "reporter.hpp"
 #include "util.hpp"
+
+namespace {
+template<typename Lik, typename DTable>
+auto MdlFrontSelect(DTable const& dtable, Operon::Problem const& problem,
+                    Operon::Span<Operon::Individual const> pop) -> Operon::Individual
+{
+    Operon::MinimumDescriptionLengthEvaluator<DTable, Lik> mdlEval(&problem, &dtable);
+    Operon::RandomGenerator rng(0);
+    std::vector<Operon::Scalar> buf(problem.TrainingRange().Size());
+    auto span = Operon::Span<Operon::Scalar>{buf.data(), buf.size()};
+
+    Operon::Individual const* best{nullptr};
+    auto bestMdl = std::numeric_limits<Operon::Scalar>::max();
+    for (auto const& ind : pop) {
+        if (ind.Rank != 0) { continue; }
+        auto r = mdlEval(rng, ind, span);
+        if (!best || r[0] < bestMdl) { bestMdl = r[0]; best = &ind; }
+    }
+    return best ? *best : pop.front();
+}
+
+template<typename Lik, typename DTable>
+auto PenalizedLikelihoodFrontSelect(DTable const& dtable, Operon::Problem const& problem,
+                                    Operon::Span<Operon::Individual const> pop,
+                                    auto penaltyFn) -> Operon::Individual
+{
+    Operon::RandomGenerator rng(0);
+    auto const nObs = static_cast<double>(problem.TrainingRange().Size());
+    std::vector<Operon::Scalar> buf(nObs);
+
+    Operon::Individual const* best{nullptr};
+    auto bestScore = std::numeric_limits<double>::max();
+    for (auto const& ind : pop) {
+        if (ind.Rank != 0) { continue; }
+
+        auto const& tree = ind.Genotype;
+        auto const params = tree.GetCoefficients();
+        auto const p = static_cast<double>(params.size());
+        auto span = Operon::Span<Operon::Scalar>{buf.data(), buf.size()};
+
+        Operon::Interpreter<Operon::Scalar, DTable> interpreter{&dtable, problem.GetDataset(), &ind.Genotype};
+        interpreter.Evaluate(params, problem.TrainingRange(), span);
+
+        auto estimated = span;
+        auto target = problem.TargetValues(problem.TrainingRange());
+
+        Operon::Scalar profiledSigma{};
+        std::span<Operon::Scalar const> sigmaSpan{};
+        if constexpr (Lik::UsesSigma) {
+            auto ssr = 0.0;
+            for (auto i = 0; i < static_cast<std::ptrdiff_t>(nObs); ++i) {
+                auto const e = static_cast<double>(estimated[i]) - static_cast<double>(target[i]);
+                ssr += e * e;
+            }
+            profiledSigma = std::max(static_cast<Operon::Scalar>(std::sqrt(ssr / nObs)),
+                                     std::numeric_limits<Operon::Scalar>::epsilon());
+            sigmaSpan = std::span<Operon::Scalar const>{&profiledSigma, 1};
+        }
+
+        auto nll = static_cast<double>(Lik::ComputeLikelihood(estimated, target, sigmaSpan));
+        if (!std::isfinite(nll)) { continue; }
+
+        auto score = nll + penaltyFn(p, nObs);
+        if (!best || score < bestScore) { bestScore = score; best = &ind; }
+    }
+    return best ? *best : pop.front();
+}
+} // namespace
 
 auto main(int argc, char** argv) -> int
 {
@@ -278,8 +347,36 @@ auto main(int argc, char** argv) -> int
         if (sorterName == "ms") { sorterPtr = &msSorter; }
         Operon::NSGA2 gp { config, &problem, &treeInitializer, coeffInitializer.get(), generator.get(), reinserter.get(), sorterPtr };
 
+        Operon::ModelSelectorFn modelSelector;
+        auto const modelSelection = result["model-selection"].as<std::string>();
+        if (modelSelection != "obj0") {
+            auto const& lik = result["mdl-likelihood"].as<std::string>();
+            if (lik == "gaussian") {
+                if (modelSelection == "mdl") {
+                    modelSelector = [&](auto pop) { return MdlFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop); };
+                } else if (modelSelection == "bic") {
+                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto p, auto n) { return p * std::log(n); }); };
+                } else if (modelSelection == "aic") {
+                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto, auto) { return 2.0; }); };
+                }
+            } else if (lik == "poisson") {
+                if (modelSelection == "mdl") {
+                    modelSelector = [&](auto pop) { return MdlFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop); };
+                } else if (modelSelection == "bic") {
+                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto p, auto n) { return p * std::log(n); }); };
+                } else if (modelSelection == "aic") {
+                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto, auto) { return 2.0; }); };
+                }
+            } else {
+                throw std::runtime_error(fmt::format("unknown mdl-likelihood: {}", lik));
+            }
+            if (!modelSelector) {
+                throw std::runtime_error(fmt::format("unknown model-selection criterion: {}", modelSelection));
+            }
+        }
+
         auto const* ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(errorEvaluator.get());
-        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr);
+        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector));
         gp.Run(executor, random, [&]() { reporter(executor, gp); });
         auto best = reporter.GetBest();
         fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::digits));

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -38,68 +38,19 @@
 #include "util.hpp"
 
 namespace {
-template<typename Lik, typename DTable>
-auto MdlFrontSelect(DTable const& dtable, Operon::Problem const& problem,
-                    Operon::Span<Operon::Individual const> pop) -> Operon::Individual
+template<typename EvaluatorType>
+auto FrontSelect(EvaluatorType const& eval, Operon::Span<Operon::Individual const> pop) -> Operon::Individual
 {
-    Operon::MinimumDescriptionLengthEvaluator<DTable, Lik> mdlEval(&problem, &dtable);
     Operon::RandomGenerator rng(0);
-    std::vector<Operon::Scalar> buf(problem.TrainingRange().Size());
+    std::vector<Operon::Scalar> buf(eval.GetProblem()->TrainingRange().Size());
     auto span = Operon::Span<Operon::Scalar>{buf.data(), buf.size()};
 
     Operon::Individual const* best{nullptr};
-    auto bestMdl = std::numeric_limits<Operon::Scalar>::max();
+    auto bestVal = std::numeric_limits<Operon::Scalar>::max();
     for (auto const& ind : pop) {
         if (ind.Rank != 0) { continue; }
-        auto r = mdlEval(rng, ind, span);
-        if (!best || r[0] < bestMdl) { bestMdl = r[0]; best = &ind; }
-    }
-    return best ? *best : pop.front();
-}
-
-template<typename Lik, typename DTable>
-auto PenalizedLikelihoodFrontSelect(DTable const& dtable, Operon::Problem const& problem,
-                                    Operon::Span<Operon::Individual const> pop,
-                                    auto penaltyFn) -> Operon::Individual
-{
-    Operon::RandomGenerator rng(0);
-    auto const nObs = static_cast<double>(problem.TrainingRange().Size());
-    std::vector<Operon::Scalar> buf(nObs);
-
-    Operon::Individual const* best{nullptr};
-    auto bestScore = std::numeric_limits<double>::max();
-    for (auto const& ind : pop) {
-        if (ind.Rank != 0) { continue; }
-
-        auto const& tree = ind.Genotype;
-        auto const params = tree.GetCoefficients();
-        auto const p = static_cast<double>(params.size());
-        auto span = Operon::Span<Operon::Scalar>{buf.data(), buf.size()};
-
-        Operon::Interpreter<Operon::Scalar, DTable> interpreter{&dtable, problem.GetDataset(), &ind.Genotype};
-        interpreter.Evaluate(params, problem.TrainingRange(), span);
-
-        auto estimated = span;
-        auto target = problem.TargetValues(problem.TrainingRange());
-
-        Operon::Scalar profiledSigma{};
-        std::span<Operon::Scalar const> sigmaSpan{};
-        if constexpr (Lik::UsesSigma) {
-            auto ssr = 0.0;
-            for (auto i = 0; i < static_cast<std::ptrdiff_t>(nObs); ++i) {
-                auto const e = static_cast<double>(estimated[i]) - static_cast<double>(target[i]);
-                ssr += e * e;
-            }
-            profiledSigma = std::max(static_cast<Operon::Scalar>(std::sqrt(ssr / nObs)),
-                                     std::numeric_limits<Operon::Scalar>::epsilon());
-            sigmaSpan = std::span<Operon::Scalar const>{&profiledSigma, 1};
-        }
-
-        auto nll = static_cast<double>(Lik::ComputeLikelihood(estimated, target, sigmaSpan));
-        if (!std::isfinite(nll)) { continue; }
-
-        auto score = nll + penaltyFn(p, nObs);
-        if (!best || score < bestScore) { bestScore = score; best = &ind; }
+        auto r = eval(rng, ind, span);
+        if (!best || r[0] < bestVal) { bestVal = r[0]; best = &ind; }
     }
     return best ? *best : pop.front();
 }
@@ -350,27 +301,25 @@ auto main(int argc, char** argv) -> int
         Operon::ModelSelectorFn modelSelector;
         auto const modelSelection = result["model-selection"].as<std::string>();
         if (modelSelection != "obj0") {
-            auto const& lik = result["mdl-likelihood"].as<std::string>();
-            if (lik == "gaussian") {
-                if (modelSelection == "mdl") {
-                    modelSelector = [&](auto pop) { return MdlFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop); };
-                } else if (modelSelection == "bic") {
-                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto p, auto n) { return p * std::log(n); }); };
-                } else if (modelSelection == "aic") {
-                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::GaussianLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto, auto) { return 2.0; }); };
+            using DTable = decltype(dtable);
+            if (modelSelection == "mdl") {
+                auto const& lik = result["mdl-likelihood"].as<std::string>();
+                if (lik == "gaussian") {
+                    auto eval = std::make_shared<Operon::MinimumDescriptionLengthEvaluator<DTable, Operon::GaussianLikelihood<Operon::Scalar>>>(&problem, &dtable);
+                    modelSelector = [eval](auto pop) { return FrontSelect(*eval, pop); };
+                } else if (lik == "poisson") {
+                    auto eval = std::make_shared<Operon::MinimumDescriptionLengthEvaluator<DTable, Operon::PoissonLikelihood<Operon::Scalar>>>(&problem, &dtable);
+                    modelSelector = [eval](auto pop) { return FrontSelect(*eval, pop); };
+                } else {
+                    throw std::runtime_error(fmt::format("unknown mdl-likelihood: {}", lik));
                 }
-            } else if (lik == "poisson") {
-                if (modelSelection == "mdl") {
-                    modelSelector = [&](auto pop) { return MdlFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop); };
-                } else if (modelSelection == "bic") {
-                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto p, auto n) { return p * std::log(n); }); };
-                } else if (modelSelection == "aic") {
-                    modelSelector = [&](auto pop) { return PenalizedLikelihoodFrontSelect<Operon::PoissonLikelihood<Operon::Scalar>>(dtable, problem, pop, [](auto, auto) { return 2.0; }); };
-                }
+            } else if (modelSelection == "bic") {
+                auto eval = std::make_shared<Operon::BayesianInformationCriterionEvaluator<DTable>>(&problem, &dtable);
+                modelSelector = [eval](auto pop) { return FrontSelect(*eval, pop); };
+            } else if (modelSelection == "aic") {
+                auto eval = std::make_shared<Operon::AkaikeInformationCriterionEvaluator<DTable>>(&problem, &dtable);
+                modelSelector = [eval](auto pop) { return FrontSelect(*eval, pop); };
             } else {
-                throw std::runtime_error(fmt::format("unknown mdl-likelihood: {}", lik));
-            }
-            if (!modelSelector) {
                 throw std::runtime_error(fmt::format("unknown model-selection criterion: {}", modelSelection));
             }
         }

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -5,21 +5,23 @@
 #include <operon/algorithms/ga_base.hpp>
 #include <operon/algorithms/phase_timer.hpp>
 
+#include <functional>
 #include <string>
 #include <taskflow/taskflow.hpp>
 
 namespace Operon {
 
-
+using ModelSelectorFn = std::function<auto(Span<Individual const>) -> Individual>;
 
 template<typename Evaluator>
 class Reporter {
     gsl::not_null<Evaluator const*> evaluator_;
     mutable Operon::Individual best_;
+    ModelSelectorFn selector_;
 
 public:
-    explicit Reporter(gsl::not_null<Evaluator const*> evaluator)
-        : evaluator_(evaluator) {}
+    explicit Reporter(gsl::not_null<Evaluator const*> evaluator, ModelSelectorFn selector = nullptr)
+        : evaluator_(evaluator), selector_(std::move(selector)) {}
 
     static auto PrintStats(std::vector<std::tuple<std::string, double, std::string>> const& stats, bool printHeader) -> void {
         std::vector<size_t> widths;
@@ -57,7 +59,7 @@ public:
             return *minElem;
         };
 
-        best_ = getBest(pop);
+        best_ = selector_ ? selector_(pop) : getBest(pop);
         ENSURE(best_.Size() > 0);
 
         tf::Taskflow tf;

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -11,7 +11,7 @@
 
 namespace Operon {
 
-using ModelSelectorFn = std::function<auto(Span<Individual const>) -> Individual>;
+using ModelSelectorFn = std::function<Individual(Span<Individual const>)>;
 
 template<typename Evaluator>
 class Reporter {

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -179,6 +179,8 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("timelimit", "Time limit after which the algorithm will terminate", cxxopts::value<size_t>()->default_value(std::to_string(std::numeric_limits<size_t>::max())))
         ("transposition-cache", "Cache fitness values keyed by Zobrist hash of tree structure; most effective with coefficient optimization enabled", cxxopts::value<bool>()->default_value("false"))
         ("pareto-front", "Write rank-0 Pareto front to this JSON file after the run (only effective with Pareto-based algorithms, e.g. operon_nsgp)", cxxopts::value<std::string>())
+        ("model-selection", "Pareto front model selection: obj0 (lowest first objective), mdl, bic, aic", cxxopts::value<std::string>()->default_value("obj0"))
+        ("mdl-likelihood", "Likelihood for MDL/BIC/AIC model selection: gaussian or poisson", cxxopts::value<std::string>()->default_value("gaussian"))
         ("debug", "Debug mode (more information displayed)")
         ("help", "Print help")
         ("version", "Print version and program information");


### PR DESCRIPTION
## Summary

Adds configurable model selection from the Pareto front in `operon_nsgp`. The reporter can now select the "best" individual using information-theoretic criteria instead of just the lowest first-objective value.

## New CLI options

- `--model-selection` (`obj0`, `mdl`, `bic`, `aic`, default: `obj0`)
- `--mdl-likelihood` (`gaussian`, `poisson`, default: `gaussian`)

## Criteria

| Criterion | Formula | Description |
|---|---|---|
| `obj0` | min(ind[0]) | Lowest first objective (existing default, no behavior change) |
| `mdl` | cComplexity + cParameters + cLikelihood | Full MDL codelength (reuses `MinimumDescriptionLengthEvaluator`) |
| `bic` | NLL + k·log(n) | Bayesian Information Criterion |
| `aic` | NLL + 2·k | Akaike Information Criterion |

## Changes

- `cli/source/reporter.hpp`: Add `ModelSelectorFn` callback; falls back to `obj0` when unset
- `cli/source/util.cpp`: Add `--model-selection` and `--mdl-likelihood` options
- `cli/source/operon_nsgp.cpp`: Add `MdlFrontSelect` and `PenalizedLikelihoodFrontSelect` helpers; wire up selection criterion

## Impact

No behavior change with default `--model-selection obj0`. The `mdl`/`bic`/`aic` options select simpler, better-generalizing models from the Pareto front by penalizing complexity.

Extracted from `feature/nsgp-sms` (which includes additional algorithm changes). This PR contains only the model selection feature to keep the scope minimal.