### PR TITLE
fix(hash): include Optimize flag in Zobrist hash

### DIFF
--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -67,9 +67,16 @@ public:
 
 // Position-aware Zobrist hash for GP trees, plus a transposition table that
 // caches fitness vectors keyed by structural hash.  The hash captures tree
-// topology and variable identity but not coefficient values — by design, so
-// that a cached fitness (computed after local search) can be reused for any
-// structurally identical tree regardless of its current coefficients.
+// topology, variable identity, and the Optimize flag of each node, but not
+// coefficient values — by design, so that a cached fitness (computed after
+// local search) can be reused for any structurally identical tree with the
+// same set of trainable parameters, regardless of current coefficient values.
+//
+// The Optimize flag is included because it determines the number and layout
+// of trainable coefficients; two trees that differ only in which nodes are
+// optimizable are functionally distinct (different coefficient counts) and
+// must not share a cache entry.  IsEnabled is NOT hashed because disabled
+// nodes are erased by Tree::Reduce() before they reach ComputeHash.
 //
 // Ownership: the caller constructs one Zobrist per experiment (or per run) and
 // passes a raw pointer into GeneticAlgorithmConfig::Cache.  The algorithm
@@ -103,6 +110,7 @@ public:
 
     [[nodiscard]] auto Rows() const { return table_.extent(0); }
     [[nodiscard]] auto Cols() const { return table_.extent(1); }
+    [[nodiscard]] auto OptimizeRow() const { return static_cast<int>(Rows()) - 1; }
 
     [[nodiscard]] auto ComputeHash(Node const& n, int pos) const -> Hash
     {
@@ -116,7 +124,7 @@ public:
             h = table_(NodeTypes::GetIndex(n.Type), pos);
         }
         if (n.Optimize) {
-            h ^= table_(static_cast<int>(Rows()) - 1, pos);
+            h ^= table_(OptimizeRow(), pos);
         }
         return h;
     }

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -106,13 +106,19 @@ public:
 
     [[nodiscard]] auto ComputeHash(Node const& n, int pos) const -> Hash
     {
+        Hash h{};
         if (n.IsVariable()) {
             auto const it = varIndex_.find(n.HashValue);
             ENSURE(it != varIndex_.end());
             auto const row = static_cast<int>(NodeTypes::Count) + it->second;
-            return table_(row, pos);
+            h = table_(row, pos);
+        } else {
+            h = table_(NodeTypes::GetIndex(n.Type), pos);
         }
-        return table_(NodeTypes::GetIndex(n.Type), pos);
+        if (n.Optimize) {
+            h ^= table_(static_cast<int>(Rows()) - 1, pos);
+        }
+        return h;
     }
 
     [[nodiscard]] auto ComputeHash(Tree const& tree) const -> Hash

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -12,7 +12,7 @@ struct Zobrist::TranspositionTable {
 };
 
 Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes)
-    : table_(static_cast<int>(NodeTypes::Count) + static_cast<int>(variableHashes.size()), maxLength)
+    : table_(static_cast<int>(NodeTypes::Count) + static_cast<int>(variableHashes.size()) + 1, maxLength)
     , tt_(std::make_unique<TranspositionTable>())
 {
     std::generate(table_.container().begin(), table_.container().end(), std::ref(rng));

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -175,4 +175,20 @@ TEST_CASE("Zobrist - duplicate inserts increment count, not entries", "[zobrist]
     REQUIRE(cache.Size() == 1); // only one entry
 }
 
+TEST_CASE("Zobrist - different Optimize flags yield different hashes", "[zobrist]")
+{
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const cache(rng, MaxLength, {});
+
+    // Two identical trees: sin(constant)
+    // One has the constant optimizable, the other does not.
+    Node c1(NodeType::Constant); c1.Value = 1.0f; c1.Optimize = true;
+    Node c2(NodeType::Constant); c2.Value = 1.0f; c2.Optimize = false;
+
+    Tree const tree1 = Tree({ c1, Node(NodeType::Sin) }).UpdateNodes();
+    Tree const tree2 = Tree({ c2, Node(NodeType::Sin) }).UpdateNodes();
+
+    REQUIRE(cache.ComputeHash(tree1) != cache.ComputeHash(tree2));
+}
+
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Trees with identical structure but different `Optimize` flags previously mapped to the same Zobrist hash
- This caused the JIT cache to reuse a compiled function with a mismatched coefficient count, leading to segfaults
- Add a dedicated table row for the `Optimize` flag and XOR it into the per-node hash when `Optimize` is true

## Test plan
- [x] All 96 non-performance test cases pass
- [x] Verified with JIT+Ref GP runs (40 runs, no crashes)