### PR TITLE
fix(cli): report eval_cnt from actual evaluator in JIT mode

### DIFF
--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -235,7 +235,7 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
         } else {
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(evaluator.get());
         }
-        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr);
+        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, nullptr, evaluator.get());
         gp.Run(executor, random, [&]() -> void { reporter(executor, gp); });
         jitReport();
         auto best = reporter.GetBest();

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -362,7 +362,7 @@ auto main(int argc, char** argv) -> int
         } else {
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(errorEvaluator.get());
         }
-        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector));
+        Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector), &evaluator);
         gp.Run(executor, random, [&]() { reporter(executor, gp); });
         jitReport();
         auto best = reporter.GetBest();

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -16,12 +16,14 @@ using ModelSelectorFn = std::function<Individual(Span<Individual const>)>;
 template<typename Evaluator>
 class Reporter {
     gsl::not_null<Evaluator const*> evaluator_;
+    EvaluatorBase const* statsSource_{nullptr}; // non-owning; must outlive Reporter (null → use evaluator_)
     mutable Operon::Individual best_;
     ModelSelectorFn selector_;
 
 public:
-    explicit Reporter(gsl::not_null<Evaluator const*> evaluator, ModelSelectorFn selector = nullptr)
-        : evaluator_(evaluator), selector_(std::move(selector)) {}
+    explicit Reporter(gsl::not_null<Evaluator const*> evaluator, ModelSelectorFn selector = nullptr,
+                      EvaluatorBase const* statsSource = nullptr)
+        : evaluator_(evaluator), statsSource_(statsSource), selector_(std::move(selector)) {}
 
     static auto PrintStats(std::vector<std::tuple<std::string, double, std::string>> const& stats, bool printHeader) -> void {
         std::vector<size_t> widths;
@@ -176,7 +178,7 @@ public:
         using T = std::tuple<std::string, double, std::string>;
         auto const* format = ":>#8.3g"; // see https://fmt.dev/latest/syntax.html
 
-        auto [resEval, jacEval, callCount, cfTime ] = evaluator_->Stats();
+        auto [resEval, jacEval, callCount, cfTime ] = statsSource_ ? statsSource_->Stats() : evaluator_->Stats();
         std::array stats {
             T{ "iteration", gp.Generation(), ":>" },
             T{ "r2_tr", r2Train, format },

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -194,7 +194,7 @@ public:
             T{ "eval_cnt", callCount, ":>" },
             T{ "res_eval", resEval, ":>" },
             T{ "jac_eval", jacEval, ":>" },
-            T{ "opt_time", cfTime, ":>" },
+            T{ "opt_time", cfTime / 1e6, format },
             T{ "seed", config.Seed, ":>10" },
             T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find(std::string{SortTaskName}); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
             T{ "elapsed", gp.Elapsed(), ":>"},

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -149,7 +149,7 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("objective", "The error metric used for calculating fitness", cxxopts::value<std::string>()->default_value("r2"))
         ("sorter", "Non-dominated sorter: rs (RankIntersect) or ms (Merge)", cxxopts::value<std::string>()->default_value("rs"))
         ("linear-scaling", "Apply linear scaling on model predictions", cxxopts::value<bool>()->default_value("true"))
-        ("jit", "JIT mode: 'all' = JIT evaluator + optimizer, 'jac' = interpreter evaluator + JIT Jacobian optimizer (requires HAVE_ASMJIT)", cxxopts::value<std::string>()->default_value("")->implicit_value("all"))
+        ("jit", "JIT mode: 'all' = JIT evaluator + optimizer, 'jac' = interpreter evaluator + JIT Jacobian optimizer (requires HAVE_ASMJIT). Use --jit=jac for jac mode; bare --jit defaults to all.", cxxopts::value<std::string>()->default_value("")->implicit_value("all"))
         ("jit-max-length", "Skip JIT compilation for trees longer than this (0 = disabled)", cxxopts::value<int>()->default_value("0"))
         ("jit-min-visits", "Compile a tree only after it has been seen this many times (default 1 = always)", cxxopts::value<std::size_t>()->default_value("1"))
         ("population-size", "Population size", cxxopts::value<size_t>()->default_value("1000"))

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -4,6 +4,7 @@
 #ifndef OPERON_GENERATOR_HPP
 #define OPERON_GENERATOR_HPP
 
+#include <chrono>
 #include "operon/core/operator.hpp"
 #include "operon/hash/zobrist.hpp"
 #include "operon/operators/crossover.hpp"
@@ -73,9 +74,12 @@ public:
         auto evaluate = [&]() {
             if (BernoulliTrial{pLocal}(random)) {
                 auto c = res.Child->Genotype.GetCoefficients(); // save original coefficients
+                auto t0 = std::chrono::steady_clock::now();
                 auto [optimizedTree, summary] = (*Optimizer())(random, std::move(res.Child->Genotype));
+                auto t1 = std::chrono::steady_clock::now();
                 Evaluator()->ResidualEvaluations += summary.FunctionEvaluations;
                 Evaluator()->JacobianEvaluations += summary.JacobianEvaluations;
+                Evaluator()->CostFunctionTime += std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
                 res.Child->Genotype = std::move(optimizedTree);
                 res.Child->Fitness = (*Evaluator())(random, *res.Child, buf);
 

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -79,7 +79,7 @@ public:
                 auto t1 = std::chrono::steady_clock::now();
                 Evaluator()->ResidualEvaluations += summary.FunctionEvaluations;
                 Evaluator()->JacobianEvaluations += summary.JacobianEvaluations;
-                Evaluator()->CostFunctionTime += std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+                Evaluator()->CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 res.Child->Genotype = std::move(optimizedTree);
                 res.Child->Fitness = (*Evaluator())(random, *res.Child, buf);
 


### PR DESCRIPTION
## Summary
- In jit-all mode, the Reporter created a fresh interpreter evaluator for computing train/test metrics but also read `Stats()` from it — `eval_cnt` was always 0
- Add a `statsSource` parameter to `Reporter` so stats are read from the `MultiEvaluator` (which aggregates the real `JitEvaluator` counts) while metrics still use the interpreter evaluator
- Fixes both `operon_nsgp` and `operon_gp`

## Test plan
- [x] `operon_nsgp --jit all` now reports non-zero `eval_cnt` (verified manually)
- [x] Non-JIT modes unaffected (statsSource defaults to null, falls back to evaluator)