### PR TITLE
fix(jit): correct Ref node handling and cache validation

### DIFF
--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -54,6 +54,8 @@ struct CompileMeta {
     asmjit::JitRuntime* rtJac  = nullptr;
     EvalFn    fn    = nullptr;
     EvalJacFn jacFn = nullptr;
+    int nVars   = 0;
+    int nConsts = 0;
 
     CompileMeta() = default;
 
@@ -67,6 +69,7 @@ struct CompileMeta {
 
     CompileMeta(CompileMeta&& o) noexcept
         : rtTree(o.rtTree), rtJac(o.rtJac), fn(o.fn), jacFn(o.jacFn)
+        , nVars(o.nVars), nConsts(o.nConsts)
     { o.rtTree = o.rtJac = nullptr; o.fn = nullptr; o.jacFn = nullptr; }
 
     CompileMeta& operator=(CompileMeta&&) = delete;

--- a/include/operon/optimizer/jit_lm_cost_function.hpp
+++ b/include/operon/optimizer/jit_lm_cost_function.hpp
@@ -40,8 +40,10 @@ struct JitLMCostFunction {
                       std::vector<float const*>                colPtrs,
                       Operon::Span<Operon::Scalar const>       target,
                       Operon::Range                            range,
-                      JIT::EvalJacFn                           jacFn     = nullptr,
-                      std::vector<float const*>                jacColPtrs = {})
+                      JIT::EvalJacFn                           jacFn      = nullptr,
+                      std::vector<float const*>                jacColPtrs = {},
+                      int                                      nVars      = -1,
+                      int                                      nConsts    = -1)
         : interpreter_(interpreter)
         , fn_(fn)
         , colPtrs_(std::move(colPtrs))
@@ -54,6 +56,8 @@ struct JitLMCostFunction {
         , nRowsPad_(static_cast<std::size_t>((static_cast<int>(range.Size()) + 7) & ~7))
         , scratchResiduals_(nRowsPad_)
         , scratchJac_(nRowsPad_ * numParameters_)
+        , nVars_(nVars)
+        , nConsts_(nConsts)
     {}
 
     inline auto Evaluate(Scalar const* parameters, Scalar* residuals, Scalar* jacobian) const -> bool // NOLINT
@@ -67,6 +71,8 @@ struct JitLMCostFunction {
         if (jacobian != nullptr) {
             ++jacobianCallCount_;
             if (jacFn_ != nullptr) {
+                ENSURE(nVars_   < 0 || static_cast<int>(jacColPtrs_.size()) == nVars_);
+                ENSURE(nConsts_ < 0 || static_cast<int>(numParameters_)     == nConsts_);
                 // Write into padded per-column scratch, then copy valid rows to jacobian.
                 std::vector<float*> outs(numParameters_);
                 for (std::size_t k = 0; k < numParameters_; ++k) {
@@ -87,6 +93,8 @@ struct JitLMCostFunction {
             ++residualCallCount_;
             Operon::Span<Operon::Scalar> res{residuals, numResiduals_};
             if (fn_ != nullptr) {
+                ENSURE(nVars_   < 0 || static_cast<int>(colPtrs_.size()) == nVars_);
+                ENSURE(nConsts_ < 0 || static_cast<int>(numParameters_)  == nConsts_);
                 fn_(scratchResiduals_.data(), colPtrs_.data(), nRowsPad, parameters);
                 std::copy_n(scratchResiduals_.data(), numResiduals_, residuals);
             } else {
@@ -146,6 +154,9 @@ private:
     std::size_t                              nRowsPad_;
     mutable std::vector<Scalar>              scratchResiduals_;
     mutable std::vector<Scalar>              scratchJac_;
+
+    int                                      nVars_   = -1;
+    int                                      nConsts_ = -1;
 
     mutable std::atomic_size_t jacobianCallCount_{0};
     mutable std::atomic_size_t residualCallCount_{0};

--- a/include/operon/optimizer/optimizer.hpp
+++ b/include/operon/optimizer/optimizer.hpp
@@ -449,7 +449,9 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
             std::move(colPtrs),
             target, range,
             jacFn,
-            std::move(jacColPtrs)};
+            std::move(jacColPtrs),
+            meta->nVars,
+            meta->nConsts};
 
         Eigen::LevenbergMarquardt<decltype(cf)> lm(cf);
         lm.setMaxfev(static_cast<int>(iters + 2));

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -126,9 +126,11 @@ void emitNodesScalar(
         auto const& n = nodes[ii];
 
         if (n.IsRef()) {
-            Vec v = nodeVecs[n.RefTo];
-            nodeVecs[ii] = v;
-            stack.push_back(v);
+            ENSURE(n.RefTo < ii);
+            Vec copy = cc.new_xmm_ss();
+            cc.vmovaps(copy, nodeVecs[n.RefTo]);
+            nodeVecs[ii] = copy;
+            stack.push_back(copy);
             continue;
         }
 
@@ -389,8 +391,10 @@ auto TreeCompiler::Compile(Operon::Tree const& tree) -> std::unique_ptr<CompileM
     if (auto err = rt.add(&fn_ptr, &code); err != Error::kOk) { return nullptr; }
 
     auto result = std::make_unique<CompileMeta>();
-    result->rtTree = &rt;
-    result->fn     = fn_ptr;
+    result->rtTree  = &rt;
+    result->fn      = fn_ptr;
+    result->nVars   = static_cast<int>(varOrder.size());
+    result->nConsts = nConsts;
     return result;
 }
 
@@ -481,9 +485,11 @@ void emitNodesAVX2(
         auto const& n = nodes[ii];
 
         if (n.IsRef()) {
-            Vec v = nodeVecs[n.RefTo];
-            nodeVecs[ii] = v;
-            stack.push_back(v);
+            ENSURE(n.RefTo < ii);
+            Vec copy = cc.new_ymm_ps();
+            cc.vmovups(copy, nodeVecs[n.RefTo]);
+            nodeVecs[ii] = copy;
+            stack.push_back(copy);
             continue;
         }
 
@@ -751,8 +757,10 @@ auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<Comp
     if (auto err = rt.add(&fn_ptr, &code); err != Error::kOk) { return nullptr; }
 
     auto result = std::make_unique<CompileMeta>();
-    result->rtTree = &rt;
-    result->fn     = fn_ptr;
+    result->rtTree  = &rt;
+    result->fn      = fn_ptr;
+    result->nVars   = static_cast<int>(varOrder.size());
+    result->nConsts = nConsts;
     return result;
 }
 

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -69,8 +69,10 @@ auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMet
         if (!e.meta) {
             e.meta = std::move(compiled);
         } else if (e.meta->fn == nullptr && compiled) {
-            e.meta->fn    = compiled->fn;    compiled->fn    = nullptr;
-            e.meta->rtTree = compiled->rtTree; compiled->rtTree = nullptr;
+            e.meta->fn      = compiled->fn;      compiled->fn      = nullptr;
+            e.meta->rtTree  = compiled->rtTree;  compiled->rtTree  = nullptr;
+            e.meta->nVars   = compiled->nVars;
+            e.meta->nConsts = compiled->nConsts;
         }
         if (e.meta && e.meta->fn) { result = e.meta.get(); }
     });
@@ -151,6 +153,8 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
 
         thread_local std::vector<Scalar> coeff;
         tree.GetCoefficients(coeff);
+        ENSURE(static_cast<int>(varOrderBuf.size()) == compiled->nVars);
+        ENSURE(static_cast<int>(coeff.size()) == compiled->nConsts);
         compiled->fn(scratch.data(), colPtrs.data(), nRowsPad,
                      coeff.empty() ? nullptr : coeff.data());
         std::copy_n(scratch.data(), nRows, buf.data());

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -200,6 +200,93 @@ TEST_CASE("JIT AVX2 correctness", "[jit][avx2]")
     }
 }
 
+// Smoke test for Ref node handling in the JIT compiler. The explicit register
+// copy (vmovaps/vmovups) is preventive — it shortens live ranges and simplifies
+// the use graph for asmjit's RA, but no wrong-result bug was observed with the
+// old aliasing code. This test exercises a tree shape with two independent use
+// chains from a shared sub-expression to verify the code path end-to-end.
+TEST_CASE("JIT Ref node forward-pass correctness", "[jit][ref]")
+{
+    auto ds    = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto range = Range{0, std::min(ds.Rows<std::size_t>(), std::size_t{200})};
+
+    JIT::JitRuntimePool compilerPool;
+    JIT::TreeCompiler compiler{&compilerPool};
+
+    // Postfix layout:
+    //   0: X1                            (Variable, Len=0)
+    //   1: X2                            (Variable, Len=0)
+    //   2: Add(X1,X2)   Arity=2 Len=2   S = X1+X2 (shared sub-expression)
+    //   3: X3                            (Variable, Len=0)
+    //   4: Ref(2)                        copy of S (Len=0)
+    //   5: Sub(Ref,X3)  Arity=2 Len=2   S - X3   (consumes Ref + X3)
+    //   6: Mul(Add,Sub) Arity=2 Len=6   S * (S - X3) (consumes node 2 + node 5)
+    //
+    // Node 2's value is consumed independently by Mul (directly) and Sub (via Ref
+    // at node 4), creating two live use chains. With the old register-aliasing
+    // code the Ref shared node 2's virtual register, extending its liveness across
+    // the Sub emit region — exactly the pattern that triggered RA mis-scheduling.
+    //
+    // Semantically: (X1+X2) * ((X1+X2) - X3)
+    auto x1Hash = ds.GetVariable("X1").value().Hash;
+    auto x2Hash = ds.GetVariable("X2").value().Hash;
+    auto x3Hash = ds.GetVariable("X3").value().Hash;
+
+    Operon::Vector<Node> nodes;
+    {
+        Node v1(NodeType::Variable); v1.HashValue = v1.CalculatedHashValue = x1Hash; v1.Value = 1.0F;
+        Node v2(NodeType::Variable); v2.HashValue = v2.CalculatedHashValue = x2Hash; v2.Value = 1.0F;
+        Node add(NodeType::Add);     add.Length = 2;
+        Node v3(NodeType::Variable); v3.HashValue = v3.CalculatedHashValue = x3Hash; v3.Value = 1.0F;
+        Node ref = Node::Ref(2);
+        Node sub(NodeType::Sub);     sub.Length = 2;
+        Node mul(NodeType::Mul);     mul.Length = 6;
+        nodes.push_back(v1);
+        nodes.push_back(v2);
+        nodes.push_back(add);
+        nodes.push_back(v3);
+        nodes.push_back(ref);
+        nodes.push_back(sub);
+        nodes.push_back(mul);
+    }
+    Tree tree{nodes};
+
+    // Reference: interpreter
+    auto ref = EvalRef(tree, ds, range);
+
+    // Verify against the known formula: (X1+X2) * ((X1+X2) - X3)
+    {
+        auto const* x1 = ds.GetPaddedValues(x1Hash);
+        auto const* x2 = ds.GetPaddedValues(x2Hash);
+        auto const* x3 = ds.GetPaddedValues(x3Hash);
+        for (std::size_t i = 0; i < range.Size(); ++i) {
+            auto s = x1[i] + x2[i];
+            auto expected = s * (s - x3[i]);
+            INFO("row " << i << ": expected=" << expected << " ref=" << ref[i]);
+            CHECK(ref[i] == Catch::Approx(expected).epsilon(Tol));
+        }
+    }
+
+    SECTION("scalar") {
+        auto jit = EvalJIT(compiler, tree, ds, range);
+        REQUIRE(ref.size() == jit.size());
+        for (std::size_t i = 0; i < ref.size(); ++i) {
+            INFO("row " << i << ": ref=" << ref[i] << " jit=" << jit[i]);
+            CHECK(jit[i] == Catch::Approx(ref[i]).epsilon(Tol));
+        }
+    }
+
+    SECTION("AVX2") {
+        if (!compiler.HasAVX2()) { SKIP("AVX2 not available"); }
+        auto avx2 = EvalJIT_AVX2(compiler, tree, ds, range);
+        REQUIRE(ref.size() == avx2.size());
+        for (std::size_t i = 0; i < ref.size(); ++i) {
+            INFO("row " << i << ": ref=" << ref[i] << " avx2=" << avx2[i]);
+            CHECK(avx2[i] == Catch::Approx(ref[i]).epsilon(Tol));
+        }
+    }
+}
+
 TEST_CASE("JitEvaluator correctness", "[jit][evaluator]")
 {
     auto ds    = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);


### PR DESCRIPTION
## Summary
- Emit explicit register copies (vmovaps/vmovups) for Ref nodes instead of aliasing the source virtual register
- Store `nVars`/`nConsts` in `CompileMeta` at compile time and copy them when merging fn into a Jacobian-only cache entry
- Add `ENSURE` assertions before calling compiled functions to catch nVars/nConsts mismatches early

## Test plan
- [x] All 96 non-performance test cases pass
- [x] JIT Ref node tests pass (scalar + AVX2)