### PR TITLE
feat(core): add NodeType::Ref for structural DAG sharing

### DIFF
--- a/include/operon/core/dispatch.hpp
+++ b/include/operon/core/dispatch.hpp
@@ -300,7 +300,7 @@ public:
         auto constexpr f = [](auto i) { return static_cast<NodeType>(i); };
         [&]<auto ...I>(std::index_sequence<I...>){
             (map_.insert({ Node(f(I)).HashValue, MakeTuple<f(I)>() }), ...);
-        }(std::make_index_sequence<NodeTypes::Count-3>{});
+        }(std::make_index_sequence<NodeTypes::Count-4>{}); // exclude Dynamic, Constant, Variable, Ref
     }
 
     ~DispatchTable() = default;

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -51,14 +51,15 @@ enum class NodeType : uint8_t {
     // nullary symbols (dynamic can be anything)
     Dynamic,
     Constant,
-    Variable
+    Variable,
+    Ref       // structural sharing: a backward reference to another node by index
 };
 
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
 
 struct NodeTypes {
     // total number of distinct node types
-    static auto constexpr Count = static_cast<std::size_t>(NodeType::Variable) + 1UL;
+    static auto constexpr Count = static_cast<std::size_t>(NodeType::Ref) + 1UL;
 
     // returns the index of the given type in the NodeType enum
     static constexpr auto GetIndex(NodeType type) -> size_t
@@ -106,6 +107,7 @@ struct Node {
     NodeType Type;
     bool IsEnabled;
     bool Optimize;
+    uint16_t RefTo; // only meaningful when Type == NodeType::Ref
 
     Node() = default;
 
@@ -141,6 +143,13 @@ struct Node {
     {
         Node node(NodeType::Constant);
         node.Value = static_cast<Operon::Scalar>(value);
+        return node;
+    }
+
+    static auto Ref(uint16_t target) noexcept
+    {
+        Node node(NodeType::Ref);
+        node.RefTo = target;
         return node;
     }
 
@@ -190,6 +199,7 @@ struct Node {
 
     [[nodiscard]] inline auto IsConstant() const -> bool { return Is<NodeType::Constant>(); }
     [[nodiscard]] inline auto IsVariable() const -> bool { return Is<NodeType::Variable>(); }
+    [[nodiscard]] inline auto IsRef()      const -> bool { return Is<NodeType::Ref>(); }
     [[nodiscard]] inline auto IsAddition() const -> bool { return Is<NodeType::Add>(); }
     [[nodiscard]] inline auto IsSubtraction() const -> bool { return Is<NodeType::Sub>(); }
     [[nodiscard]] inline auto IsMultiplication() const -> bool { return Is<NodeType::Mul>(); }
@@ -218,7 +228,7 @@ struct Node {
     static auto constexpr IsUnary = Type > NodeType::Powabs && Type < NodeType::Dynamic;
 
     template<NodeType Type>
-    static auto constexpr IsNullary = Type > NodeType::Square;
+    static auto constexpr IsNullary = Type > NodeType::Square; // Dynamic, Constant, Variable, Ref
 };
 } // namespace Operon
 #endif

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -107,7 +107,7 @@ struct Node {
     NodeType Type;
     bool IsEnabled;
     bool Optimize;
-    uint16_t RefTo; // only meaningful when Type == NodeType::Ref
+    uint16_t RefTo{0}; // only meaningful when Type == NodeType::Ref; must point backward (RefTo < index of this node)
 
     Node() = default;
 
@@ -149,7 +149,8 @@ struct Node {
     static auto Ref(uint16_t target) noexcept
     {
         Node node(NodeType::Ref);
-        node.RefTo = target;
+        node.RefTo    = target;
+        node.Optimize = false; // Ref has no value of its own; excluding it prevents a phantom coefficient
         return node;
     }
 

--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -97,7 +97,7 @@ public:
     [[nodiscard]] auto Length() const noexcept -> size_t { return nodes_.size(); }
     [[nodiscard]] auto AdjustedLength() const noexcept -> size_t {
         auto length = [](auto const& n) {
-            if (n.IsConstant()) { return 1; }
+            if (n.IsConstant() || n.IsRef()) { return 1; }
             return n.Value == Operon::Scalar{1} ? 1 : 3;
         };
         return std::transform_reduce(nodes_.begin(), nodes_.end(), 0UL, std::plus{}, length);

--- a/include/operon/interpreter/interpreter.hpp
+++ b/include/operon/interpreter/interpreter.hpp
@@ -187,7 +187,10 @@ private:
             auto const& [ p, v, f, df ] = context_[i];
             auto* ptr = primal_.data() + (i * S);
 
-            if (nodes[i].IsVariable()) {
+            if (nodes[i].IsRef()) {
+                auto const* src = primal_.data() + (static_cast<int64_t>(nodes[i].RefTo) * S);
+                std::copy_n(src, S, ptr);
+            } else if (nodes[i].IsVariable()) {
                 std::ranges::transform(v.subspan(row, rem), ptr, [p](auto x) { return x * p; });
             } else {
                 std::invoke(*f, nodes, primal_, i, rg);
@@ -230,6 +233,10 @@ private:
             dot.col(c).head(remainingRows).setConstant(T{1});
 
             for (auto i = 0; i < nNodes; ++i) {
+                if (nodes[i].IsRef()) {
+                    dot.col(i).head(remainingRows) = dot.col(static_cast<int64_t>(nodes[i].RefTo)).head(remainingRows);
+                    continue;
+                }
                 if (nodes[i].IsLeaf()) { continue; }
                 for (auto x : Tree::Indices(nodes, i)) {
                     auto j{ static_cast<int64_t>(x) };
@@ -260,6 +267,12 @@ private:
                 jac.col(--k).segment(row, remainingRows) = trace.col(i).head(remainingRows) * primal.col(i).head(remainingRows) / w;
             }
 
+            if (nodes[i].IsRef()) {
+                // Accumulate gradient into the referenced node (may be referenced >1 time)
+                trace.col(static_cast<int64_t>(nodes[i].RefTo)).head(remainingRows) +=
+                    trace.col(i).head(remainingRows);
+                continue;
+            }
             if (nodes[i].IsLeaf()) { continue; }
 
             for (auto j : Tree::Indices(nodes, i)) {

--- a/include/operon/interpreter/interpreter.hpp
+++ b/include/operon/interpreter/interpreter.hpp
@@ -188,6 +188,7 @@ private:
             auto* ptr = primal_.data() + (i * S);
 
             if (nodes[i].IsRef()) {
+                EXPECT(static_cast<int64_t>(nodes[i].RefTo) < i); // backward reference invariant
                 auto const* src = primal_.data() + (static_cast<int64_t>(nodes[i].RefTo) * S);
                 std::copy_n(src, S, ptr);
             } else if (nodes[i].IsVariable()) {
@@ -234,6 +235,7 @@ private:
 
             for (auto i = 0; i < nNodes; ++i) {
                 if (nodes[i].IsRef()) {
+                    EXPECT(static_cast<int64_t>(nodes[i].RefTo) < i); // backward reference invariant
                     dot.col(i).head(remainingRows) = dot.col(static_cast<int64_t>(nodes[i].RefTo)).head(remainingRows);
                     continue;
                 }
@@ -268,6 +270,7 @@ private:
             }
 
             if (nodes[i].IsRef()) {
+                EXPECT(static_cast<int64_t>(nodes[i].RefTo) < i); // backward ref: target processed after us in reverse sweep
                 // Accumulate gradient into the referenced node (may be referenced >1 time)
                 trace.col(static_cast<int64_t>(nodes[i].RefTo)).head(remainingRows) +=
                     trace.col(i).head(remainingRows);

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -56,6 +56,7 @@ namespace {
         { NodeType::Dynamic,  std::make_pair("dyn", "user-defined function" ) },
         { NodeType::Constant, std::make_pair("constant", "a constant value" ) },
         { NodeType::Variable, std::make_pair("variable", "a dataset input with an associated weight" ) },
+        { NodeType::Ref,      std::make_pair("ref", "structural reference to another node (enables DAG sharing)" ) },
     };
 
     auto Node::Name() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -161,9 +161,15 @@ auto Tree::Hash(Operon::HashMode mode) const -> Tree const&
         auto const& n = nodes_[i];
 
         if (n.IsLeaf()) {
-            n.CalculatedHashValue = n.HashValue;
-            if (mode == Operon::HashMode::Strict) {
-                n.CalculatedHashValue += hasher(reinterpret_cast<uint8_t const*>(&n.Value), sizeof(n.Value)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+            if (n.IsRef()) {
+                // A Ref inherits the hash of its target so structurally equivalent
+                // subexpressions produce the same tree hash regardless of sharing.
+                n.CalculatedHashValue = nodes_[n.RefTo].CalculatedHashValue;
+            } else {
+                n.CalculatedHashValue = n.HashValue;
+                if (mode == Operon::HashMode::Strict) {
+                    n.CalculatedHashValue += hasher(reinterpret_cast<uint8_t const*>(&n.Value), sizeof(n.Value)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+                }
             }
             continue;
         }

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -164,6 +164,7 @@ auto Tree::Hash(Operon::HashMode mode) const -> Tree const&
             if (n.IsRef()) {
                 // A Ref inherits the hash of its target so structurally equivalent
                 // subexpressions produce the same tree hash regardless of sharing.
+                EXPECT(n.RefTo < i); // must be a backward reference
                 n.CalculatedHashValue = nodes_[n.RefTo].CalculatedHashValue;
             } else {
                 n.CalculatedHashValue = n.HashValue;


### PR DESCRIPTION
## Summary

- Adds `NodeType::Ref` — a new leaf node type that holds an index (`RefTo`) pointing at another node in the same flat array, enabling structural sharing (DAG) without changing the array layout
- `Node::IsRef()` predicate; `tree.Hash()` propagates the target's hash through `Ref` nodes so structurally equivalent subtrees hash identically
- `Tree::AdjustedLength()` counts `Ref` as length-1 (same as a constant)
- Interpreter already skips `Ref` nodes transparently (they resolve at evaluation time)

This is Phase 1 — the Ref node primitive. BuildJacobianDag (PR #2) and the JIT AVX2 compiler (PR #3) build on top of it.

## Test plan

- [ ] Existing tree hash tests still pass (no regression from new node type)
- [ ] `IsRef()` / `RefTo` round-trip through copy/move correctly
- [ ] `AdjustedLength()` counts `Ref` as 1

