### PR TITLE
feat(hash): consolidate cache primitives into zobrist.hpp

### DIFF
--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -7,12 +7,63 @@
 #include <atomic>
 #include <memory>
 
+#include <gtl/phmap.hpp>
+
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
 #include "operon/operon_export.hpp"
 
 namespace Operon {
+
+// ── Cache primitives ─────────────────────────────────────────────────────────
+
+// Variadic mixin: assembles a cache entry from multiple data components.
+// Example:  using FitnessEntry = CacheEntry<FitnessData>;
+//           using JitEntry     = CacheEntry<VisitData, MetaData>;
+template<typename... Data>
+struct CacheEntry : Data... {};
+
+// Fitness value produced by the evaluator after local search.
+struct FitnessData {
+    Vector<Scalar>  Value;
+    std::size_t     Visits{1};
+};
+
+using FitnessEntry = CacheEntry<FitnessData>;
+
+// Thread-safe cache keyed by Operon::Hash, backed by gtl::parallel_flat_hash_map_m.
+template<typename Entry>
+class ZobristCache {
+    gtl::parallel_flat_hash_map_m<Hash, Entry> map_;
+
+public:
+    template<typename Fn>
+    auto IfContains(Hash h, Fn&& fn) const -> bool {
+        bool found = false;
+        map_.if_contains(h, [&](auto const& kv) { std::forward<Fn>(fn)(kv.second); found = true; });
+        return found;
+    }
+
+    template<typename Fn>
+    auto ModifyIf(Hash h, Fn&& fn) -> bool {
+        return map_.modify_if(h, [&](auto& kv) { std::forward<Fn>(fn)(kv.second); });
+    }
+
+    template<typename OnExisting, typename OnNew>
+    auto LazyEmplace(Hash h, OnExisting&& onExisting, OnNew&& onNew) -> void {
+        map_.lazy_emplace_l(
+            h,
+            [&](auto& kv)         { std::forward<OnExisting>(onExisting)(kv.second); },
+            [&](auto const& ctor) { Entry e{}; std::forward<OnNew>(onNew)(e); ctor(h, std::move(e)); }
+        );
+    }
+
+    [[nodiscard]] auto Size() const -> std::size_t { return map_.size(); }
+    auto Clear() -> void { map_.clear(); }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 // Position-aware Zobrist hash for GP trees, plus a transposition table that
 // caches fitness vectors keyed by structural hash.  The hash captures tree
@@ -23,13 +74,16 @@ namespace Operon {
 // Ownership: the caller constructs one Zobrist per experiment (or per run) and
 // passes a raw pointer into GeneticAlgorithmConfig::Cache.  The algorithm
 // borrows the pointer; the caller is responsible for lifetime.
+//
+// Subclassing: JitZobrist (in jit_evaluator.hpp) is the only intended subclass.
+// The virtual destructor exists to support nanobind exposure of both types.
 class OPERON_EXPORT Zobrist {
-    using Value = Operon::Vector<Operon::Scalar>;
+    using Value   = Vector<Scalar>;
     using Extents = std::extents<int, std::dynamic_extent, std::dynamic_extent>;
-    using Table   = Operon::MDArray<Operon::Hash, Extents>;
+    using Table   = MDArray<Hash, Extents>;
 
     Table table_;
-    Operon::Map<Operon::Hash, int> varIndex_;
+    Map<Hash, int> varIndex_;
 
     struct TranspositionTable;
     std::unique_ptr<TranspositionTable> tt_;
@@ -40,8 +94,8 @@ public:
     // variableHashes must include every variable hash that can appear in a tree.
     // Each variable gets its own row of independent random values so that
     // permuting variables at different positions always yields a different hash.
-    Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes);
-    ~Zobrist();
+    Zobrist(RandomGenerator& rng, int maxLength, Span<Hash const> variableHashes);
+    virtual ~Zobrist();
     Zobrist(Zobrist const&)            = delete;
     Zobrist(Zobrist&&)                 = delete;
     auto operator=(Zobrist const&)     -> Zobrist& = delete;
@@ -50,7 +104,7 @@ public:
     [[nodiscard]] auto Rows() const { return table_.extent(0); }
     [[nodiscard]] auto Cols() const { return table_.extent(1); }
 
-    [[nodiscard]] auto ComputeHash(Operon::Node const& n, int pos) const -> Operon::Hash
+    [[nodiscard]] auto ComputeHash(Node const& n, int pos) const -> Hash
     {
         if (n.IsVariable()) {
             auto const it = varIndex_.find(n.HashValue);
@@ -61,10 +115,10 @@ public:
         return table_(NodeTypes::GetIndex(n.Type), pos);
     }
 
-    [[nodiscard]] auto ComputeHash(Operon::Tree const& tree) const -> Operon::Hash
+    [[nodiscard]] auto ComputeHash(Tree const& tree) const -> Hash
     {
         EXPECT(std::ssize(tree.Nodes()) <= Cols());
-        Operon::Hash h{};
+        Hash h{};
         auto const& nodes = tree.Nodes();
         for (auto i = 0; i < std::ssize(nodes); ++i) {
             h ^= ComputeHash(nodes[i], i);
@@ -73,10 +127,10 @@ public:
     }
 
     // Returns true and fills `val` if the hash is found; thread-safe.
-    [[nodiscard]] auto TryGet(Operon::Hash hash, Value& val) const -> bool;
+    [[nodiscard]] auto TryGet(Hash hash, Value& val) const -> bool;
 
     // Inserts or increments the visit counter; thread-safe.
-    auto Insert(Operon::Hash hash, Value const& val) -> void;
+    auto Insert(Hash hash, Value const& val) -> void;
 
     // Clears the transposition table and resets the hit counter.
     // NOT safe to call concurrently with TryGet or Insert — call only after
@@ -86,7 +140,6 @@ public:
     [[nodiscard]] auto Hits() const -> std::size_t { return hits_.load(); }
     [[nodiscard]] auto Size() const -> std::size_t;
 };
-
 
 } // namespace Operon
 

--- a/include/operon/interpreter/backend/jit/jit_evaluator.hpp
+++ b/include/operon/interpreter/backend/jit/jit_evaluator.hpp
@@ -15,23 +15,49 @@
 
 namespace Operon::JIT {
 
+// ---- JIT-specific cache entry components -----------------------------------
+
+// Per-hash visit counter used by the frequency gate (compile only after N visits).
+struct VisitData { std::size_t Visits{0}; };
+
+// Holds the compiled fn + jacFn for one structural hash.
+struct MetaData { std::unique_ptr<CompileMeta> meta; };
+
+using JitEntry = Operon::CacheEntry<VisitData, MetaData>;
+
+// Extends Zobrist with a compiled-function cache (JitEntry map) and a pool
+// of JitRuntimes whose code pages back all cached CompileMeta objects.
+//
+// Declaration order is load-bearing: pool_ is declared BEFORE cache_ so that
+// it is destroyed AFTER cache_ (C++ destroys members in reverse order).
+// This guarantees CompileMeta::~CompileMeta() can safely call rt->release()
+// during cache teardown.
+class OPERON_EXPORT JitZobrist final : public Operon::Zobrist {
+    JIT::JitRuntimePool pool_;                          // destroyed last
+    mutable Operon::ZobristCache<JitEntry> cache_;     // destroyed first
+public:
+    JitZobrist(Operon::RandomGenerator& rng, int maxLength,
+               Operon::Span<Operon::Hash const> variableHashes);
+    ~JitZobrist() override = default;
+
+    [[nodiscard]] auto JitCache() const -> Operon::ZobristCache<JitEntry>& { return cache_; }
+    [[nodiscard]] auto Pool()     const noexcept -> JIT::JitRuntimePool const& { return pool_; }
+};
+
 // Evaluator that replaces the interpreter forward pass with a JIT-compiled
 // function, keyed by Zobrist structural hash.  Structurally identical trees
-// share the same compiled function; only the coefficient array (consts[]) and
-// column pointers differ per call.
+// share the same compiled function; only the coefficient array and column
+// pointers differ per call.  Column pointers are rebuilt from the tree at
+// call time (VarOrder) — no per-entry varOrder storage needed.
 //
-// Compilation is lazy: first call for a new structure compiles and inserts;
-// subsequent calls with the same structural hash are O(1) map lookups.
 // Thread-safe: uses gtl::parallel_flat_hash_map_m internally.
-//
-// AVX2 is attempted first; falls back to the scalar Phase-1 path on machines
-// without AVX2.
+// AVX2 is attempted first; falls back to the scalar path on older CPUs.
 class OPERON_EXPORT JitEvaluator final : public EvaluatorBase {
 public:
-    JitEvaluator(gsl::not_null<Problem const*> problem,
-                 gsl::not_null<Zobrist const*>  zobrist,
-                 ErrorMetric                    error         = MSE{},
-                 bool                           linearScaling = true);
+    JitEvaluator(gsl::not_null<Problem const*>    problem,
+                 gsl::not_null<JitZobrist const*> zobrist,
+                 ErrorMetric                      error         = MSE{},
+                 bool                             linearScaling = true);
 
     ~JitEvaluator() override;
 
@@ -43,37 +69,48 @@ public:
     auto operator()(RandomGenerator& rng, Individual const& ind, Span<Scalar> buf) const -> ReturnType override;
     auto operator()(RandomGenerator& rng, Individual const& ind)                  const -> ReturnType override;
 
-    [[nodiscard]] auto CacheSize() const -> std::size_t;
-    [[nodiscard]] auto CacheHits() const -> std::size_t { return hits_.load(); }
+    [[nodiscard]] auto CacheSize()   const -> std::size_t;
+    [[nodiscard]] auto CacheHits()   const -> std::size_t { return hits_.load(); }
+    [[nodiscard]] auto CacheMisses() const -> std::size_t { return misses_.load(); }
 
+    void ResetCounters(); // not thread-safe; call only when no evaluations are in flight
     void ClearCache();
 
-    // Returns the compiled forward function for `tree` (compiling on first call).
-    // Public so that JitLevenbergMarquardtOptimizer can share the same cache.
-    [[nodiscard]] auto GetOrCompile(Tree const& tree) const -> std::shared_ptr<CompiledTree>;
+    void SetMaxLength(int maxLength) { maxLength_ = maxLength; }
+    [[nodiscard]] auto MaxLength() const -> int { return maxLength_; }
 
-    // Returns the compiled Jacobian function for `tree` (compiling on first call).
-    // Keyed by the same structural hash as GetOrCompile. Thread-safe.
-    [[nodiscard]] auto GetOrCompileJacobian(Tree const& tree) const -> std::shared_ptr<CompiledJacobian>;
+    void SetMinVisits(std::size_t minVisits) { minVisits_ = minVisits; }
+    [[nodiscard]] auto MinVisits() const -> std::size_t { return minVisits_; }
+
+    // Returns a CompileMeta with fn set (compiling on first call past the frequency gate).
+    // Returns nullptr if the tree is above maxLength_, below minVisits_, or compilation fails.
+    // Valid for the lifetime of JitZobrist.
+    [[nodiscard]] auto GetOrCompile(Tree const& tree) const -> CompileMeta const*;
+
+    // Compiles the Jacobian and stores it in the existing cache entry (or creates one).
+    // Does NOT guarantee that fn is set — call GetOrCompile separately if the forward pass
+    // is also needed.  Returns nullptr only if CompileJacobian fails (e.g. non-AVX2 CPU).
+    [[nodiscard]] auto GetOrCompileJacobian(Tree const& tree) const -> CompileMeta const*;
+
+    [[nodiscard]] auto Avx2Fails()    const -> std::size_t { return avx2Fails_.load(); }
+    [[nodiscard]] auto CompileFails() const -> std::size_t { return compileFails_.load(); }
 
 private:
-    [[nodiscard]] auto GetOrCompile(Tree const& tree, Hash hash) const -> std::shared_ptr<CompiledTree>;
+    [[nodiscard]] auto GetOrCompile(Tree const& tree, Hash hash) const -> CompileMeta const*;
 
-    gsl::not_null<Zobrist const*> zobrist_;
-    ErrorMetric                   error_;
-    bool                          scaling_;
+    gsl::not_null<JitZobrist const*> zobrist_;
+    ErrorMetric                      error_;
+    bool                             scaling_;
 
     mutable TreeCompiler compiler_;
 
-    struct CacheImpl;
-    mutable std::unique_ptr<CacheImpl> cache_;
-    mutable std::atomic<std::size_t> hits_{0};
-    mutable std::atomic<std::size_t> avx2Fails_{0};    // AVX2 compile failed, scalar used
-    mutable std::atomic<std::size_t> compileFails_{0}; // both paths failed, ErrMax used
+    int         maxLength_{0};
+    std::size_t minVisits_{1};
 
-public:
-    [[nodiscard]] auto Avx2Fails()    const -> std::size_t { return avx2Fails_.load(); }
-    [[nodiscard]] auto CompileFails() const -> std::size_t { return compileFails_.load(); }
+    mutable std::atomic<std::size_t> hits_{0};
+    mutable std::atomic<std::size_t> misses_{0};
+    mutable std::atomic<std::size_t> avx2Fails_{0};
+    mutable std::atomic<std::size_t> compileFails_{0};
 };
 
 } // namespace Operon::JIT

--- a/include/operon/optimizer/jit_lm_cost_function.hpp
+++ b/include/operon/optimizer/jit_lm_cost_function.hpp
@@ -20,8 +20,8 @@ namespace Operon {
 // functions.  Residuals use the compiled forward pass; Jacobian uses the compiled
 // derivative DAG (EvalJacFn) when available, falling back to interpreter JacRev.
 //
-// colPtrs[i] must point to the dataset column for compiled->varOrder[i],
-// jacColPtrs[i] for compiledJac->varOrder[i], each already offset to range.Start().
+// colPtrs[i] and jacColPtrs[i] must follow the ordering returned by VarOrder(tree),
+// each already offset to range.Start().
 template<typename T = Operon::Scalar, int StorageOrder = Eigen::ColMajor>
 struct JitLMCostFunction {
     static auto constexpr Storage{ StorageOrder };
@@ -85,8 +85,14 @@ struct JitLMCostFunction {
 
         if (residuals != nullptr) {
             ++residualCallCount_;
-            fn_(scratchResiduals_.data(), colPtrs_.data(), nRowsPad, parameters);
-            std::copy_n(scratchResiduals_.data(), numResiduals_, residuals);
+            Operon::Span<Operon::Scalar> res{residuals, numResiduals_};
+            if (fn_ != nullptr) {
+                fn_(scratchResiduals_.data(), colPtrs_.data(), nRowsPad, parameters);
+                std::copy_n(scratchResiduals_.data(), numResiduals_, residuals);
+            } else {
+                Operon::Span<Operon::Scalar const> params{parameters, numParameters_};
+                interpreter_->Evaluate(params, range_, res);
+            }
             Eigen::Map<Eigen::Array<Operon::Scalar, -1, 1>> x(residuals, static_cast<Eigen::Index>(numResiduals_));
             Eigen::Map<Eigen::Array<Operon::Scalar, -1, 1> const> y(target_.data(), static_cast<Eigen::Index>(numResiduals_));
             x -= y;

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -4,12 +4,11 @@
 #include "operon/hash/zobrist.hpp"
 
 #include <algorithm>
-#include <gtl/phmap.hpp>
 
 namespace Operon {
 
 struct Zobrist::TranspositionTable {
-    gtl::parallel_flat_hash_map_m<Operon::Hash, std::pair<Zobrist::Value, std::size_t>> Map;
+    ZobristCache<FitnessEntry> Cache;
 };
 
 Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes)
@@ -26,33 +25,28 @@ Zobrist::~Zobrist() = default;
 
 auto Zobrist::TryGet(Operon::Hash hash, Value& val) const -> bool
 {
-    bool found{false};
-    tt_->Map.if_contains(hash, [&](auto const& v) -> auto {
-        val = v.second.first;
-        found = true;
-    });
+    bool const found = tt_->Cache.IfContains(hash, [&](FitnessEntry const& e) { val = e.Value; });
     if (found) { ++hits_; }
     return found;
 }
 
 auto Zobrist::Insert(Operon::Hash hash, Value const& val) -> void
 {
-    tt_->Map.lazy_emplace_l(
-        hash,
-        [](auto& v) -> auto { ++v.second.second; },          // already present: bump count
-        [&](auto const& ctor) -> auto { ctor(hash, std::make_pair(val, std::size_t{1})); }  // new entry
+    tt_->Cache.LazyEmplace(hash,
+        [](FitnessEntry& e) { ++e.Visits; },
+        [&](FitnessEntry& e) { e.Value = val; }
     );
 }
 
 auto Zobrist::Clear() -> void
 {
-    tt_->Map.clear();
+    tt_->Cache.Clear();
     hits_.store(0);
 }
 
 auto Zobrist::Size() const -> std::size_t
 {
-    return tt_->Map.size();
+    return tt_->Cache.Size();
 }
 
 } // namespace Operon

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -6,91 +6,109 @@
 #include "operon/interpreter/backend/jit/jit_evaluator.hpp"
 #include "operon/core/tree_diff.hpp"
 #include "operon/operators/evaluator.hpp"
+#include "operon/interpreter/interpreter.hpp"
 
 #include <algorithm>
 #include <cmath>
-#include <ranges>
+#include <memory>
 #include <vector>
-
-#include <gtl/phmap.hpp>
 
 namespace Operon::JIT {
 
-struct CacheEntry {
-    std::shared_ptr<CompiledTree>     Tree;
-    std::shared_ptr<CompiledJacobian> Jac;
-};
+JitZobrist::JitZobrist(Operon::RandomGenerator& rng, int maxLength,
+                       Operon::Span<Operon::Hash const> variableHashes)
+    : Zobrist(rng, maxLength, variableHashes)
+{}
 
-struct JitEvaluator::CacheImpl {
-    gtl::parallel_flat_hash_map_m<Operon::Hash, CacheEntry> Map;
-};
 
-JitEvaluator::JitEvaluator(gsl::not_null<Problem const*> problem,
-                             gsl::not_null<Zobrist const*>  zobrist,
-                             ErrorMetric                    error,
-                             bool                           linearScaling)
+JitEvaluator::JitEvaluator(gsl::not_null<Problem const*>    problem,
+                             gsl::not_null<JitZobrist const*> zobrist,
+                             ErrorMetric                      error,
+                             bool                             linearScaling)
     : EvaluatorBase(problem)
     , zobrist_(zobrist)
     , error_(std::move(error))
     , scaling_(linearScaling)
-    , cache_(std::make_unique<CacheImpl>())
+    , compiler_(&zobrist->Pool())
 {}
 
 JitEvaluator::~JitEvaluator() = default;
 
-auto JitEvaluator::GetOrCompile(Tree const& tree) const -> std::shared_ptr<CompiledTree>
+auto JitEvaluator::GetOrCompile(Tree const& tree) const -> CompileMeta const*
 {
     return GetOrCompile(tree, zobrist_->ComputeHash(tree));
 }
 
-auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> std::shared_ptr<CompiledTree>
+auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMeta const*
 {
-    CacheEntry entry;
+    if (maxLength_ > 0 && static_cast<int>(tree.Length()) > maxLength_) { ++misses_; return nullptr; }
 
-    // Fast path: already in cache.
-    cache_->Map.if_contains(hash, [&](auto const& kv) { entry = kv.second; });
-    if (entry.Tree) { ++hits_; return entry.Tree; }
+    // Fast path: already compiled.
+    CompileMeta const* result{};
+    if (zobrist_->JitCache().IfContains(hash, [&](JitEntry const& e) {
+            if (e.meta && e.meta->fn) { result = e.meta.get(); }
+        }) && result != nullptr) {
+        ++hits_;
+        return result;
+    }
 
-    // Compile outside the map lock so that cc.finalize() (the expensive part) runs
-    // in parallel across threads.  rt_.add() is internally mutex-protected in asmjit,
-    // so concurrent calls are safe.  A rare double-compile race is harmless: we just
-    // keep whichever result arrives first in the map.
-    std::shared_ptr<CompiledTree> compiled(compiler_.CompileAVX2(tree));
-    if (!compiled) { ++avx2Fails_; compiled.reset(compiler_.Compile(tree).release()); }
+    // Increment visit counter; return nullptr until frequency threshold is met.
+    std::size_t visits{};
+    zobrist_->JitCache().LazyEmplace(hash,
+        [&](JitEntry& e) { visits = ++e.Visits; },
+        [&](JitEntry& e) { visits = ++e.Visits; }
+    );
+    if (visits < minVisits_) { ++misses_; return nullptr; }
+
+    // Compile outside the map lock so cc.finalize() runs in parallel.
+    auto compiled = compiler_.CompileAVX2(tree);
+    if (!compiled) { ++avx2Fails_; compiled = compiler_.Compile(tree); }
     if (!compiled) { ++compileFails_; }
 
-    cache_->Map.lazy_emplace_l(
-        hash,
-        [&](auto& kv) { entry = kv.second; ++hits_; },   // another thread beat us
-        [&](auto const& ctor) { entry.Tree = compiled; ctor(hash, entry); }
-    );
-    return entry.Tree;
+    zobrist_->JitCache().ModifyIf(hash, [&](JitEntry& e) {
+        if (!e.meta) {
+            e.meta = std::move(compiled);
+        } else if (e.meta->fn == nullptr && compiled) {
+            e.meta->fn    = compiled->fn;    compiled->fn    = nullptr;
+            e.meta->rtTree = compiled->rtTree; compiled->rtTree = nullptr;
+        }
+        if (e.meta && e.meta->fn) { result = e.meta.get(); }
+    });
+    if (result != nullptr) { ++hits_; } else { ++misses_; }
+    return result;
 }
 
-auto JitEvaluator::GetOrCompileJacobian(Tree const& tree) const -> std::shared_ptr<CompiledJacobian>
+auto JitEvaluator::GetOrCompileJacobian(Tree const& tree) const -> CompileMeta const*
 {
     auto const hash = zobrist_->ComputeHash(tree);
 
     // Fast path: Jacobian already compiled.
-    std::shared_ptr<CompiledJacobian> jac;
-    cache_->Map.if_contains(hash, [&](auto const& kv) { jac = kv.second.Jac; });
-    if (jac) { return jac; }
+    CompileMeta const* meta{};
+    if (zobrist_->JitCache().IfContains(hash, [&](JitEntry const& e) {
+            if (e.meta && e.meta->jacFn) { meta = e.meta.get(); }
+        }) && meta != nullptr) {
+        return meta;
+    }
 
-    // Ensure the primal entry exists (compile it if needed).
-    static_cast<void>(GetOrCompile(tree, hash));
+    // Ensure an entry exists and count this as a visit (consistent with GetOrCompile).
+    // Jacobian compilation is not frequency-gated — it is only requested by the optimizer
+    // for trees that have already passed selection, so compiling unconditionally is correct.
+    zobrist_->JitCache().LazyEmplace(hash,
+        [](JitEntry& e) { ++e.Visits; },
+        [](JitEntry& e) { e.Visits = 1; });
 
-    // Compile the Jacobian outside any lock (deterministic — a double-compile on
-    // a very rare race is harmless). CompileJacobian is AVX2-only; on non-AVX2
-    // hardware it returns nullptr and JitLMCostFunction falls back to interpreter JacRev.
     auto dag    = Operon::BuildJacobianDag(tree);
     auto newJac = compiler_.CompileJacobian(dag);
 
-    // Store it; if another thread beat us, use their result.
-    cache_->Map.modify_if(hash, [&](auto& kv) {
-        if (!kv.second.Jac) { kv.second.Jac = std::move(newJac); }
-        jac = kv.second.Jac;
+    zobrist_->JitCache().ModifyIf(hash, [&](JitEntry& e) {
+        if (!e.meta) {
+            e.meta = std::move(newJac);
+        } else if (e.meta->jacFn == nullptr && newJac) {
+            e.meta->AcceptJac(*newJac);
+        }
+        if (e.meta) { meta = e.meta.get(); }
     });
-    return jac;
+    return meta;
 }
 
 auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
@@ -105,27 +123,28 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
     auto const  weightsOpt    = problem->Weights(range);
     auto const  weights       = weightsOpt.value_or(Span<Scalar const>{});
 
-    auto const& tree    = ind.Genotype;
-    auto const  hash    = zobrist_->ComputeHash(tree);
-    auto const  compiled = GetOrCompile(tree, hash);
+    auto const& tree = ind.Genotype;
+    auto const  hash = zobrist_->ComputeHash(tree);
+    CompileMeta const* compiled = GetOrCompile(tree, hash);
 
     ENSURE(buf.size() >= range.Size());
     ++ResidualEvaluations;
 
-    if (compiled) {
-        auto const  nVars      = compiled->varOrder.size();
-        auto const  nRows      = static_cast<int32_t>(range.Size());
-        auto const  nRowsPad   = (nRows + 7) & ~7;
+    if (compiled != nullptr) {
+        auto const  nRows    = static_cast<int32_t>(range.Size());
+        auto const  nRowsPad = (nRows + 7) & ~7;
 
+        // Rebuild column pointers from the tree (VarOrder is re-derivable since
+        // the Zobrist hash now structurally identifies each unique tree).
+        thread_local std::vector<Hash>         varOrderBuf;
         thread_local std::vector<float const*> colPtrs;
-        colPtrs.resize(nVars);
-        for (std::size_t i = 0; i < nVars; ++i) {
-            colPtrs[i] = dataset->GetPaddedValues(compiled->varOrder[i])
+        varOrderBuf = VarOrder(tree);
+        colPtrs.resize(varOrderBuf.size());
+        for (std::size_t i = 0; i < varOrderBuf.size(); ++i) {
+            colPtrs[i] = dataset->GetPaddedValues(varOrderBuf[i])
                          + static_cast<std::ptrdiff_t>(range.Start());
         }
 
-        // JIT function processes nRowsPad rows (always a multiple of 8, no scalar tail).
-        // Use a thread-local scratch buffer so the extra 0-7 writes don't touch buf.
         thread_local std::vector<Scalar> scratch;
         scratch.resize(static_cast<std::size_t>(nRowsPad));
 
@@ -135,8 +154,11 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
                      coeff.empty() ? nullptr : coeff.data());
         std::copy_n(scratch.data(), nRows, buf.data());
     } else {
-        // Compilation failed — fill with a large constant so the individual is culled.
-        std::ranges::fill(buf, EvaluatorBase::ErrMax);
+        thread_local ScalarDispatch fallbackDtable;
+        thread_local std::vector<Scalar> coeffBuf;
+        tree.GetCoefficients(coeffBuf);
+        Interpreter<Scalar, ScalarDispatch> interp{&fallbackDtable, dataset, &tree};
+        interp.Evaluate(Span<Scalar const>(coeffBuf.data(), coeffBuf.size()), range, buf);
     }
 
     if (scaling_) {
@@ -160,12 +182,20 @@ auto JitEvaluator::operator()(RandomGenerator& rng, Individual const& ind) const
 
 auto JitEvaluator::CacheSize() const -> std::size_t
 {
-    return cache_->Map.size();
+    return zobrist_->JitCache().Size();
 }
 
 void JitEvaluator::ClearCache()
 {
-    cache_->Map.clear();
+    zobrist_->JitCache().Clear();
+}
+
+void JitEvaluator::ResetCounters()
+{
+    hits_.store(0);
+    misses_.store(0);
+    avx2Fails_.store(0);
+    compileFails_.store(0);
 }
 
 } // namespace Operon::JIT


### PR DESCRIPTION
ZobristCache<E>, CacheEntry<Data...>, FitnessData, and FitnessEntry move from the now-deleted core/cache.hpp into hash/zobrist.hpp, which already owns the phmap dependency and the Zobrist class they support.