### PR TITLE
perf(interpreter): skip redundant BindTree when range is unchanged

### DIFF
--- a/include/operon/core/range.hpp
+++ b/include/operon/core/range.hpp
@@ -41,7 +41,7 @@ class Range {
             EXPECT(start <= end);
             return { start, end };
         }
-        std::pair<std::size_t, std::size_t> range_;
+        std::pair<std::size_t, std::size_t> range_{};
 };
 } // namespace Operon
 

--- a/include/operon/core/range.hpp
+++ b/include/operon/core/range.hpp
@@ -26,6 +26,8 @@ class Range {
         {
         }
 
+        [[nodiscard]] auto operator==(Range const& other) const noexcept -> bool { return range_ == other.range_; }
+
         auto operator=(std::pair<std::size_t, std::size_t> p) -> Range&
         {
             auto [start, end] = p;

--- a/include/operon/interpreter/interpreter.hpp
+++ b/include/operon/interpreter/interpreter.hpp
@@ -286,8 +286,9 @@ private:
         auto const& dt = dtable_.get();
         for (int64_t i = 0; i < nNodes; ++i) {
             auto const& n = nodes[i];
-            auto const* ptr     = n.IsVariable() ? dataset_->GetValues(n.HashValue).subspan(range.Start(), range.Size()).data() : nullptr;
-            auto variableValues = std::tuple_element_t<1, Data>(ptr, nRows);
+            auto variableValues = n.IsVariable()
+                ? std::tuple_element_t<1, Data>(dataset_->GetValues(n.HashValue).subspan(range.Start(), range.Size()).data(), nRows)
+                : std::tuple_element_t<1, Data>{};
             auto nodeFunction   = dt->template TryGetFunction<T>(n.HashValue);
             auto nodeDerivative = dt->template TryGetDerivative<T>(n.HashValue);
 
@@ -319,7 +320,7 @@ private:
     }
 
     auto InitContext(Operon::Span<T const> coeff, Operon::Range range) const {
-        if (range_.Start() != range.Start() || range_.End() != range.End()) { BindTree(range); }
+        if (context_.empty() || range_ != range) { BindTree(range); }
         UpdateCoefficients(coeff);
     }
 };


### PR DESCRIPTION
## Summary

- Splits `InitContext` into two paths: `BindTree` (full init — allocates `primal_`, rebuilds `context_` with function/derivative pointers and variable data spans) and `UpdateCoefficients` (cheap — patches coefficient values and re-fills constant columns).
- `InitContext` now calls `BindTree` only when `range` differs from the cached `range_`; `UpdateCoefficients` runs unconditionally.
- Adds `mutable Operon::Range range_{}` member to track the last bound range.
- Adds `Range::operator==` so ranges can be compared without spelling out `Start()`/`End()` individually.
- Guards `InitContext` on `context_.empty()` so the first call always triggers `BindTree`, preventing UB from uninitialized `context_`/`primal_`.
- Constructs `variableValues` as an empty span for non-variable nodes to avoid UB from null-pointer `std::span` construction.
- Value-initializes `range_` in the default constructor to make default-constructed `Range` safe to compare and inspect.

The hot path is the LM optimizer inner loop: the `Interpreter` is constructed once per tree, then `JacRev` / `Evaluate` are called repeatedly with the same range but updated coefficients. Previously `InitContext` re-allocated `primal_` and did all dispatch-table lookups on every call. Now only `UpdateCoefficients` runs on optimizer steps, which is O(nNodes) with no allocation.

## Test plan

- [ ] All interpreter/optimizer tests pass (`operon_test "[interpreter]" "[optimizer]"`)
- [ ] `compare_operon` quality equivalence check passes (6/6 groups)