### PR TITLE
feat(tools): DuckDB experiment tracking and JIT benchmarks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,7 @@
             packages = [
               (pkgs.python3.withPackages (
                 ps: with ps; [
+                  duckdb
                   pandas
                   pyarrow
                   optuna

--- a/tools/bench_jit_eval.py
+++ b/tools/bench_jit_eval.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Benchmark JIT vs interpreter evaluation (0 LM iterations).
+
+Runs adaptive reps for each configuration and stores results in DuckDB.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from run_operon import run_reps, save
+from results_db import ResultsDB
+
+BINARY = "build/cli/operon_nsgp"
+DB = Path("results.duckdb")
+
+DATASETS = {
+    "Poly-10":    {"file": "data/Poly-10.csv",   "target": "Y",  "train": "0:300",  "test": "300:500"},
+    "Friedman-I": {"file": "data/Friedman-I.csv", "target": "Y",  "train": "0:7000", "test": "7000:10000"},
+}
+
+SHARED_ARGS = [
+    "--iterations", "0",
+    "--generations", "200",
+    "--population-size", "1000",
+    "--threads", "16",
+    "--enable-symbols", "add,sub,mul,div,exp,log,sqrt,sin,cos,tanh",
+]
+
+CONFIGS = {
+    "interp":   [],
+    "jit-all":  ["--jit", "all"],
+    "jit-jac":  ["--jit", "jac"],
+}
+
+
+def main():
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+
+    for ds_name, ds in DATASETS.items():
+        ds_args = ["--dataset", ds["file"], "--target", ds["target"],
+                   "--train", ds["train"], "--test", ds["test"]]
+
+        for cfg_name, cfg_args in CONFIGS.items():
+            label = f"{ds_name} / {cfg_name}"
+            console.print(f"[bold]Running {label}...[/bold]")
+
+            args = [*SHARED_ARGS, *ds_args, *cfg_args]
+            df = run_reps(
+                BINARY, args,
+                adaptive=True, max_reps=50, tol=0.003, window=10,
+                base_seed=42, metric="elapsed",
+            )
+
+            if df.empty:
+                console.print(f"  [red]No data for {label}[/red]")
+                continue
+
+            save(df, DB,
+                 binary=BINARY, dataset=ds_name, problem=cfg_name,
+                 tags=["jit-eval", "iter0", cfg_name],
+                 args=args)
+
+            med = df["elapsed"].median()
+            n = len(df)
+            console.print(f"  [green]✓[/green] {label}: {n} reps, elapsed={med:.3f}s")
+
+    with ResultsDB(DB) as db:
+        summary = db.experiments()
+        table = Table(title="Experiment Summary")
+        for col in summary.columns:
+            table.add_column(col)
+        for _, row in summary.iterrows():
+            table.add_row(*[str(v) for v in row])
+        console.print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bench_jit_sweep.py
+++ b/tools/bench_jit_sweep.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Sweep LM iterations to find JIT breakeven point.
+
+Runs interp vs jit-all vs jit-jac at increasing iteration counts.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from run_operon import run_reps, save
+from results_db import ResultsDB
+
+BINARY = "build/cli/operon_nsgp"
+DB = Path("results.duckdb")
+
+DATASETS = {
+    "Poly-10":       {"file": "data/Poly-10.csv",        "target": "Y",      "train": "0:300",   "test": "300:500"},
+    "Friedman-I":    {"file": "data/Friedman-I.csv",     "target": "Y",      "train": "0:7000",  "test": "7000:10000"},
+    "Friedman-II":   {"file": "data/Friedman-II.csv",    "target": "Y",      "train": "0:7000",  "test": "7000:10000"},
+    "Breiman-I":     {"file": "data/Breiman-I.csv",      "target": "Y",      "train": "0:7000",  "test": "7000:10001"},
+    "Chemical-I":    {"file": "data/Chemical-I.csv",     "target": "target", "train": "0:3500",  "test": "3500:4999"},
+    "Vlad-4":        {"file": "data/Vladislavleva-4.csv","target": "Y",      "train": "0:4000",  "test": "4000:6024"},
+    "Flow-stress":   {"file": "data/Flow_stress.csv",    "target": "target", "train": "0:5500",  "test": "5500:7800"},
+}
+
+BASE_ARGS = [
+    "--generations", "200",
+    "--population-size", "1000",
+    "--threads", "16",
+    "--enable-symbols", "add,sub,mul,div,exp,log,sqrt,sin,cos,tanh",
+]
+
+ITERATIONS = [0, 5, 10, 20, 50]
+
+CONFIGS = {
+    "interp":   [],
+    "jit-all":  ["--jit", "all"],
+    "jit-jac":  ["--jit", "jac"],
+}
+
+
+def main():
+    from rich.console import Console
+    console = Console()
+
+    for iters in ITERATIONS:
+        for ds_name, ds in DATASETS.items():
+            ds_args = ["--dataset", ds["file"], "--target", ds["target"],
+                       "--train", ds["train"], "--test", ds["test"]]
+
+            for cfg_name, cfg_args in CONFIGS.items():
+                label = f"iter={iters} {ds_name} / {cfg_name}"
+                console.print(f"[bold]{label}...[/bold]")
+
+                args = [*BASE_ARGS, "--iterations", str(iters), *ds_args, *cfg_args]
+                df = run_reps(
+                    BINARY, args,
+                    adaptive=True, max_reps=50, tol=0.005, window=10,
+                    base_seed=42, metric="elapsed",
+                )
+
+                if df.empty:
+                    console.print(f"  [red]No data[/red]")
+                    continue
+
+                save(df, DB,
+                     binary=BINARY, dataset=ds_name,
+                     problem=f"{cfg_name}/iter{iters}",
+                     tags=["jit-sweep", cfg_name, f"iter{iters}"],
+                     args=args)
+
+                med_elapsed = df["elapsed"].median()
+                med_r2 = df["r2_te"].median()
+                console.print(f"  [green]✓[/green] {len(df)} reps, elapsed={med_elapsed:.3f}s, r2_te={med_r2:.4f}")
+
+    console.print("\n[bold]Summary[/bold]")
+    with ResultsDB(DB) as db:
+        print(db.query("""
+            SELECT
+                REGEXP_EXTRACT(e.problem, '([^/]+)', 1) AS mode,
+                CAST(e.config->>'iterations' AS INT) AS iters,
+                e.dataset,
+                COUNT(DISTINCT r.rep) AS reps,
+                ROUND(MEDIAN(r.elapsed), 3) AS elapsed,
+                ROUND(MEDIAN(r.r2_te), 4) AS r2_te,
+                ROUND(MEDIAN(r.opt_time), 3) AS opt_time
+            FROM experiments e JOIN runs r USING (experiment_id)
+            WHERE list_contains(e.tags, 'jit-sweep')
+            GROUP BY ALL
+            ORDER BY e.dataset, iters, mode
+        """).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/results_db.py
+++ b/tools/results_db.py
@@ -6,7 +6,7 @@ Usage from other tools:
     from results_db import ResultsDB
     db = ResultsDB("results.duckdb")
     db.store(df, binary="build/cli/operon_nsgp", dataset="Poly-10.csv")
-    db.summary()
+    db.experiments()
 """
 import json
 import logging
@@ -144,15 +144,15 @@ class ResultsDB:
              tags or [], json.dumps(config) if config else None],
         )
 
-        known_cols = {
+        known_cols = [
             "rep", "iteration",
             "r2_tr", "r2_te", "mae_tr", "mae_te",
             "nmse_tr", "nmse_te", "best_fit", "avg_fit",
             "best_len", "avg_len", "eval_cnt", "res_eval",
             "jac_eval", "opt_time", "seed", "sort_ms", "elapsed",
-        }
-        run_cols = [c for c in df.columns if c in known_cols]
-        dropped = set(df.columns) - known_cols - {"experiment_id"}
+        ]
+        run_cols = [c for c in known_cols if c in df.columns]
+        dropped = set(df.columns) - set(known_cols) - {"experiment_id"}
         if dropped:
             logger.warning("Dropped columns not in runs schema: %s", sorted(dropped))
 

--- a/tools/results_db.py
+++ b/tools/results_db.py
@@ -8,6 +8,7 @@ Usage from other tools:
     db.store(df, binary="build/cli/operon_nsgp", dataset="Poly-10.csv")
     db.summary()
 """
+import json
 import subprocess
 import uuid
 from datetime import datetime, timezone
@@ -43,12 +44,22 @@ def _parse_args(args: list[str]) -> dict:
     while i < len(args):
         a = args[i]
         if a.startswith("--"):
-            key = a[2:]
-            if i + 1 < len(args) and not args[i + 1].startswith("--"):
-                result[key] = args[i + 1]
+            if "=" in a:
+                key, val = a[2:].split("=", 1)
+                result[key] = val
+                i += 1
+            elif i + 1 < len(args) and not args[i + 1].startswith("-"):
+                result[a[2:]] = args[i + 1]
                 i += 2
             else:
-                result[key] = True
+                result[a[2:]] = True
+                i += 1
+        elif a.startswith("-") and len(a) == 2:
+            if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                result[a[1:]] = args[i + 1]
+                i += 2
+            else:
+                result[a[1:]] = True
                 i += 1
         else:
             i += 1
@@ -119,7 +130,6 @@ class ResultsDB:
             parsed = _parse_args(args)
             config = {**(config or {}), **parsed}
 
-        import json
         self.con.execute(
             """INSERT INTO experiments VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             [experiment_id, now, commit, dirty, binary, dataset, problem,
@@ -141,7 +151,7 @@ class ResultsDB:
         return experiment_id
 
     def experiments(self, limit: int = 20) -> pd.DataFrame:
-        return self.con.execute(f"""
+        return self.con.execute("""
             SELECT e.experiment_id, e.timestamp, e.git_commit, e.git_dirty,
                    e.binary, e.dataset, e.problem, e.tags,
                    COUNT(DISTINCT r.rep) AS reps,
@@ -151,8 +161,8 @@ class ResultsDB:
             JOIN runs r USING (experiment_id)
             GROUP BY ALL
             ORDER BY e.timestamp DESC
-            LIMIT {limit}
-        """).df()
+            LIMIT ?
+        """, [limit]).df()
 
     def runs(self, experiment_id: str) -> pd.DataFrame:
         return self.con.execute(

--- a/tools/results_db.py
+++ b/tools/results_db.py
@@ -9,6 +9,7 @@ Usage from other tools:
     db.summary()
 """
 import json
+import logging
 import subprocess
 import uuid
 from datetime import datetime, timezone
@@ -16,6 +17,8 @@ from pathlib import Path
 
 import duckdb
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def _git_commit() -> str:
@@ -38,6 +41,10 @@ def _git_dirty() -> bool:
         return False
 
 
+def _is_flag(token: str) -> bool:
+    return token.startswith("--") or (token.startswith("-") and len(token) == 2 and token[1:].isalpha())
+
+
 def _parse_args(args: list[str]) -> dict:
     result = {}
     i = 0
@@ -48,14 +55,14 @@ def _parse_args(args: list[str]) -> dict:
                 key, val = a[2:].split("=", 1)
                 result[key] = val
                 i += 1
-            elif i + 1 < len(args) and not args[i + 1].startswith("-"):
+            elif i + 1 < len(args) and not _is_flag(args[i + 1]):
                 result[a[2:]] = args[i + 1]
                 i += 2
             else:
                 result[a[2:]] = True
                 i += 1
-        elif a.startswith("-") and len(a) == 2:
-            if i + 1 < len(args) and not args[i + 1].startswith("-"):
+        elif a.startswith("-") and len(a) == 2 and a[1:].isalpha():
+            if i + 1 < len(args) and not _is_flag(args[i + 1]):
                 result[a[1:]] = args[i + 1]
                 i += 2
             else:
@@ -106,6 +113,7 @@ class ResultsDB:
                 FOREIGN KEY (experiment_id) REFERENCES experiments(experiment_id)
             )
         """)
+        self.con.execute("CREATE INDEX IF NOT EXISTS idx_runs_eid ON runs(experiment_id)")
 
     def store(
         self,
@@ -136,13 +144,17 @@ class ResultsDB:
              tags or [], json.dumps(config) if config else None],
         )
 
-        run_cols = [c for c in df.columns if c in {
+        known_cols = {
             "rep", "iteration",
             "r2_tr", "r2_te", "mae_tr", "mae_te",
             "nmse_tr", "nmse_te", "best_fit", "avg_fit",
             "best_len", "avg_len", "eval_cnt", "res_eval",
             "jac_eval", "opt_time", "seed", "sort_ms", "elapsed",
-        }]
+        }
+        run_cols = [c for c in df.columns if c in known_cols]
+        dropped = set(df.columns) - known_cols - {"experiment_id"}
+        if dropped:
+            logger.warning("Dropped columns not in runs schema: %s", sorted(dropped))
 
         run_df = df[run_cols].copy()
         run_df.insert(0, "experiment_id", experiment_id)

--- a/tools/results_db.py
+++ b/tools/results_db.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Persistent experiment storage backed by DuckDB.
+
+Usage from other tools:
+    from results_db import ResultsDB
+    db = ResultsDB("results.duckdb")
+    db.store(df, binary="build/cli/operon_nsgp", dataset="Poly-10.csv")
+    db.summary()
+"""
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _git_dirty() -> bool:
+    try:
+        return subprocess.call(
+            ["git", "diff", "--quiet", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        ) != 0
+    except FileNotFoundError:
+        return False
+
+
+def _parse_args(args: list[str]) -> dict:
+    result = {}
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a.startswith("--"):
+            key = a[2:]
+            if i + 1 < len(args) and not args[i + 1].startswith("--"):
+                result[key] = args[i + 1]
+                i += 2
+            else:
+                result[key] = True
+                i += 1
+        else:
+            i += 1
+    return result
+
+
+class ResultsDB:
+    def __init__(self, path: str | Path = "results.duckdb"):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.con = duckdb.connect(str(self.path))
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS experiments (
+                experiment_id VARCHAR PRIMARY KEY,
+                "timestamp"   TIMESTAMPTZ,
+                git_commit    VARCHAR,
+                git_dirty     BOOLEAN,
+                "binary"      VARCHAR,
+                dataset       VARCHAR,
+                problem       VARCHAR,
+                tags          VARCHAR[],
+                config        JSON
+            )
+        """)
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS runs (
+                experiment_id VARCHAR,
+                rep           INTEGER,
+                iteration     INTEGER,
+                r2_tr         DOUBLE, r2_te         DOUBLE,
+                mae_tr        DOUBLE, mae_te        DOUBLE,
+                nmse_tr       DOUBLE, nmse_te       DOUBLE,
+                best_fit      DOUBLE, avg_fit       DOUBLE,
+                best_len      DOUBLE, avg_len       DOUBLE,
+                eval_cnt      BIGINT, res_eval      BIGINT,
+                jac_eval      BIGINT,
+                opt_time      DOUBLE,
+                seed          BIGINT,
+                sort_ms       DOUBLE,
+                elapsed       DOUBLE,
+                FOREIGN KEY (experiment_id) REFERENCES experiments(experiment_id)
+            )
+        """)
+
+    def store(
+        self,
+        df: pd.DataFrame,
+        *,
+        binary: str = "",
+        dataset: str = "",
+        problem: str = "",
+        tags: list[str] | None = None,
+        config: dict | None = None,
+        args: list[str] | None = None,
+    ) -> str:
+        if df.empty:
+            return ""
+
+        experiment_id = uuid.uuid4().hex[:12]
+        commit = _git_commit()
+        dirty = _git_dirty()
+        now = datetime.now(timezone.utc)
+
+        if args is not None:
+            parsed = _parse_args(args)
+            config = {**(config or {}), **parsed}
+
+        import json
+        self.con.execute(
+            """INSERT INTO experiments VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [experiment_id, now, commit, dirty, binary, dataset, problem,
+             tags or [], json.dumps(config) if config else None],
+        )
+
+        run_cols = [c for c in df.columns if c in {
+            "rep", "iteration",
+            "r2_tr", "r2_te", "mae_tr", "mae_te",
+            "nmse_tr", "nmse_te", "best_fit", "avg_fit",
+            "best_len", "avg_len", "eval_cnt", "res_eval",
+            "jac_eval", "opt_time", "seed", "sort_ms", "elapsed",
+        }]
+
+        run_df = df[run_cols].copy()
+        run_df.insert(0, "experiment_id", experiment_id)
+        self.con.execute("INSERT INTO runs SELECT * FROM run_df")
+
+        return experiment_id
+
+    def experiments(self, limit: int = 20) -> pd.DataFrame:
+        return self.con.execute(f"""
+            SELECT e.experiment_id, e.timestamp, e.git_commit, e.git_dirty,
+                   e.binary, e.dataset, e.problem, e.tags,
+                   COUNT(DISTINCT r.rep) AS reps,
+                   MEDIAN(r.r2_te) AS r2_te_median,
+                   MEDIAN(r.elapsed) AS elapsed_median
+            FROM experiments e
+            JOIN runs r USING (experiment_id)
+            GROUP BY ALL
+            ORDER BY e.timestamp DESC
+            LIMIT {limit}
+        """).df()
+
+    def runs(self, experiment_id: str) -> pd.DataFrame:
+        return self.con.execute(
+            "SELECT * FROM runs WHERE experiment_id = ? ORDER BY rep, iteration",
+            [experiment_id],
+        ).df()
+
+    def query(self, sql: str) -> pd.DataFrame:
+        return self.con.execute(sql).df()
+
+    def close(self) -> None:
+        self.con.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/tools/run_operon.py
+++ b/tools/run_operon.py
@@ -126,9 +126,14 @@ def run_reps(
     return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 
 
-def save(df: pd.DataFrame, output: Path, *, append: bool = False) -> None:
+def save(df: pd.DataFrame, output: Path, *, append: bool = False, **db_kwargs) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
-    if output.suffix == ".feather":
+    if output.suffix == ".duckdb":
+        from results_db import ResultsDB
+        with ResultsDB(output) as db:
+            eid = db.store(df, **db_kwargs)
+        logger.info(f"Stored {len(df)} rows → {output} (experiment {eid})")
+    elif output.suffix == ".feather":
         if append and output.exists():
             existing = pd.read_feather(output)
             if "rep" in existing.columns and "rep" in df.columns:
@@ -136,13 +141,14 @@ def save(df: pd.DataFrame, output: Path, *, append: bool = False) -> None:
                 df["rep"] += int(existing["rep"].max()) + 1
             df = pd.concat([existing, df], ignore_index=True)
         df.to_feather(output)
+        logger.info(f"Saved {len(df)} rows → {output}")
     elif output.suffix == ".csv":
         df.to_csv(output, index=False,
                   mode="a" if append else "w",
                   header=not (append and output.exists()))
+        logger.info(f"Saved {len(df)} rows → {output}")
     else:
-        raise ValueError(f"Unsupported format '{output.suffix}': use .csv or .feather")
-    logger.info(f"Saved {len(df)} rows → {output}")
+        raise ValueError(f"Unsupported format '{output.suffix}': use .duckdb, .csv, or .feather")
 
 
 def reps_kwargs_from_cfg(cfg: dict, *, show_progress: bool = True) -> dict:

--- a/tools/run_operon.py
+++ b/tools/run_operon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Run an operon binary, capture per-generation stats, save to CSV or feather.
+Run an operon binary, capture per-generation stats, save to CSV, feather, or DuckDB.
 
 Usage:
     run_operon.py BINARY --output PATH [--all-gens] [--reps N]


### PR DESCRIPTION
## Summary
- Add `tools/results_db.py`: persistent experiment storage backed by DuckDB with git commit tracking, UUID-based experiment IDs, and structured runs table
- Extend `run_operon.py` `save()` to support `.duckdb` output format, delegating to `ResultsDB.store()`
- Add `tools/bench_jit_eval.py`: JIT vs interpreter benchmark at 0 LM iterations
- Add `tools/bench_jit_sweep.py`: iteration sweep across datasets to find JIT breakeven point
- Add `duckdb` to nix tools shell

## Test plan
- [ ] `nix develop .#tools` includes duckdb
- [ ] `python -c "from results_db import ResultsDB"` imports cleanly
- [ ] Run `bench_jit_eval.py` on a small dataset and verify `results.duckdb` is created with experiment + run rows