### PR TITLE
fix(core): exclude Ref nodes from coefficient optimization

### DIFF
--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -136,7 +136,7 @@ struct Node {
         }
         Length = Arity;
         IsEnabled = true;
-        Optimize = IsLeaf(); // we only optimize leaf nodes
+        Optimize = IsLeaf() && !IsRef();
         Value = 1.;
     }
 


### PR DESCRIPTION
## Summary
- Ref nodes are leaves (Arity=0) but reference another node's result — they have no value of their own
- The `Optimize` flag was set to `true` for all leaves, causing Ref nodes to be treated as optimizable coefficients
- Change `Optimize = IsLeaf()` to `Optimize = IsLeaf() && !IsRef()` in the Node constructor

## Test plan
- [x] All 96 non-performance test cases pass