### PR TITLE
feat(core): JSON/BEVE serialization and checkpoint save/resume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,12 @@ if (HAVE_ASMJIT)
         source/interpreter/backend/jit/jit_evaluator.cpp
         source/interpreter/backend/jit/jit_factory.cpp
     )
+    # jit_compiler.cpp emits AVX2 intrinsics; guard explicitly so non-preset
+    # builds (plain cmake -B build) and Windows builds still get AVX2 codegen.
+    if (NOT MSVC)
+        set_source_files_properties(source/interpreter/backend/jit/jit_compiler.cpp
+            PROPERTIES COMPILE_OPTIONS "-mavx2")
+    endif()
 endif()
 
 target_compile_definitions(operon_operon PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(
     source/core/node.cpp
     source/core/pset.cpp
     source/core/tree.cpp
+    source/core/serialization.cpp
     source/core/tree_diff.cpp
     source/core/version.cpp
     source/formatter/dot.cpp
@@ -86,6 +87,11 @@ find_package(Eigen3 REQUIRED)
 find_package(eve REQUIRED)
 find_package(FastFloat REQUIRED)
 find_package(fluky REQUIRED)
+find_package(glaze REQUIRED)
+# Glaze declares cxx_std_23 in its INTERFACE_COMPILE_FEATURES. Strip it so
+# linking glaze PRIVATE does not upgrade the whole library to C++23; instead
+# we set CXX_STANDARD 23 on serialization.cpp alone via source properties.
+set_target_properties(glaze::glaze PROPERTIES INTERFACE_COMPILE_FEATURES "")
 find_package(fmt REQUIRED)
 find_package(gtl REQUIRED)
 find_package(lbfgs REQUIRED)
@@ -224,6 +230,7 @@ target_link_libraries(operon_operon PUBLIC
 
 target_link_libraries(operon_operon PRIVATE
     AriaCsvParser::AriaCsvParser
+    glaze::glaze
     ndsort::ndsort
     Taskflow::Taskflow
     cpp-sort::cpp-sort
@@ -233,6 +240,9 @@ target_link_libraries(operon_operon PRIVATE
 )
 
 target_compile_features(operon_operon PUBLIC cxx_std_23)
+
+# serialization.cpp includes glaze headers which require C++23.
+set_source_files_properties(source/core/serialization.cpp PROPERTIES COMPILE_OPTIONS "-std=gnu++23")
 
 if(MSVC)
     target_compile_options(operon_operon PRIVATE "/std:c++latest")
@@ -249,14 +259,6 @@ if (HAVE_ASMJIT)
         source/interpreter/backend/jit/jit_compiler.cpp
         source/interpreter/backend/jit/jit_evaluator.cpp
         source/interpreter/backend/jit/jit_factory.cpp
-    )
-    # jit_compiler.cpp hosts the AVX2 transcendental helpers (vec_sinf etc.) backed
-    # by eve::wide<float, eve::fixed<8>>.  -mavx2 is required so eve maps W8 to a
-    # single ymm register; the helpers are only called from CompileAVX2(), which
-    # guards entry behind a runtime CpuFeatures::X86::kAVX2 check.
-    set_source_files_properties(
-        source/interpreter/backend/jit/jit_compiler.cpp
-        PROPERTIES COMPILE_OPTIONS "-mavx2"
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,9 +241,6 @@ target_link_libraries(operon_operon PRIVATE
 
 target_compile_features(operon_operon PUBLIC cxx_std_23)
 
-# serialization.cpp includes glaze headers which require C++23.
-set_source_files_properties(source/core/serialization.cpp PROPERTIES COMPILE_OPTIONS "-std=gnu++23")
-
 if(MSVC)
     target_compile_options(operon_operon PRIVATE "/std:c++latest")
 else()

--- a/cli/source/jit_setup.cpp
+++ b/cli/source/jit_setup.cpp
@@ -13,19 +13,19 @@
 namespace Operon::CLI {
 
 auto MakeJitObjects(
-    std::string_view              jitMode,
-    Operon::Problem&              problem,
-    Operon::ScalarDispatch const& dtable,
-    std::string const&            objective,
-    bool                          linearScaling,
-    int                           jitMaxLength,
-    std::size_t                   jitMinVisits,
-    int                           maxLength,
-    std::size_t                   seed
+    [[maybe_unused]] std::string_view              jitMode,
+    [[maybe_unused]] Operon::Problem&              problem,
+    [[maybe_unused]] Operon::ScalarDispatch const& dtable,
+    [[maybe_unused]] std::string const&            objective,
+    [[maybe_unused]] bool                          linearScaling,
+    [[maybe_unused]] int                           jitMaxLength,
+    [[maybe_unused]] std::size_t                   jitMinVisits,
+    [[maybe_unused]] int                           maxLength,
+    [[maybe_unused]] std::size_t                   seed
 ) -> JitObjects {
 #if !defined(HAVE_ASMJIT)
     fmt::print(stderr, "error: --jit requires a build with JIT support (HAVE_ASMJIT)\n");
-    return JitObjects{.Error = true};
+    return JitObjects{.Evaluator = nullptr, .OptimizerJacEval = nullptr, .Optimizer = nullptr, .Zobrist = nullptr, .Report = [](){}, .Error = true};
 #else
     auto [metric, supportsLinearScale] = Operon::ParseErrorMetric(objective);
     auto j = Operon::JIT::MakeJitObjects(

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -243,6 +243,7 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             reporter(executor, gp);
             Operon::MaybeSaveCheckpoint(gp, random, result);
         }, warmStart);
+        Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();
         auto best = reporter.GetBest();
         fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), 6));

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -228,6 +228,8 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
         tf::Executor executor(threads);
         Operon::GeneticProgrammingAlgorithm gp { config, &problem, &treeInitializer, coeffInitializer.get(), generator.get(), reinserter.get() };
 
+        auto const warmStart = Operon::ResumeFromCheckpoint(gp, random, result);
+
         std::unique_ptr<Operon::Evaluator<decltype(dtable)>> reporterEvalStorage;
         Operon::Evaluator<decltype(dtable)> const* ptr = nullptr;
         if (jitMode == "all") {
@@ -237,7 +239,10 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(evaluator.get());
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, nullptr, evaluator.get());
-        gp.Run(executor, random, [&]() -> void { reporter(executor, gp); });
+        gp.Run(executor, random, [&]() -> void {
+            reporter(executor, gp);
+            Operon::MaybeSaveCheckpoint(gp, random, result);
+        }, warmStart);
         jitReport();
         auto best = reporter.GetBest();
         fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), 6));

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -364,7 +364,11 @@ auto main(int argc, char** argv) -> int
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(errorEvaluator.get());
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector), &evaluator);
-        gp.Run(executor, random, [&]() { reporter(executor, gp); });
+        auto const warmStart = Operon::ResumeFromCheckpoint(gp, random, result);
+        gp.Run(executor, random, [&]() {
+            reporter(executor, gp);
+            Operon::MaybeSaveCheckpoint(gp, random, result);
+        }, warmStart);
         jitReport();
         auto best = reporter.GetBest();
         fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::digits));

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -369,6 +369,7 @@ auto main(int argc, char** argv) -> int
             reporter(executor, gp);
             Operon::MaybeSaveCheckpoint(gp, random, result);
         }, warmStart);
+        Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();
         auto best = reporter.GetBest();
         fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::digits));

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -215,6 +215,14 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
     for (std::size_t i = 0; i < cp.Population.size(); ++i) {
         parents[i] = std::move(cp.Population[i]);
     }
+    auto& workers = algo.WorkerRngs();
+    workers.clear();
+    workers.reserve(cp.WorkerRngStates.size());
+    for (auto const& state : cp.WorkerRngStates) {
+        RandomGenerator worker(0ULL);
+        worker.set_state(state);
+        workers.push_back(std::move(worker));
+    }
     return true;
 }
 
@@ -229,6 +237,10 @@ auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const
     cp.RngState   = rng.state();
     cp.Generation = gen;
     cp.Population.assign(algo.Parents().begin(), algo.Parents().end());
+    cp.WorkerRngStates.reserve(algo.WorkerRngs().size());
+    for (auto const& worker : algo.WorkerRngs()) {
+        cp.WorkerRngStates.push_back(worker.state());
+    }
     Serialization::SaveCheckpoint(cp, path);
 }
 

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -210,26 +210,29 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
     }
     rng.set_state(cp.RngState);
     algo.Generation() = cp.Generation;
-    algo.IsFitted()   = true;
     auto parents = algo.Parents();
     for (std::size_t i = 0; i < cp.Population.size(); ++i) {
         parents[i] = std::move(cp.Population[i]);
     }
     auto const& config = algo.GetConfig();
     auto const workerCount = std::max(config.PopulationSize, config.PoolSize);
-    if (!cp.WorkerRngStates.empty() && cp.WorkerRngStates.size() != workerCount) {
+    if (cp.WorkerRngStates.empty()) {
+        fmt::print(stderr, "warning: checkpoint has no worker RNG states — bit-exactness of resumed run is not guaranteed\n");
+    } else if (cp.WorkerRngStates.size() != workerCount) {
         throw std::runtime_error(fmt::format(
             "checkpoint worker RNG count {} doesn't match expected {} (max of --population-size and --pool-size)",
             cp.WorkerRngStates.size(), workerCount));
+    } else {
+        auto& workers = algo.WorkerRngs();
+        workers.clear();
+        workers.reserve(cp.WorkerRngStates.size());
+        for (auto const& state : cp.WorkerRngStates) {
+            RandomGenerator worker(0ULL);
+            worker.set_state(state);
+            workers.push_back(std::move(worker));
+        }
     }
-    auto& workers = algo.WorkerRngs();
-    workers.clear();
-    workers.reserve(cp.WorkerRngStates.size());
-    for (auto const& state : cp.WorkerRngStates) {
-        RandomGenerator worker(0ULL);
-        worker.set_state(state);
-        workers.push_back(std::move(worker));
-    }
+    algo.IsFitted() = true;
     return true;
 }
 

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -198,38 +198,38 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
     if (!result.contains("resume")) { return false; }
     auto const path = result["resume"].as<std::string>();
     auto cp = Serialization::LoadCheckpoint(path);
-    if (cp.Population.empty()) {
-        fmt::print(stderr, "warning: checkpoint '{}' is empty or could not be loaded, starting fresh\n", path);
+    if (!cp) {
+        fmt::print(stderr, "warning: checkpoint '{}' could not be loaded, starting fresh\n", path);
         return false;
     }
-    auto const popSize = algo.GetConfig().PopulationSize;
-    if (cp.Population.size() != popSize) {
+    auto const& config = algo.GetConfig();
+    auto const popSize = config.PopulationSize;
+    if (cp->Population.size() != popSize) {
         throw std::runtime_error(fmt::format(
             "checkpoint population size {} doesn't match --population-size {}",
-            cp.Population.size(), popSize));
+            cp->Population.size(), popSize));
     }
-    rng.set_state(cp.RngState);
-    algo.Generation() = cp.Generation;
+    rng.set_state(cp->RngState);
+    algo.Generation() = cp->Generation;
     auto parents = algo.Parents();
-    for (std::size_t i = 0; i < cp.Population.size(); ++i) {
-        parents[i] = std::move(cp.Population[i]);
+    for (std::size_t i = 0; i < cp->Population.size(); ++i) {
+        parents[i] = std::move(cp->Population[i]);
     }
-    auto const& config = algo.GetConfig();
     auto const workerCount = std::max(config.PopulationSize, config.PoolSize);
-    if (cp.WorkerRngStates.empty()) {
+    if (cp->WorkerRngStates.empty()) {
         fmt::print(stderr, "warning: checkpoint has no worker RNG states — bit-exactness of resumed run is not guaranteed\n");
-    } else if (cp.WorkerRngStates.size() != workerCount) {
+    } else if (cp->WorkerRngStates.size() != workerCount) {
         throw std::runtime_error(fmt::format(
             "checkpoint worker RNG count {} doesn't match expected {} (max of --population-size and --pool-size)",
-            cp.WorkerRngStates.size(), workerCount));
+            cp->WorkerRngStates.size(), workerCount));
     } else {
         auto& workers = algo.WorkerRngs();
         workers.clear();
-        workers.reserve(cp.WorkerRngStates.size());
-        for (auto const& state : cp.WorkerRngStates) {
+        workers.reserve(cp->WorkerRngStates.size());
+        for (auto const& state : cp->WorkerRngStates) {
             RandomGenerator worker(0ULL);
             worker.set_state(state);
-            workers.push_back(std::move(worker));
+            workers.push_back(worker);
         }
     }
     algo.IsFitted() = true;
@@ -237,11 +237,12 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
 }
 
 auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const& rng,
-                         cxxopts::ParseResult const& result) -> void
+                         cxxopts::ParseResult const& result, bool force) -> void
 {
     auto const interval = result["checkpoint-interval"].as<std::size_t>();
     auto const gen      = algo.Generation();
-    if (interval == 0 || gen == 0 || gen % interval != 0) { return; }
+    if (interval == 0) { return; }
+    if (!force && (gen == 0 || gen % interval != 0)) { return; }
     auto const path = result["checkpoint-file"].as<std::string>();
     Serialization::Checkpoint cp;
     cp.RngState   = rng.state();

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -229,7 +229,7 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
         for (auto const& state : cp->WorkerRngStates) {
             RandomGenerator worker(0ULL);
             worker.set_state(state);
-            workers.push_back(worker);
+            workers.push_back(std::move(worker));
         }
     }
     algo.IsFitted() = true;
@@ -243,6 +243,11 @@ auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const
     auto const gen      = algo.Generation();
     if (interval == 0) { return; }
     if (!force && (gen == 0 || gen % interval != 0)) { return; }
+
+    // Avoid writing the same generation twice when the run ends exactly on an interval boundary.
+    static uint64_t lastSaved = std::numeric_limits<uint64_t>::max();
+    if (force && gen == lastSaved) { return; }
+
     auto const path = result["checkpoint-file"].as<std::string>();
     Serialization::Checkpoint cp;
     cp.RngState   = rng.state();
@@ -252,7 +257,11 @@ auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const
     for (auto const& worker : algo.WorkerRngs()) {
         cp.WorkerRngStates.push_back(worker.state());
     }
-    Serialization::SaveCheckpoint(cp, path);
+    if (!Serialization::SaveCheckpoint(cp, path)) {
+        fmt::print(stderr, "warning: checkpoint save failed at generation {} — run continues but resume may not be possible\n", gen);
+    } else {
+        lastSaved = gen;
+    }
 }
 
 auto SetupRanges(cxxopts::ParseResult const& result, Dataset const& dataset,

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -17,6 +17,7 @@
 
 #include "operon/core/node.hpp"
 #include "operon/core/pset.hpp"
+#include "operon/core/serialization.hpp"
 #include "operon/core/version.hpp"
 #include "operon/core/types.hpp"
 
@@ -182,10 +183,53 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("pareto-front", "Write rank-0 Pareto front to this JSON file after the run (only effective with Pareto-based algorithms, e.g. operon_nsgp)", cxxopts::value<std::string>())
         ("model-selection", "Pareto front model selection: obj0 (lowest first objective), mdl, bic, aic", cxxopts::value<std::string>()->default_value("obj0"))
         ("mdl-likelihood", "Likelihood for MDL/BIC/AIC model selection: gaussian or poisson", cxxopts::value<std::string>()->default_value("gaussian"))
+        ("checkpoint-interval", "Save a checkpoint every N generations (0 = disabled)", cxxopts::value<std::size_t>()->default_value("0"))
+        ("checkpoint-file", "Path for checkpoint output (BEVE binary format)", cxxopts::value<std::string>()->default_value("checkpoint.beve"))
+        ("resume", "Resume a previous run from this checkpoint file", cxxopts::value<std::string>())
         ("debug", "Debug mode (more information displayed)")
         ("help", "Print help")
         ("version", "Print version and program information");
     return opts;
+}
+
+auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
+                          cxxopts::ParseResult const& result) -> bool
+{
+    if (!result.contains("resume")) { return false; }
+    auto const path = result["resume"].as<std::string>();
+    auto cp = Serialization::LoadCheckpoint(path);
+    if (cp.Population.empty()) {
+        fmt::print(stderr, "warning: checkpoint '{}' is empty or could not be loaded, starting fresh\n", path);
+        return false;
+    }
+    auto const popSize = algo.GetConfig().PopulationSize;
+    if (cp.Population.size() != popSize) {
+        throw std::runtime_error(fmt::format(
+            "checkpoint population size {} doesn't match --population-size {}",
+            cp.Population.size(), popSize));
+    }
+    rng.set_state(cp.RngState);
+    algo.Generation() = cp.Generation;
+    algo.IsFitted()   = true;
+    auto parents = algo.Parents();
+    for (std::size_t i = 0; i < cp.Population.size(); ++i) {
+        parents[i] = std::move(cp.Population[i]);
+    }
+    return true;
+}
+
+auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const& rng,
+                         cxxopts::ParseResult const& result) -> void
+{
+    auto const interval = result["checkpoint-interval"].as<std::size_t>();
+    auto const gen      = algo.Generation();
+    if (interval == 0 || gen == 0 || gen % interval != 0) { return; }
+    auto const path = result["checkpoint-file"].as<std::string>();
+    Serialization::Checkpoint cp;
+    cp.RngState   = rng.state();
+    cp.Generation = gen;
+    cp.Population.assign(algo.Parents().begin(), algo.Parents().end());
+    Serialization::SaveCheckpoint(cp, path);
 }
 
 auto SetupRanges(cxxopts::ParseResult const& result, Dataset const& dataset,

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -215,6 +215,13 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
     for (std::size_t i = 0; i < cp.Population.size(); ++i) {
         parents[i] = std::move(cp.Population[i]);
     }
+    auto const& config = algo.GetConfig();
+    auto const workerCount = std::max(config.PopulationSize, config.PoolSize);
+    if (!cp.WorkerRngStates.empty() && cp.WorkerRngStates.size() != workerCount) {
+        throw std::runtime_error(fmt::format(
+            "checkpoint worker RNG count {} doesn't match expected {} (max of --population-size and --pool-size)",
+            cp.WorkerRngStates.size(), workerCount));
+    }
     auto& workers = algo.WorkerRngs();
     workers.clear();
     workers.reserve(cp.WorkerRngStates.size());

--- a/cli/source/util.hpp
+++ b/cli/source/util.hpp
@@ -5,6 +5,7 @@
 #ifndef OPERON_CLI_UTIL_HPP
 #define OPERON_CLI_UTIL_HPP
 
+#include "operon/algorithms/ga_base.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/range.hpp"
@@ -36,5 +37,16 @@ auto SetupRanges(cxxopts::ParseResult const& result, Dataset const& dataset,
 // Throws std::runtime_error if a named variable does not exist in the dataset.
 auto BuildInputs(cxxopts::ParseResult const& result, Dataset const& dataset,
                  Hash targetHash) -> std::vector<Hash>;
+
+// Restore algorithm state from a checkpoint file specified via --resume.
+// Returns true if a checkpoint was applied (caller should pass warmStart=true to Run()).
+// Throws std::runtime_error if the checkpoint population size mismatches --population-size.
+auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
+                          cxxopts::ParseResult const& result) -> bool;
+
+// Save a checkpoint if --checkpoint-interval is set and the current generation is due.
+// No-op when interval == 0 or when Generation() == 0 (initial evaluation).
+auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const& rng,
+                         cxxopts::ParseResult const& result) -> void;
 } // namespace Operon
 #endif

--- a/cli/source/util.hpp
+++ b/cli/source/util.hpp
@@ -45,8 +45,9 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
                           cxxopts::ParseResult const& result) -> bool;
 
 // Save a checkpoint if --checkpoint-interval is set and the current generation is due.
+// Pass force=true to save unconditionally (e.g. at end of run).
 // No-op when interval == 0 or when Generation() == 0 (initial evaluation).
 auto MaybeSaveCheckpoint(GeneticAlgorithmBase const& algo, RandomGenerator const& rng,
-                         cxxopts::ParseResult const& result) -> void;
+                         cxxopts::ParseResult const& result, bool force = false) -> void;
 } // namespace Operon
 #endif

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782459418,
-        "narHash": "sha256-WZGZgbAhpXZhpa91N83VYjD4kRGGl/k75DSMMOnqSEc=",
+        "lastModified": 1782506317,
+        "narHash": "sha256-nK9sIJSnSRcg1kP2e1jRPp57gJkZJE1VeOikETnuHtU=",
         "owner": "foolnotion",
         "repo": "fluky",
-        "rev": "78d041c48acf55caffcd75a78085f9957c919578",
+        "rev": "3f04aa78fbcf4a1175d6936e444ed5686ad9f6cd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744043502,
-        "narHash": "sha256-j8dxvzDU8m3TnGwt/3QDinfK5PSBaNHmP/GXj95yiFs=",
+        "lastModified": 1782459418,
+        "narHash": "sha256-WZGZgbAhpXZhpa91N83VYjD4kRGGl/k75DSMMOnqSEc=",
         "owner": "foolnotion",
         "repo": "fluky",
-        "rev": "19320e7499cf0958268dc11fec28a6e41ac332e4",
+        "rev": "78d041c48acf55caffcd75a78085f9957c919578",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782506317,
-        "narHash": "sha256-nK9sIJSnSRcg1kP2e1jRPp57gJkZJE1VeOikETnuHtU=",
+        "lastModified": 1782546386,
+        "narHash": "sha256-YjehPpsbznjzVBYi9s1sigLZI07OmsjjbRpdjYndAxE=",
         "owner": "foolnotion",
         "repo": "fluky",
-        "rev": "3f04aa78fbcf4a1175d6936e444ed5686ad9f6cd",
+        "rev": "27b7ea8e4091332770fa74f6ea09f89384c7245b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,7 @@
               foolnotion.overlay
               (final: prev: {
                 fluky = fluky.packages.${system}.default;
-                glaze = prev.glaze.overrideAttrs (old: {
-                  cmakeFlags = (old.cmakeFlags or []) ++ [ "-DGLAZE_ENABLE_SSL=OFF" ];
-                });
+                glaze = prev.glaze.override { enableSSL = false; };
                 lbfgs = lbfgs.packages.${system}.default;
                 infix-parser = infix-parser.packages.${system}.default;
                 ndsort = ndsort.packages.${system}.default;

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
               foolnotion.overlay
               (final: prev: {
                 fluky = fluky.packages.${system}.default;
+                glaze = prev.glaze.overrideAttrs (old: {
+                  cmakeFlags = (old.cmakeFlags or []) ++ [ "-DGLAZE_ENABLE_SSL=OFF" ];
+                });
                 lbfgs = lbfgs.packages.${system}.default;
                 infix-parser = infix-parser.packages.${system}.default;
                 ndsort = ndsort.packages.${system}.default;

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -58,6 +58,9 @@ public:
     [[nodiscard]] auto GetGenerator() const -> OffspringGeneratorBase const* { return generator_.get(); }
     [[nodiscard]] auto GetReinserter() const -> ReinserterBase const* { return reinserter_.get(); }
 
+    [[nodiscard]] auto WorkerRngs() const -> std::vector<Operon::RandomGenerator> const& { return workerRngs_; }
+    auto WorkerRngs() -> std::vector<Operon::RandomGenerator>& { return workerRngs_; }
+
     [[nodiscard]] auto Generation() const -> size_t { return generation_; }
     auto Generation() -> size_t& { return generation_; }
 
@@ -103,6 +106,7 @@ private:
     Operon::Span<Individual> parents_;
     Operon::Span<Individual> offspring_;
 
+    std::vector<Operon::RandomGenerator> workerRngs_;
     size_t generation_{0};
     double elapsed_{0};
     Operon::Map<std::string, double> phaseTimes_;

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_SERIALIZATION_HPP
+#define OPERON_SERIALIZATION_HPP
+
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "operon/operon_export.hpp"
+#include "operon/core/individual.hpp"
+
+namespace Operon::Serialization {
+
+OPERON_EXPORT auto ToJson(Tree const& tree) -> std::string;
+OPERON_EXPORT auto ToJson(Individual const& individual) -> std::string;
+OPERON_EXPORT auto ToJson(std::span<Individual const> front) -> std::string;
+
+OPERON_EXPORT auto TreeFromJson(std::string_view json) -> Tree;
+OPERON_EXPORT auto IndividualFromJson(std::string_view json) -> Individual;
+
+} // namespace Operon::Serialization
+
+#endif

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -37,9 +37,10 @@ OPERON_EXPORT auto IndividualFromBeve(std::string_view data) -> Individual;
 // ---- Checkpoint (algorithm save / resume) ----
 
 struct OPERON_EXPORT Checkpoint {
-    std::array<uint64_t, 4>    RngState{};
-    std::size_t                Generation{0};
-    Operon::Vector<Individual> Population;
+    std::array<uint64_t, 4>                   RngState{};
+    std::size_t                               Generation{0};
+    Operon::Vector<Individual>                Population;
+    std::vector<std::array<uint64_t, 4>>      WorkerRngStates;
 };
 
 OPERON_EXPORT auto ToBeve(Checkpoint const&) -> std::string;

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -5,11 +5,11 @@
 #define OPERON_SERIALIZATION_HPP
 
 #include <array>
-#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "operon/operon_export.hpp"
 #include "operon/core/individual.hpp"
@@ -38,7 +38,7 @@ OPERON_EXPORT auto IndividualFromBeve(std::string_view data) -> Individual;
 
 struct OPERON_EXPORT Checkpoint {
     std::array<uint64_t, 4>                   RngState{};
-    std::size_t                               Generation{0};
+    uint64_t                                  Generation{0};
     Operon::Vector<Individual>                Population;
     std::vector<std::array<uint64_t, 4>>      WorkerRngStates;
 };

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -47,7 +47,8 @@ struct OPERON_EXPORT Checkpoint {
 OPERON_EXPORT auto ToBeve(Checkpoint const&) -> std::string;
 OPERON_EXPORT auto CheckpointFromBeve(std::string_view data) -> std::optional<Checkpoint>;
 
-OPERON_EXPORT auto SaveCheckpoint(Checkpoint const&, std::string_view path) -> void;
+// Returns true on success, false if the write or rename failed (error printed to stderr).
+OPERON_EXPORT auto SaveCheckpoint(Checkpoint const&, std::string_view path) -> bool;
 OPERON_EXPORT auto LoadCheckpoint(std::string_view path) -> std::optional<Checkpoint>;
 
 } // namespace Operon::Serialization

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -4,6 +4,9 @@
 #ifndef OPERON_SERIALIZATION_HPP
 #define OPERON_SERIALIZATION_HPP
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <span>
 #include <string>
 #include <string_view>
@@ -13,12 +16,37 @@
 
 namespace Operon::Serialization {
 
+// ---- JSON ----
+
 OPERON_EXPORT auto ToJson(Tree const& tree) -> std::string;
 OPERON_EXPORT auto ToJson(Individual const& individual) -> std::string;
 OPERON_EXPORT auto ToJson(std::span<Individual const> front) -> std::string;
 
 OPERON_EXPORT auto TreeFromJson(std::string_view json) -> Tree;
 OPERON_EXPORT auto IndividualFromJson(std::string_view json) -> Individual;
+
+// ---- BEVE (binary) ----
+
+OPERON_EXPORT auto ToBeve(Tree const& tree) -> std::string;
+OPERON_EXPORT auto ToBeve(Individual const& individual) -> std::string;
+OPERON_EXPORT auto ToBeve(std::span<Individual const> front) -> std::string;
+
+OPERON_EXPORT auto TreeFromBeve(std::string_view data) -> Tree;
+OPERON_EXPORT auto IndividualFromBeve(std::string_view data) -> Individual;
+
+// ---- Checkpoint (algorithm save / resume) ----
+
+struct OPERON_EXPORT Checkpoint {
+    std::array<uint64_t, 4>    RngState{};
+    std::size_t                Generation{0};
+    Operon::Vector<Individual> Population;
+};
+
+OPERON_EXPORT auto ToBeve(Checkpoint const&) -> std::string;
+OPERON_EXPORT auto CheckpointFromBeve(std::string_view data) -> Checkpoint;
+
+OPERON_EXPORT auto SaveCheckpoint(Checkpoint const&, std::string_view path) -> void;
+OPERON_EXPORT auto LoadCheckpoint(std::string_view path) -> Checkpoint;
 
 } // namespace Operon::Serialization
 

--- a/include/operon/core/serialization.hpp
+++ b/include/operon/core/serialization.hpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -22,8 +23,8 @@ OPERON_EXPORT auto ToJson(Tree const& tree) -> std::string;
 OPERON_EXPORT auto ToJson(Individual const& individual) -> std::string;
 OPERON_EXPORT auto ToJson(std::span<Individual const> front) -> std::string;
 
-OPERON_EXPORT auto TreeFromJson(std::string_view json) -> Tree;
-OPERON_EXPORT auto IndividualFromJson(std::string_view json) -> Individual;
+OPERON_EXPORT auto TreeFromJson(std::string_view json) -> std::optional<Tree>;
+OPERON_EXPORT auto IndividualFromJson(std::string_view json) -> std::optional<Individual>;
 
 // ---- BEVE (binary) ----
 
@@ -31,8 +32,8 @@ OPERON_EXPORT auto ToBeve(Tree const& tree) -> std::string;
 OPERON_EXPORT auto ToBeve(Individual const& individual) -> std::string;
 OPERON_EXPORT auto ToBeve(std::span<Individual const> front) -> std::string;
 
-OPERON_EXPORT auto TreeFromBeve(std::string_view data) -> Tree;
-OPERON_EXPORT auto IndividualFromBeve(std::string_view data) -> Individual;
+OPERON_EXPORT auto TreeFromBeve(std::string_view data) -> std::optional<Tree>;
+OPERON_EXPORT auto IndividualFromBeve(std::string_view data) -> std::optional<Individual>;
 
 // ---- Checkpoint (algorithm save / resume) ----
 
@@ -44,10 +45,10 @@ struct OPERON_EXPORT Checkpoint {
 };
 
 OPERON_EXPORT auto ToBeve(Checkpoint const&) -> std::string;
-OPERON_EXPORT auto CheckpointFromBeve(std::string_view data) -> Checkpoint;
+OPERON_EXPORT auto CheckpointFromBeve(std::string_view data) -> std::optional<Checkpoint>;
 
 OPERON_EXPORT auto SaveCheckpoint(Checkpoint const&, std::string_view path) -> void;
-OPERON_EXPORT auto LoadCheckpoint(std::string_view path) -> Checkpoint;
+OPERON_EXPORT auto LoadCheckpoint(std::string_view path) -> std::optional<Checkpoint>;
 
 } // namespace Operon::Serialization
 

--- a/operon.nix
+++ b/operon.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
       fast-float
       fluky
       fmt_11
+      glaze
       gtl
       icu
       lbfgs

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -69,6 +69,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
 
     auto parents = Parents();
     auto offspring = Offspring();
+    std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
 
     auto timer = executor.make_observer<PhaseTimer>();
 
@@ -82,16 +83,24 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                              if (report) { std::invoke(report); }
                                          }).name("report progress");
 
+            auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                   auto id = executor.this_worker_id();
+                                   if (slots[id].size() < trainSize) { slots[id].resize(trainSize); }
+                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                               })
+                            .name("evaluate population");
+            eval.precede(reportProgress);
+
             if (IsFitted() && warmStart) {
-                // warm resume: population already has valid fitness; skip init and eval to preserve RNG state
-                prepareEval.precede(reportProgress);
+                // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
+                // the worker RNG states so that subsequent generations remain deterministic.
+                auto saveRngs    = subflow.emplace([&]() { savedRngs = rngs; }).name("save rng states");
+                auto restoreRngs = subflow.emplace([&]() { rngs = std::move(savedRngs); }).name("restore rng states");
+                prepareEval.precede(saveRngs);
+                saveRngs.precede(eval);
+                eval.precede(restoreRngs);
+                restoreRngs.precede(reportProgress);
             } else {
-                auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                       auto id = executor.this_worker_id();
-                                       if (slots[id].size() < trainSize) { slots[id].resize(trainSize); }
-                                       parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
-                                   })
-                                .name("evaluate population");
                 auto init = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                        parents[i].Genotype = (*treeInit)(rngs[i]);
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
@@ -99,7 +108,6 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                 .name("initialize population");
                 init.precede(prepareEval);
                 prepareEval.precede(eval);
-                eval.precede(reportProgress);
             }
         }, // init
         stop, // loop condition

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -41,12 +41,13 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
         return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count()) / ms;
     };
 
-    // random seeds for each thread
+    // random seeds for each thread — reuse existing states on warm resume, seed fresh otherwise
     size_t const s = std::max(config.PopulationSize, config.PoolSize);
-    std::vector<Operon::RandomGenerator> rngs;
-    rngs.reserve(s);
-    for (size_t i = 0; i < s; ++i) {
-        rngs.emplace_back(random());
+    auto& rngs = WorkerRngs();
+    if (rngs.size() != s) {
+        rngs.clear();
+        rngs.reserve(s);
+        for (size_t i = 0; i < s; ++i) { rngs.emplace_back(random()); }
     }
 
     auto idx = 0;

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -77,30 +77,29 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     auto [init, cond, body, back, done] = taskflow.emplace(
         [&, timer](tf::Subflow& subflow) -> void {
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
-            auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                   auto id = executor.this_worker_id();
-                                   // make sure the worker has a large enough buffer
-                                   if (slots[id].size() < trainSize) {
-                                       slots[id].resize(trainSize);
-                                   }
-                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
-                               })
-                            .name("evaluate population");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
                                              if (report) { std::invoke(report); }
                                          }).name("report progress");
-            prepareEval.precede(eval);
-            eval.precede(reportProgress);
 
-            if (!(IsFitted() && warmStart)) {
+            if (IsFitted() && warmStart) {
+                // warm resume: population already has valid fitness; skip init and eval to preserve RNG state
+                prepareEval.precede(reportProgress);
+            } else {
+                auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                       auto id = executor.this_worker_id();
+                                       if (slots[id].size() < trainSize) { slots[id].resize(trainSize); }
+                                       parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                                   })
+                                .name("evaluate population");
                 auto init = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                        parents[i].Genotype = (*treeInit)(rngs[i]);
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
                                    })
                                 .name("initialize population");
-
                 init.precede(prepareEval);
+                prepareEval.precede(eval);
+                eval.precede(reportProgress);
             }
         }, // init
         stop, // loop condition

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -25,7 +25,9 @@
 namespace Operon {
 auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report, bool warmStart) -> void
 {
+    auto const savedGeneration = Generation();
     Reset();
+    if (warmStart) { Generation() = savedGeneration; }
 
     const auto config = GetConfig();
     const auto& treeInit = GetTreeInitializer();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -113,12 +113,13 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
         return static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count()) / us;
     };
 
-    // random seeds for each thread
+    // random seeds for each thread — reuse existing states on warm resume, seed fresh otherwise
     size_t const s = std::max(config.PopulationSize, config.PoolSize);
-    std::vector<Operon::RandomGenerator> rngs;
-    rngs.reserve(s);
-    for (size_t i = 0; i < s; ++i) {
-        rngs.emplace_back(random());
+    auto& rngs = WorkerRngs();
+    if (rngs.size() != s) {
+        rngs.clear();
+        rngs.reserve(s);
+        for (size_t i = 0; i < s; ++i) { rngs.emplace_back(random()); }
     }
 
     auto const* evaluator = generator->Evaluator();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -141,6 +141,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
     auto& individuals = Individuals();
     auto parents = Parents();
     auto offspring = Offspring();
+    std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
 
     // while loop control flow
     auto timer = executor.make_observer<PhaseTimer>();
@@ -159,17 +160,25 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                       .name("report progress");
             nonDominatedSort.precede(reportProgress);
 
+            // nonDominatedSort runs after eval in both paths to rebuild fronts_ from current fitness.
+            auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                   auto const id = executor.this_worker_id();
+                                   slots[id].resize(trainSize);
+                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                               })
+                            .name("evaluate population");
+            eval.precede(nonDominatedSort);
+
             if (IsFitted() && warmStart) {
-                // warm resume: population already has valid fitness; skip init and eval to preserve RNG state
-                // nonDominatedSort still runs to rebuild internal fronts_ state from the restored population
-                prepareEval.precede(nonDominatedSort);
+                // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
+                // the worker RNG states so that subsequent generations remain deterministic.
+                auto saveRngs    = subflow.emplace([&]() { savedRngs = rngs; }).name("save rng states");
+                auto restoreRngs = subflow.emplace([&]() { rngs = std::move(savedRngs); }).name("restore rng states");
+                prepareEval.precede(saveRngs);
+                saveRngs.precede(eval);
+                eval.precede(restoreRngs);
+                restoreRngs.precede(nonDominatedSort);
             } else {
-                auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                       auto const id = executor.this_worker_id();
-                                       slots[id].resize(trainSize);
-                                       parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
-                                   })
-                                .name("evaluate population");
                 auto init = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                        parents[i].Genotype = (*treeInit)(rngs[i]);
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
@@ -177,7 +186,6 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                 .name("initialize population");
                 init.precede(prepareEval);
                 prepareEval.precede(eval);
-                eval.precede(nonDominatedSort);
             }
         }, // init
         stop, // loop condition

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -97,7 +97,9 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
 
 auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report, bool warmStart) -> void // NOLINT(readability-function-cognitive-complexity)
 {
+    auto const savedGeneration = Generation();
     Reset();
+    if (warmStart) { Generation() = savedGeneration; }
 
     const auto& config = GetConfig();
     const auto& treeInit = GetTreeInitializer();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -149,13 +149,6 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
     auto [init, cond, body, back, done] = taskflow.emplace(
         [&, timer](tf::Subflow& subflow) -> void {
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
-            auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                   // make sure the worker has a large enough buffer
-                                   auto const id = executor.this_worker_id();
-                                   slots[id].resize(trainSize);
-                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
-                               })
-                            .name("evaluate population");
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{SortTaskName});
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
@@ -164,18 +157,27 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
                                              }
                                          })
                                       .name("report progress");
-            prepareEval.precede(eval);
-            eval.precede(nonDominatedSort);
             nonDominatedSort.precede(reportProgress);
 
-            if (!(IsFitted() && warmStart)) {
+            if (IsFitted() && warmStart) {
+                // warm resume: population already has valid fitness; skip init and eval to preserve RNG state
+                // nonDominatedSort still runs to rebuild internal fronts_ state from the restored population
+                prepareEval.precede(nonDominatedSort);
+            } else {
+                auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                       auto const id = executor.this_worker_id();
+                                       slots[id].resize(trainSize);
+                                       parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                                   })
+                                .name("evaluate population");
                 auto init = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                        parents[i].Genotype = (*treeInit)(rngs[i]);
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
                                    })
                                 .name("initialize population");
-
                 init.precede(prepareEval);
+                prepareEval.precede(eval);
+                eval.precede(nonDominatedSort);
             }
         }, // init
         stop, // loop condition

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/core/serialization.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+
+#include <glaze/glaze.hpp>
+
+// glz::meta specializations — all glaze details stay in this translation unit.
+template <>
+struct glz::meta<Operon::NodeType> {
+    static constexpr auto value = glz::enumerate(
+        "Add",      Operon::NodeType::Add,
+        "Mul",      Operon::NodeType::Mul,
+        "Sub",      Operon::NodeType::Sub,
+        "Div",      Operon::NodeType::Div,
+        "Fmin",     Operon::NodeType::Fmin,
+        "Fmax",     Operon::NodeType::Fmax,
+        "Aq",       Operon::NodeType::Aq,
+        "Pow",      Operon::NodeType::Pow,
+        "Powabs",   Operon::NodeType::Powabs,
+        "Abs",      Operon::NodeType::Abs,
+        "Acos",     Operon::NodeType::Acos,
+        "Asin",     Operon::NodeType::Asin,
+        "Atan",     Operon::NodeType::Atan,
+        "Cbrt",     Operon::NodeType::Cbrt,
+        "Ceil",     Operon::NodeType::Ceil,
+        "Cos",      Operon::NodeType::Cos,
+        "Cosh",     Operon::NodeType::Cosh,
+        "Exp",      Operon::NodeType::Exp,
+        "Floor",    Operon::NodeType::Floor,
+        "Log",      Operon::NodeType::Log,
+        "Logabs",   Operon::NodeType::Logabs,
+        "Log1p",    Operon::NodeType::Log1p,
+        "Sin",      Operon::NodeType::Sin,
+        "Sinh",     Operon::NodeType::Sinh,
+        "Sqrt",     Operon::NodeType::Sqrt,
+        "Sqrtabs",  Operon::NodeType::Sqrtabs,
+        "Tan",      Operon::NodeType::Tan,
+        "Tanh",     Operon::NodeType::Tanh,
+        "Square",   Operon::NodeType::Square,
+        "Dynamic",  Operon::NodeType::Dynamic,
+        "Constant", Operon::NodeType::Constant,
+        "Variable", Operon::NodeType::Variable,
+        "Ref",      Operon::NodeType::Ref
+    );
+};
+
+// Serialization proxy for Node — excludes fields recomputed by UpdateNodes().
+namespace {
+struct NodeProxy {
+    Operon::NodeType Type{};
+    Operon::Hash     HashValue{};
+    Operon::Scalar   Value{};
+    bool             IsEnabled{true};
+    bool             Optimize{false};
+    uint16_t         RefTo{0};
+
+    static auto FromNode(Operon::Node const& n) noexcept -> NodeProxy {
+        return { n.Type, n.HashValue, n.Value, n.IsEnabled, n.Optimize, n.RefTo };
+    }
+
+    auto ToNode() const noexcept -> Operon::Node {
+        Operon::Node n(Type, HashValue);
+        n.Value     = Value;
+        n.IsEnabled = IsEnabled;
+        n.Optimize  = Optimize;
+        n.RefTo     = RefTo;
+        return n;
+    }
+};
+} // anonymous namespace
+
+template <>
+struct glz::meta<NodeProxy> {
+    using T = NodeProxy;
+    static constexpr auto value = glz::object(
+        "type",      &T::Type,
+        "hash",      &T::HashValue,
+        "value",     &T::Value,
+        "enabled",   &T::IsEnabled,
+        "optimize",  &T::Optimize,
+        "ref_to",    &T::RefTo
+    );
+};
+
+template <>
+struct glz::meta<Operon::Individual> {
+    using T = Operon::Individual;
+    static constexpr auto value = glz::object(
+        "fitness",  &T::Fitness,
+        "rank",     &T::Rank,
+        "distance", &T::Distance
+    );
+};
+
+namespace {
+
+auto NodesToProxies(Operon::Vector<Operon::Node> const& nodes) -> std::vector<NodeProxy>
+{
+    std::vector<NodeProxy> proxies;
+    proxies.reserve(nodes.size());
+    for (auto const& n : nodes) { proxies.push_back(NodeProxy::FromNode(n)); }
+    return proxies;
+}
+
+auto ProxiesToTree(std::vector<NodeProxy> const& proxies) -> Operon::Tree
+{
+    Operon::Vector<Operon::Node> nodes;
+    nodes.reserve(proxies.size());
+    for (auto const& p : proxies) { nodes.push_back(p.ToNode()); }
+    return Operon::Tree(std::move(nodes)).UpdateNodes();
+}
+
+struct TreeJson {
+    std::vector<NodeProxy> nodes;
+};
+
+struct IndividualJson {
+    TreeJson               tree;
+    Operon::Vector<Operon::Scalar> fitness;
+    std::size_t            rank{};
+    Operon::Scalar         distance{};
+};
+
+} // anonymous namespace
+
+template <>
+struct glz::meta<TreeJson> {
+    using T = TreeJson;
+    static constexpr auto value = glz::object("nodes", &T::nodes);
+};
+
+template <>
+struct glz::meta<IndividualJson> {
+    using T = IndividualJson;
+    static constexpr auto value = glz::object(
+        "tree",     &T::tree,
+        "fitness",  &T::fitness,
+        "rank",     &T::rank,
+        "distance", &T::distance
+    );
+};
+
+namespace Operon::Serialization {
+
+auto ToJson(Tree const& tree) -> std::string
+{
+    TreeJson tj{ NodesToProxies(tree.Nodes()) };
+    auto result = glz::write_json(tj);
+    if (!result) {
+        return "{}";
+    }
+    return std::move(*result);
+}
+
+auto ToJson(Individual const& ind) -> std::string
+{
+    IndividualJson ij{
+        { NodesToProxies(ind.Genotype.Nodes()) },
+        ind.Fitness,
+        ind.Rank,
+        ind.Distance
+    };
+    auto result = glz::write_json(ij);
+    if (!result) {
+        return "{}";
+    }
+    return std::move(*result);
+}
+
+auto ToJson(std::span<Individual const> front) -> std::string
+{
+    std::vector<IndividualJson> arr;
+    arr.reserve(front.size());
+    for (auto const& ind : front) {
+        arr.push_back({
+            { NodesToProxies(ind.Genotype.Nodes()) },
+            ind.Fitness,
+            ind.Rank,
+            ind.Distance
+        });
+    }
+    auto result = glz::write_json(arr);
+    if (!result) {
+        return "[]";
+    }
+    return std::move(*result);
+}
+
+auto TreeFromJson(std::string_view json) -> Tree
+{
+    TreeJson tj;
+    if (glz::read_json(tj, json)) { return {}; }
+    return ProxiesToTree(tj.nodes);
+}
+
+auto IndividualFromJson(std::string_view json) -> Individual
+{
+    IndividualJson ij;
+    if (glz::read_json(ij, json)) { return {}; }
+    Individual ind;
+    ind.Genotype = ProxiesToTree(ij.tree.nodes);
+    ind.Fitness  = std::move(ij.fitness);
+    ind.Rank     = ij.rank;
+    ind.Distance = ij.distance;
+    return ind;
+}
+
+} // namespace Operon::Serialization

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -84,9 +84,10 @@ struct IndividualProxy {
 };
 
 struct CheckpointProxy {
-    std::array<uint64_t, 4>      RngState{};
-    std::size_t                  Generation{0};
-    std::vector<IndividualProxy> Population;
+    std::array<uint64_t, 4>                  RngState{};
+    std::size_t                              Generation{0};
+    std::vector<IndividualProxy>             Population;
+    std::vector<std::array<uint64_t, 4>>     WorkerRngStates;
 };
 
 auto NodesToProxies(Operon::Vector<Operon::Node> const& nodes) -> std::vector<NodeProxy>
@@ -155,9 +156,10 @@ template <>
 struct glz::meta<CheckpointProxy> {
     using T = CheckpointProxy;
     static constexpr auto value = glz::object(
-        "rng_state",  &T::RngState,
-        "generation", &T::Generation,
-        "population", &T::Population
+        "rng_state",        &T::RngState,
+        "generation",       &T::Generation,
+        "population",       &T::Population,
+        "worker_rng_states", &T::WorkerRngStates
     );
 };
 
@@ -243,13 +245,33 @@ auto IndividualFromBeve(std::string_view data) -> Individual
 
 // ---- Checkpoint ----
 
-auto ToBeve(Checkpoint const& cp) -> std::string
+namespace {
+auto ToProxy(Checkpoint const& cp) -> CheckpointProxy
 {
     CheckpointProxy proxy;
-    proxy.RngState    = cp.RngState;
-    proxy.Generation  = cp.Generation;
+    proxy.RngState        = cp.RngState;
+    proxy.Generation      = cp.Generation;
+    proxy.WorkerRngStates = cp.WorkerRngStates;
     proxy.Population.reserve(cp.Population.size());
     for (auto const& ind : cp.Population) { proxy.Population.push_back(IndividualToProxy(ind)); }
+    return proxy;
+}
+
+auto FromProxy(CheckpointProxy const& proxy) -> Checkpoint
+{
+    Checkpoint cp;
+    cp.RngState        = proxy.RngState;
+    cp.Generation      = proxy.Generation;
+    cp.WorkerRngStates = proxy.WorkerRngStates;
+    cp.Population.reserve(proxy.Population.size());
+    for (auto const& ip : proxy.Population) { cp.Population.push_back(ProxyToIndividual(ip)); }
+    return cp;
+}
+} // anonymous namespace
+
+auto ToBeve(Checkpoint const& cp) -> std::string
+{
+    auto proxy  = ToProxy(cp);
     auto result = glz::write_beve(proxy);
     return result ? std::move(*result) : std::string{};
 }
@@ -258,21 +280,12 @@ auto CheckpointFromBeve(std::string_view data) -> Checkpoint
 {
     CheckpointProxy proxy;
     if (glz::read_beve(proxy, data)) { return {}; }
-    Checkpoint cp;
-    cp.RngState   = proxy.RngState;
-    cp.Generation = proxy.Generation;
-    cp.Population.reserve(proxy.Population.size());
-    for (auto const& ip : proxy.Population) { cp.Population.push_back(ProxyToIndividual(ip)); }
-    return cp;
+    return FromProxy(proxy);
 }
 
 auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
 {
-    CheckpointProxy proxy;
-    proxy.RngState   = cp.RngState;
-    proxy.Generation = cp.Generation;
-    proxy.Population.reserve(cp.Population.size());
-    for (auto const& ind : cp.Population) { proxy.Population.push_back(IndividualToProxy(ind)); }
+    auto proxy = ToProxy(cp);
     std::string buf;
     (void)glz::write_file_beve(proxy, std::string(path), buf);
 }
@@ -282,12 +295,7 @@ auto LoadCheckpoint(std::string_view path) -> Checkpoint
     CheckpointProxy proxy;
     std::string buf;
     if (glz::read_file_beve(proxy, std::string(path), buf)) { return {}; }
-    Checkpoint cp;
-    cp.RngState   = proxy.RngState;
-    cp.Generation = proxy.Generation;
-    cp.Population.reserve(proxy.Population.size());
-    for (auto const& ip : proxy.Population) { cp.Population.push_back(ProxyToIndividual(ip)); }
-    return cp;
+    return FromProxy(proxy);
 }
 
 } // namespace Operon::Serialization

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -6,6 +6,7 @@
 #include "operon/core/tree.hpp"
 
 #include <filesystem>
+#include <stdexcept>
 #include <utility>
 #include <fmt/core.h>
 #include <glaze/glaze.hpp>
@@ -113,6 +114,9 @@ auto NodesToProxies(Operon::Vector<Operon::Node> const& nodes) -> std::vector<No
 
 auto ProxiesToTree(std::vector<NodeProxy> const& proxies) -> Operon::Tree
 {
+    if (proxies.empty()) {
+        throw std::runtime_error("cannot deserialize tree: node list is empty");
+    }
     Operon::Vector<Operon::Node> nodes;
     nodes.reserve(proxies.size());
     for (auto const& p : proxies) { nodes.push_back(p.ToNode()); }
@@ -212,7 +216,10 @@ auto TreeFromJson(std::string_view json) -> Tree
         fmt::print(stderr, "serialization error (TreeFromJson): {}\n", glz::format_error(ec, json));
         return {};
     }
-    return ProxiesToTree(tp.Nodes);
+    try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
+        fmt::print(stderr, "serialization error (TreeFromJson): {}\n", e.what());
+        return {};
+    }
 }
 
 auto IndividualFromJson(std::string_view json) -> Individual
@@ -222,7 +229,10 @@ auto IndividualFromJson(std::string_view json) -> Individual
         fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", glz::format_error(ec, json));
         return {};
     }
-    return ProxyToIndividual(ip);
+    try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
+        fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", e.what());
+        return {};
+    }
 }
 
 // ---- BEVE ----
@@ -257,7 +267,10 @@ auto TreeFromBeve(std::string_view data) -> Tree
         fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
-    return ProxiesToTree(tp.Nodes);
+    try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
+        fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", e.what());
+        return {};
+    }
 }
 
 auto IndividualFromBeve(std::string_view data) -> Individual
@@ -267,7 +280,10 @@ auto IndividualFromBeve(std::string_view data) -> Individual
         fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
-    return ProxyToIndividual(ip);
+    try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
+        fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", e.what());
+        return {};
+    }
 }
 
 // ---- Checkpoint ----
@@ -319,7 +335,12 @@ auto CheckpointFromBeve(std::string_view data) -> Checkpoint
         fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
-    return FromProxy(proxy);
+    try {
+        return FromProxy(proxy);
+    } catch (std::exception const& e) {
+        fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", e.what());
+        return {};
+    }
 }
 
 auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
@@ -332,13 +353,19 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
         std::filesystem::remove(tmpPath);
         return;
     }
+    // On POSIX, rename() atomically replaces the destination so the old checkpoint
+    // is never removed before the new one is in place.  On Windows, rename() fails
+    // if the destination exists; only in that case do we remove it and retry.
     std::error_code ec;
-    std::filesystem::remove(std::string(path), ec); // best-effort; rename fails on Windows if dest exists
-    ec.clear();
     std::filesystem::rename(tmpPath, std::string(path), ec);
     if (ec) {
-        fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());
-        std::filesystem::remove(tmpPath);
+        std::filesystem::remove(std::string(path), ec);
+        ec.clear();
+        std::filesystem::rename(tmpPath, std::string(path), ec);
+        if (ec) {
+            fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());
+            std::filesystem::remove(tmpPath, ec);
+        }
     }
 }
 
@@ -350,7 +377,12 @@ auto LoadCheckpoint(std::string_view path) -> Checkpoint
         fmt::print(stderr, "error loading checkpoint '{}': {}\n", path, glz::format_error(ec, buf));
         return {};
     }
-    return FromProxy(proxy);
+    try {
+        return FromProxy(proxy);
+    } catch (std::exception const& e) {
+        fmt::print(stderr, "error deserializing checkpoint '{}': {}\n", path, e.what());
+        return {};
+    }
 }
 
 } // namespace Operon::Serialization

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -327,11 +327,17 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
     auto const tmpPath = std::string(path) + ".tmp";
     auto proxy = ToProxy(cp);
     std::string buf;
-    if (auto ec = glz::write_file_beve(proxy, tmpPath, buf); ec) {
-        fmt::print(stderr, "error writing checkpoint to '{}': {}\n", tmpPath, glz::format_error(ec));
+    if (auto wec = glz::write_file_beve(proxy, tmpPath, buf); wec) {
+        fmt::print(stderr, "error writing checkpoint to '{}': {}\n", tmpPath, glz::format_error(wec));
+        std::filesystem::remove(tmpPath);
         return;
     }
-    std::filesystem::rename(tmpPath, std::string(path));
+    std::error_code ec;
+    std::filesystem::rename(tmpPath, std::string(path), ec);
+    if (ec) {
+        fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());
+        std::filesystem::remove(tmpPath);
+    }
 }
 
 auto LoadCheckpoint(std::string_view path) -> Checkpoint

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -5,6 +5,7 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 
+#include <exception>
 #include <filesystem>
 #include <optional>
 #include <utility>
@@ -214,10 +215,7 @@ auto TreeFromJson(std::string_view json) -> std::optional<Tree>
         fmt::print(stderr, "serialization error (TreeFromJson): {}\n", glz::format_error(ec, json));
         return std::nullopt;
     }
-    try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
-        fmt::print(stderr, "serialization error (TreeFromJson): {}\n", e.what());
-        return std::nullopt;
-    }
+    return ProxiesToTree(tp.Nodes);
 }
 
 auto IndividualFromJson(std::string_view json) -> std::optional<Individual>
@@ -227,10 +225,7 @@ auto IndividualFromJson(std::string_view json) -> std::optional<Individual>
         fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", glz::format_error(ec, json));
         return std::nullopt;
     }
-    try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
-        fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", e.what());
-        return std::nullopt;
-    }
+    return ProxyToIndividual(ip);
 }
 
 // ---- BEVE ----
@@ -265,10 +260,7 @@ auto TreeFromBeve(std::string_view data) -> std::optional<Tree>
         fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", glz::format_error(ec, data));
         return std::nullopt;
     }
-    try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
-        fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", e.what());
-        return std::nullopt;
-    }
+    return ProxiesToTree(tp.Nodes);
 }
 
 auto IndividualFromBeve(std::string_view data) -> std::optional<Individual>
@@ -278,10 +270,7 @@ auto IndividualFromBeve(std::string_view data) -> std::optional<Individual>
         fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", glz::format_error(ec, data));
         return std::nullopt;
     }
-    try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
-        fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", e.what());
-        return std::nullopt;
-    }
+    return ProxyToIndividual(ip);
 }
 
 // ---- Checkpoint ----
@@ -333,15 +322,10 @@ auto CheckpointFromBeve(std::string_view data) -> std::optional<Checkpoint>
         fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", glz::format_error(ec, data));
         return std::nullopt;
     }
-    try {
-        return FromProxy(proxy);
-    } catch (std::exception const& e) {
-        fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", e.what());
-        return std::nullopt;
-    }
+    return FromProxy(proxy);
 }
 
-auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
+auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> bool
 {
     auto const tmpPath = std::string(path) + ".tmp";
     auto proxy = ToProxy(cp);
@@ -349,7 +333,7 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
     if (auto wec = glz::write_file_beve(proxy, tmpPath, buf); wec) {
         fmt::print(stderr, "error writing checkpoint to '{}': {}\n", tmpPath, glz::format_error(wec));
         std::filesystem::remove(tmpPath);
-        return;
+        return false;
     }
     // On POSIX, rename() atomically replaces the destination — no removal needed.
     // On Windows, rename() fails when the destination already exists as a regular
@@ -368,8 +352,10 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
         if (ec) {
             fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());
             std::filesystem::remove(tmpPath, ec);
+            return false;
         }
     }
+    return true;
 }
 
 auto LoadCheckpoint(std::string_view path) -> std::optional<Checkpoint>
@@ -380,12 +366,7 @@ auto LoadCheckpoint(std::string_view path) -> std::optional<Checkpoint>
         fmt::print(stderr, "error loading checkpoint '{}': {}\n", path, glz::format_error(ec, buf));
         return std::nullopt;
     }
-    try {
-        return FromProxy(proxy);
-    } catch (std::exception const& e) {
-        fmt::print(stderr, "error deserializing checkpoint '{}': {}\n", path, e.what());
-        return std::nullopt;
-    }
+    return FromProxy(proxy);
 }
 
 } // namespace Operon::Serialization

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -6,7 +6,7 @@
 #include "operon/core/tree.hpp"
 
 #include <filesystem>
-#include <stdexcept>
+#include <optional>
 #include <utility>
 #include <fmt/core.h>
 #include <glaze/glaze.hpp>
@@ -87,7 +87,7 @@ struct TreeProxy {
 struct IndividualProxy {
     TreeProxy                      Tree;
     Operon::Vector<Operon::Scalar> Fitness;
-    std::size_t                    Rank{};
+    uint64_t                       Rank{};
     Operon::Scalar                 Distance{};
 };
 
@@ -99,7 +99,7 @@ struct CheckpointProxy {
     uint32_t                                 Magic{CheckpointMagic};
     uint32_t                                 Version{CheckpointVersion};
     std::array<uint64_t, 4>                  RngState{};
-    std::size_t                              Generation{0};
+    uint64_t                                 Generation{0};
     std::vector<IndividualProxy>             Population;
     std::vector<std::array<uint64_t, 4>>     WorkerRngStates;
 };
@@ -114,9 +114,7 @@ auto NodesToProxies(Operon::Vector<Operon::Node> const& nodes) -> std::vector<No
 
 auto ProxiesToTree(std::vector<NodeProxy> const& proxies) -> Operon::Tree
 {
-    if (proxies.empty()) {
-        throw std::runtime_error("cannot deserialize tree: node list is empty");
-    }
+    if (proxies.empty()) { return {}; }
     Operon::Vector<Operon::Node> nodes;
     nodes.reserve(proxies.size());
     for (auto const& p : proxies) { nodes.push_back(p.ToNode()); }
@@ -209,29 +207,29 @@ auto ToJson(std::span<Individual const> front) -> std::string
     return result ? std::move(*result) : "[]";
 }
 
-auto TreeFromJson(std::string_view json) -> Tree
+auto TreeFromJson(std::string_view json) -> std::optional<Tree>
 {
     TreeProxy tp;
     if (auto ec = glz::read_json(tp, json); ec) {
         fmt::print(stderr, "serialization error (TreeFromJson): {}\n", glz::format_error(ec, json));
-        return {};
+        return std::nullopt;
     }
     try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
         fmt::print(stderr, "serialization error (TreeFromJson): {}\n", e.what());
-        return {};
+        return std::nullopt;
     }
 }
 
-auto IndividualFromJson(std::string_view json) -> Individual
+auto IndividualFromJson(std::string_view json) -> std::optional<Individual>
 {
     IndividualProxy ip;
     if (auto ec = glz::read_json(ip, json); ec) {
         fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", glz::format_error(ec, json));
-        return {};
+        return std::nullopt;
     }
     try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
         fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", e.what());
-        return {};
+        return std::nullopt;
     }
 }
 
@@ -260,29 +258,29 @@ auto ToBeve(std::span<Individual const> front) -> std::string
     return result ? std::move(*result) : std::string{};
 }
 
-auto TreeFromBeve(std::string_view data) -> Tree
+auto TreeFromBeve(std::string_view data) -> std::optional<Tree>
 {
     TreeProxy tp;
     if (auto ec = glz::read_beve(tp, data); ec) {
         fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", glz::format_error(ec, data));
-        return {};
+        return std::nullopt;
     }
     try { return ProxiesToTree(tp.Nodes); } catch (std::exception const& e) {
         fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", e.what());
-        return {};
+        return std::nullopt;
     }
 }
 
-auto IndividualFromBeve(std::string_view data) -> Individual
+auto IndividualFromBeve(std::string_view data) -> std::optional<Individual>
 {
     IndividualProxy ip;
     if (auto ec = glz::read_beve(ip, data); ec) {
         fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", glz::format_error(ec, data));
-        return {};
+        return std::nullopt;
     }
     try { return ProxyToIndividual(ip); } catch (std::exception const& e) {
         fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", e.what());
-        return {};
+        return std::nullopt;
     }
 }
 
@@ -300,12 +298,12 @@ auto ToProxy(Checkpoint const& cp) -> CheckpointProxy
     return proxy;
 }
 
-auto FromProxy(CheckpointProxy const& proxy) -> Checkpoint
+auto FromProxy(CheckpointProxy const& proxy) -> std::optional<Checkpoint>
 {
     if (proxy.Magic != CheckpointMagic || proxy.Version != CheckpointVersion) {
         fmt::print(stderr, "error: incompatible checkpoint format (magic={:#010x}, version={})\n",
                      proxy.Magic, proxy.Version);
-        return {};
+        return std::nullopt;
     }
     Checkpoint cp;
     cp.RngState        = proxy.RngState;
@@ -328,18 +326,18 @@ auto ToBeve(Checkpoint const& cp) -> std::string
     return std::move(*result);
 }
 
-auto CheckpointFromBeve(std::string_view data) -> Checkpoint
+auto CheckpointFromBeve(std::string_view data) -> std::optional<Checkpoint>
 {
     CheckpointProxy proxy;
     if (auto ec = glz::read_beve(proxy, data); ec) {
         fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", glz::format_error(ec, data));
-        return {};
+        return std::nullopt;
     }
     try {
         return FromProxy(proxy);
     } catch (std::exception const& e) {
         fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", e.what());
-        return {};
+        return std::nullopt;
     }
 }
 
@@ -374,19 +372,19 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
     }
 }
 
-auto LoadCheckpoint(std::string_view path) -> Checkpoint
+auto LoadCheckpoint(std::string_view path) -> std::optional<Checkpoint>
 {
     CheckpointProxy proxy;
     std::string buf;
     if (auto ec = glz::read_file_beve(proxy, std::string(path), buf); ec) {
         fmt::print(stderr, "error loading checkpoint '{}': {}\n", path, glz::format_error(ec, buf));
-        return {};
+        return std::nullopt;
     }
     try {
         return FromProxy(proxy);
     } catch (std::exception const& e) {
         fmt::print(stderr, "error deserializing checkpoint '{}': {}\n", path, e.what());
-        return {};
+        return std::nullopt;
     }
 }
 

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -333,6 +333,8 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
         return;
     }
     std::error_code ec;
+    std::filesystem::remove(std::string(path), ec); // best-effort; rename fails on Windows if dest exists
+    ec.clear();
     std::filesystem::rename(tmpPath, std::string(path), ec);
     if (ec) {
         fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -353,15 +353,20 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
         std::filesystem::remove(tmpPath);
         return;
     }
-    // On POSIX, rename() atomically replaces the destination so the old checkpoint
-    // is never removed before the new one is in place.  On Windows, rename() fails
-    // if the destination exists; only in that case do we remove it and retry.
+    // On POSIX, rename() atomically replaces the destination — no removal needed.
+    // On Windows, rename() fails when the destination already exists as a regular
+    // file; only in that specific case do we remove it and retry.  For any other
+    // failure reason (permissions, I/O, cross-device) we leave the old checkpoint
+    // in place rather than risk destroying it.
     std::error_code ec;
     std::filesystem::rename(tmpPath, std::string(path), ec);
     if (ec) {
-        std::filesystem::remove(std::string(path), ec);
-        ec.clear();
-        std::filesystem::rename(tmpPath, std::string(path), ec);
+        std::error_code existsEc;
+        if (std::filesystem::is_regular_file(std::string(path), existsEc) && !existsEc) {
+            std::filesystem::remove(std::string(path), ec);
+            ec.clear();
+            std::filesystem::rename(tmpPath, std::string(path), ec);
+        }
         if (ec) {
             fmt::print(stderr, "error renaming checkpoint '{}' to '{}': {}\n", tmpPath, path, ec.message());
             std::filesystem::remove(tmpPath, ec);

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -219,7 +219,7 @@ auto IndividualFromJson(std::string_view json) -> Individual
 {
     IndividualProxy ip;
     if (auto ec = glz::read_json(ip, json); ec) {
-        fmt::print(stderr, "serialization error (IndividualFromJson): %s\n", glz::format_error(ec, json));
+        fmt::print(stderr, "serialization error (IndividualFromJson): {}\n", glz::format_error(ec, json));
         return {};
     }
     return ProxyToIndividual(ip);
@@ -254,7 +254,7 @@ auto TreeFromBeve(std::string_view data) -> Tree
 {
     TreeProxy tp;
     if (auto ec = glz::read_beve(tp, data); ec) {
-        fmt::print(stderr, "serialization error (TreeFromBeve): %s\n", glz::format_error(ec, data));
+        fmt::print(stderr, "serialization error (TreeFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
     return ProxiesToTree(tp.Nodes);
@@ -264,7 +264,7 @@ auto IndividualFromBeve(std::string_view data) -> Individual
 {
     IndividualProxy ip;
     if (auto ec = glz::read_beve(ip, data); ec) {
-        fmt::print(stderr, "serialization error (IndividualFromBeve): %s\n", glz::format_error(ec, data));
+        fmt::print(stderr, "serialization error (IndividualFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
     return ProxyToIndividual(ip);
@@ -306,7 +306,7 @@ auto ToBeve(Checkpoint const& cp) -> std::string
     auto proxy  = ToProxy(cp);
     auto result = glz::write_beve(proxy);
     if (!result) {
-        fmt::print(stderr, "serialization error (ToBeve Checkpoint): %s\n", glz::format_error(result));
+        fmt::print(stderr, "serialization error (ToBeve Checkpoint): {}\n", glz::format_error(result.error()));
         return {};
     }
     return std::move(*result);
@@ -316,7 +316,7 @@ auto CheckpointFromBeve(std::string_view data) -> Checkpoint
 {
     CheckpointProxy proxy;
     if (auto ec = glz::read_beve(proxy, data); ec) {
-        fmt::print(stderr, "serialization error (CheckpointFromBeve): %s\n", glz::format_error(ec, data));
+        fmt::print(stderr, "serialization error (CheckpointFromBeve): {}\n", glz::format_error(ec, data));
         return {};
     }
     return FromProxy(proxy);
@@ -328,7 +328,7 @@ auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
     auto proxy = ToProxy(cp);
     std::string buf;
     if (auto ec = glz::write_file_beve(proxy, tmpPath, buf); ec) {
-        fmt::print(stderr, "error writing checkpoint to '%s': %s\n", tmpPath.c_str(), glz::format_error(ec));
+        fmt::print(stderr, "error writing checkpoint to '{}': {}\n", tmpPath, glz::format_error(ec));
         return;
     }
     std::filesystem::rename(tmpPath, std::string(path));
@@ -339,7 +339,7 @@ auto LoadCheckpoint(std::string_view path) -> Checkpoint
     CheckpointProxy proxy;
     std::string buf;
     if (auto ec = glz::read_file_beve(proxy, std::string(path), buf); ec) {
-        fmt::print(stderr, "error loading checkpoint '%s': %s\n", std::string(path).c_str(), glz::format_error(ec, buf));
+        fmt::print(stderr, "error loading checkpoint '{}': {}\n", path, glz::format_error(ec, buf));
         return {};
     }
     return FromProxy(proxy);

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -5,7 +5,14 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 
+#include <filesystem>
+#include <utility>
+#include <fmt/core.h>
 #include <glaze/glaze.hpp>
+
+// Ensure the enumerate below stays in sync with NodeType additions.
+static_assert(Operon::NodeTypes::Count == 33,
+              "NodeType count changed — update glz::meta<Operon::NodeType>");
 
 // glz::meta specializations — all glaze details stay in this translation unit.
 template <>
@@ -83,7 +90,13 @@ struct IndividualProxy {
     Operon::Scalar                 Distance{};
 };
 
+// Bump Version whenever the on-disk layout changes in a backwards-incompatible way.
+constexpr uint32_t CheckpointMagic   = 0x4F50434BU; // "OPCK"
+constexpr uint32_t CheckpointVersion = 1U;
+
 struct CheckpointProxy {
+    uint32_t                                 Magic{CheckpointMagic};
+    uint32_t                                 Version{CheckpointVersion};
     std::array<uint64_t, 4>                  RngState{};
     std::size_t                              Generation{0};
     std::vector<IndividualProxy>             Population;
@@ -156,6 +169,8 @@ template <>
 struct glz::meta<CheckpointProxy> {
     using T = CheckpointProxy;
     static constexpr auto value = glz::object(
+        "magic",            &T::Magic,
+        "version",          &T::Version,
         "rng_state",        &T::RngState,
         "generation",       &T::Generation,
         "population",       &T::Population,
@@ -193,14 +208,20 @@ auto ToJson(std::span<Individual const> front) -> std::string
 auto TreeFromJson(std::string_view json) -> Tree
 {
     TreeProxy tp;
-    if (glz::read_json(tp, json)) { return {}; }
+    if (auto ec = glz::read_json(tp, json); ec) {
+        fmt::print(stderr, "serialization error (TreeFromJson): {}\n", glz::format_error(ec, json));
+        return {};
+    }
     return ProxiesToTree(tp.Nodes);
 }
 
 auto IndividualFromJson(std::string_view json) -> Individual
 {
     IndividualProxy ip;
-    if (glz::read_json(ip, json)) { return {}; }
+    if (auto ec = glz::read_json(ip, json); ec) {
+        fmt::print(stderr, "serialization error (IndividualFromJson): %s\n", glz::format_error(ec, json));
+        return {};
+    }
     return ProxyToIndividual(ip);
 }
 
@@ -232,14 +253,20 @@ auto ToBeve(std::span<Individual const> front) -> std::string
 auto TreeFromBeve(std::string_view data) -> Tree
 {
     TreeProxy tp;
-    if (glz::read_beve(tp, data)) { return {}; }
+    if (auto ec = glz::read_beve(tp, data); ec) {
+        fmt::print(stderr, "serialization error (TreeFromBeve): %s\n", glz::format_error(ec, data));
+        return {};
+    }
     return ProxiesToTree(tp.Nodes);
 }
 
 auto IndividualFromBeve(std::string_view data) -> Individual
 {
     IndividualProxy ip;
-    if (glz::read_beve(ip, data)) { return {}; }
+    if (auto ec = glz::read_beve(ip, data); ec) {
+        fmt::print(stderr, "serialization error (IndividualFromBeve): %s\n", glz::format_error(ec, data));
+        return {};
+    }
     return ProxyToIndividual(ip);
 }
 
@@ -259,6 +286,11 @@ auto ToProxy(Checkpoint const& cp) -> CheckpointProxy
 
 auto FromProxy(CheckpointProxy const& proxy) -> Checkpoint
 {
+    if (proxy.Magic != CheckpointMagic || proxy.Version != CheckpointVersion) {
+        fmt::print(stderr, "error: incompatible checkpoint format (magic={:#010x}, version={})\n",
+                     proxy.Magic, proxy.Version);
+        return {};
+    }
     Checkpoint cp;
     cp.RngState        = proxy.RngState;
     cp.Generation      = proxy.Generation;
@@ -273,28 +305,43 @@ auto ToBeve(Checkpoint const& cp) -> std::string
 {
     auto proxy  = ToProxy(cp);
     auto result = glz::write_beve(proxy);
-    return result ? std::move(*result) : std::string{};
+    if (!result) {
+        fmt::print(stderr, "serialization error (ToBeve Checkpoint): %s\n", glz::format_error(result));
+        return {};
+    }
+    return std::move(*result);
 }
 
 auto CheckpointFromBeve(std::string_view data) -> Checkpoint
 {
     CheckpointProxy proxy;
-    if (glz::read_beve(proxy, data)) { return {}; }
+    if (auto ec = glz::read_beve(proxy, data); ec) {
+        fmt::print(stderr, "serialization error (CheckpointFromBeve): %s\n", glz::format_error(ec, data));
+        return {};
+    }
     return FromProxy(proxy);
 }
 
 auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
 {
+    auto const tmpPath = std::string(path) + ".tmp";
     auto proxy = ToProxy(cp);
     std::string buf;
-    (void)glz::write_file_beve(proxy, std::string(path), buf);
+    if (auto ec = glz::write_file_beve(proxy, tmpPath, buf); ec) {
+        fmt::print(stderr, "error writing checkpoint to '%s': %s\n", tmpPath.c_str(), glz::format_error(ec));
+        return;
+    }
+    std::filesystem::rename(tmpPath, std::string(path));
 }
 
 auto LoadCheckpoint(std::string_view path) -> Checkpoint
 {
     CheckpointProxy proxy;
     std::string buf;
-    if (glz::read_file_beve(proxy, std::string(path), buf)) { return {}; }
+    if (auto ec = glz::read_file_beve(proxy, std::string(path), buf); ec) {
+        fmt::print(stderr, "error loading checkpoint '%s': %s\n", std::string(path).c_str(), glz::format_error(ec, buf));
+        return {};
+    }
     return FromProxy(proxy);
 }
 

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -47,7 +47,8 @@ struct glz::meta<Operon::NodeType> {
     );
 };
 
-// Serialization proxy for Node — excludes fields recomputed by UpdateNodes().
+// Serialization proxies — exclude fields recomputed by UpdateNodes().
+// Member names are CamelCase; serialized key names (in glz::meta) are lowercase.
 namespace {
 struct NodeProxy {
     Operon::NodeType Type{};
@@ -70,32 +71,23 @@ struct NodeProxy {
         return n;
     }
 };
-} // anonymous namespace
 
-template <>
-struct glz::meta<NodeProxy> {
-    using T = NodeProxy;
-    static constexpr auto value = glz::object(
-        "type",      &T::Type,
-        "hash",      &T::HashValue,
-        "value",     &T::Value,
-        "enabled",   &T::IsEnabled,
-        "optimize",  &T::Optimize,
-        "ref_to",    &T::RefTo
-    );
+struct TreeProxy {
+    std::vector<NodeProxy> Nodes;
 };
 
-template <>
-struct glz::meta<Operon::Individual> {
-    using T = Operon::Individual;
-    static constexpr auto value = glz::object(
-        "fitness",  &T::Fitness,
-        "rank",     &T::Rank,
-        "distance", &T::Distance
-    );
+struct IndividualProxy {
+    TreeProxy                      Tree;
+    Operon::Vector<Operon::Scalar> Fitness;
+    std::size_t                    Rank{};
+    Operon::Scalar                 Distance{};
 };
 
-namespace {
+struct CheckpointProxy {
+    std::array<uint64_t, 4>      RngState{};
+    std::size_t                  Generation{0};
+    std::vector<IndividualProxy> Population;
+};
 
 auto NodesToProxies(Operon::Vector<Operon::Node> const& nodes) -> std::vector<NodeProxy>
 {
@@ -113,99 +105,189 @@ auto ProxiesToTree(std::vector<NodeProxy> const& proxies) -> Operon::Tree
     return Operon::Tree(std::move(nodes)).UpdateNodes();
 }
 
-struct TreeJson {
-    std::vector<NodeProxy> nodes;
-};
+auto IndividualToProxy(Operon::Individual const& ind) -> IndividualProxy
+{
+    return { { NodesToProxies(ind.Genotype.Nodes()) }, ind.Fitness, ind.Rank, ind.Distance };
+}
 
-struct IndividualJson {
-    TreeJson               tree;
-    Operon::Vector<Operon::Scalar> fitness;
-    std::size_t            rank{};
-    Operon::Scalar         distance{};
-};
-
+auto ProxyToIndividual(IndividualProxy const& p) -> Operon::Individual
+{
+    Operon::Individual ind;
+    ind.Genotype = ProxiesToTree(p.Tree.Nodes);
+    ind.Fitness  = p.Fitness;
+    ind.Rank     = p.Rank;
+    ind.Distance = p.Distance;
+    return ind;
+}
 } // anonymous namespace
 
 template <>
-struct glz::meta<TreeJson> {
-    using T = TreeJson;
-    static constexpr auto value = glz::object("nodes", &T::nodes);
+struct glz::meta<NodeProxy> {
+    using T = NodeProxy;
+    static constexpr auto value = glz::object(
+        "type",     &T::Type,
+        "hash",     &T::HashValue,
+        "value",    &T::Value,
+        "enabled",  &T::IsEnabled,
+        "optimize", &T::Optimize,
+        "ref_to",   &T::RefTo
+    );
 };
 
 template <>
-struct glz::meta<IndividualJson> {
-    using T = IndividualJson;
+struct glz::meta<TreeProxy> {
+    using T = TreeProxy;
+    static constexpr auto value = glz::object("nodes", &T::Nodes);
+};
+
+template <>
+struct glz::meta<IndividualProxy> {
+    using T = IndividualProxy;
     static constexpr auto value = glz::object(
-        "tree",     &T::tree,
-        "fitness",  &T::fitness,
-        "rank",     &T::rank,
-        "distance", &T::distance
+        "tree",     &T::Tree,
+        "fitness",  &T::Fitness,
+        "rank",     &T::Rank,
+        "distance", &T::Distance
+    );
+};
+
+template <>
+struct glz::meta<CheckpointProxy> {
+    using T = CheckpointProxy;
+    static constexpr auto value = glz::object(
+        "rng_state",  &T::RngState,
+        "generation", &T::Generation,
+        "population", &T::Population
     );
 };
 
 namespace Operon::Serialization {
 
+// ---- JSON ----
+
 auto ToJson(Tree const& tree) -> std::string
 {
-    TreeJson tj{ NodesToProxies(tree.Nodes()) };
-    auto result = glz::write_json(tj);
-    if (!result) {
-        return "{}";
-    }
-    return std::move(*result);
+    TreeProxy tp{ NodesToProxies(tree.Nodes()) };
+    auto result = glz::write_json(tp);
+    return result ? std::move(*result) : "{}";
 }
 
-auto ToJson(Individual const& ind) -> std::string
+auto ToJson(Individual const& individual) -> std::string
 {
-    IndividualJson ij{
-        { NodesToProxies(ind.Genotype.Nodes()) },
-        ind.Fitness,
-        ind.Rank,
-        ind.Distance
-    };
-    auto result = glz::write_json(ij);
-    if (!result) {
-        return "{}";
-    }
-    return std::move(*result);
+    auto ip = IndividualToProxy(individual);
+    auto result = glz::write_json(ip);
+    return result ? std::move(*result) : "{}";
 }
 
 auto ToJson(std::span<Individual const> front) -> std::string
 {
-    std::vector<IndividualJson> arr;
+    std::vector<IndividualProxy> arr;
     arr.reserve(front.size());
-    for (auto const& ind : front) {
-        arr.push_back({
-            { NodesToProxies(ind.Genotype.Nodes()) },
-            ind.Fitness,
-            ind.Rank,
-            ind.Distance
-        });
-    }
+    for (auto const& ind : front) { arr.push_back(IndividualToProxy(ind)); }
     auto result = glz::write_json(arr);
-    if (!result) {
-        return "[]";
-    }
-    return std::move(*result);
+    return result ? std::move(*result) : "[]";
 }
 
 auto TreeFromJson(std::string_view json) -> Tree
 {
-    TreeJson tj;
-    if (glz::read_json(tj, json)) { return {}; }
-    return ProxiesToTree(tj.nodes);
+    TreeProxy tp;
+    if (glz::read_json(tp, json)) { return {}; }
+    return ProxiesToTree(tp.Nodes);
 }
 
 auto IndividualFromJson(std::string_view json) -> Individual
 {
-    IndividualJson ij;
-    if (glz::read_json(ij, json)) { return {}; }
-    Individual ind;
-    ind.Genotype = ProxiesToTree(ij.tree.nodes);
-    ind.Fitness  = std::move(ij.fitness);
-    ind.Rank     = ij.rank;
-    ind.Distance = ij.distance;
-    return ind;
+    IndividualProxy ip;
+    if (glz::read_json(ip, json)) { return {}; }
+    return ProxyToIndividual(ip);
+}
+
+// ---- BEVE ----
+
+auto ToBeve(Tree const& tree) -> std::string
+{
+    TreeProxy tp{ NodesToProxies(tree.Nodes()) };
+    auto result = glz::write_beve(tp);
+    return result ? std::move(*result) : std::string{};
+}
+
+auto ToBeve(Individual const& individual) -> std::string
+{
+    auto ip = IndividualToProxy(individual);
+    auto result = glz::write_beve(ip);
+    return result ? std::move(*result) : std::string{};
+}
+
+auto ToBeve(std::span<Individual const> front) -> std::string
+{
+    std::vector<IndividualProxy> arr;
+    arr.reserve(front.size());
+    for (auto const& ind : front) { arr.push_back(IndividualToProxy(ind)); }
+    auto result = glz::write_beve(arr);
+    return result ? std::move(*result) : std::string{};
+}
+
+auto TreeFromBeve(std::string_view data) -> Tree
+{
+    TreeProxy tp;
+    if (glz::read_beve(tp, data)) { return {}; }
+    return ProxiesToTree(tp.Nodes);
+}
+
+auto IndividualFromBeve(std::string_view data) -> Individual
+{
+    IndividualProxy ip;
+    if (glz::read_beve(ip, data)) { return {}; }
+    return ProxyToIndividual(ip);
+}
+
+// ---- Checkpoint ----
+
+auto ToBeve(Checkpoint const& cp) -> std::string
+{
+    CheckpointProxy proxy;
+    proxy.RngState    = cp.RngState;
+    proxy.Generation  = cp.Generation;
+    proxy.Population.reserve(cp.Population.size());
+    for (auto const& ind : cp.Population) { proxy.Population.push_back(IndividualToProxy(ind)); }
+    auto result = glz::write_beve(proxy);
+    return result ? std::move(*result) : std::string{};
+}
+
+auto CheckpointFromBeve(std::string_view data) -> Checkpoint
+{
+    CheckpointProxy proxy;
+    if (glz::read_beve(proxy, data)) { return {}; }
+    Checkpoint cp;
+    cp.RngState   = proxy.RngState;
+    cp.Generation = proxy.Generation;
+    cp.Population.reserve(proxy.Population.size());
+    for (auto const& ip : proxy.Population) { cp.Population.push_back(ProxyToIndividual(ip)); }
+    return cp;
+}
+
+auto SaveCheckpoint(Checkpoint const& cp, std::string_view path) -> void
+{
+    CheckpointProxy proxy;
+    proxy.RngState   = cp.RngState;
+    proxy.Generation = cp.Generation;
+    proxy.Population.reserve(cp.Population.size());
+    for (auto const& ind : cp.Population) { proxy.Population.push_back(IndividualToProxy(ind)); }
+    std::string buf;
+    (void)glz::write_file_beve(proxy, std::string(path), buf);
+}
+
+auto LoadCheckpoint(std::string_view path) -> Checkpoint
+{
+    CheckpointProxy proxy;
+    std::string buf;
+    if (glz::read_file_beve(proxy, std::string(path), buf)) { return {}; }
+    Checkpoint cp;
+    cp.RngState   = proxy.RngState;
+    cp.Generation = proxy.Generation;
+    cp.Population.reserve(proxy.Population.size());
+    for (auto const& ip : proxy.Population) { cp.Population.push_back(ProxyToIndividual(ip)); }
+    return cp;
 }
 
 } // namespace Operon::Serialization

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -19,6 +19,7 @@
 namespace Operon {
 auto Tree::UpdateNodes() -> Tree&
 {
+    if (nodes_.empty()) { return *this; }
     for (size_t i = 0; i < nodes_.size(); ++i) {
         auto& s = nodes_[i];
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(operon_test
     source/implementation/optimizer.cpp
     source/implementation/random.cpp
     source/implementation/selection.cpp
+    source/implementation/serialization.cpp
     source/performance/autodiff.cpp
     source/performance/creator.cpp
     source/performance/distance.cpp

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -88,7 +88,8 @@ TEST_CASE("Tree JSON round-trip", "[serialization]")
         auto original = MakeTree(rng);
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::TreeFromJson(json);
-        CHECK(TreesEqual(original, restored));
+        REQUIRE(restored);
+        CHECK(TreesEqual(original, *restored));
     }
 }
 
@@ -99,11 +100,12 @@ TEST_CASE("Individual JSON round-trip", "[serialization]")
         auto original = MakeIndividual(rng);
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::IndividualFromJson(json);
-        CHECK(IndividualsEqual(original, restored));
+        REQUIRE(restored);
+        CHECK(IndividualsEqual(original, *restored));
     }
 }
 
-TEST_CASE("Pareto front JSON round-trip", "[serialization]")
+TEST_CASE("Population span JSON produces array", "[serialization]")
 {
     Operon::RandomGenerator rng(42);
     Operon::Vector<Operon::Individual> front(10);
@@ -116,7 +118,8 @@ TEST_CASE("Pareto front JSON round-trip", "[serialization]")
     for (auto const& original : front) {
         auto elemJson = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::IndividualFromJson(elemJson);
-        CHECK(IndividualsEqual(original, restored));
+        REQUIRE(restored);
+        CHECK(IndividualsEqual(original, *restored));
     }
 }
 
@@ -127,7 +130,8 @@ TEST_CASE("Tree BEVE round-trip", "[serialization]")
         auto original = MakeTree(rng);
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::TreeFromBeve(beve);
-        CHECK(TreesEqual(original, restored));
+        REQUIRE(restored);
+        CHECK(TreesEqual(original, *restored));
     }
 }
 
@@ -138,7 +142,8 @@ TEST_CASE("Individual BEVE round-trip", "[serialization]")
         auto original = MakeIndividual(rng);
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::IndividualFromBeve(beve);
-        CHECK(IndividualsEqual(original, restored));
+        REQUIRE(restored);
+        CHECK(IndividualsEqual(original, *restored));
     }
 }
 
@@ -160,16 +165,17 @@ TEST_CASE("Checkpoint BEVE round-trip", "[serialization]")
 
     auto beve     = Operon::Serialization::ToBeve(original);
     auto restored = Operon::Serialization::CheckpointFromBeve(beve);
+    REQUIRE(restored);
 
-    CHECK(restored.RngState   == original.RngState);
-    CHECK(restored.Generation == original.Generation);
-    REQUIRE(restored.Population.size() == original.Population.size());
+    CHECK(restored->RngState   == original.RngState);
+    CHECK(restored->Generation == original.Generation);
+    REQUIRE(restored->Population.size() == original.Population.size());
     for (std::size_t i = 0; i < original.Population.size(); ++i) {
-        CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+        CHECK(IndividualsEqual(original.Population[i], restored->Population[i]));
     }
-    REQUIRE(restored.WorkerRngStates.size() == original.WorkerRngStates.size());
+    REQUIRE(restored->WorkerRngStates.size() == original.WorkerRngStates.size());
     for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
-        CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
+        CHECK(restored->WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
 }
 
@@ -192,16 +198,17 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     auto const path = (std::filesystem::temp_directory_path() / "operon_test_checkpoint.beve").string();
     Operon::Serialization::SaveCheckpoint(original, path);
     auto restored = Operon::Serialization::LoadCheckpoint(path);
+    REQUIRE(restored);
 
-    CHECK(restored.RngState   == original.RngState);
-    CHECK(restored.Generation == original.Generation);
-    REQUIRE(restored.Population.size() == original.Population.size());
+    CHECK(restored->RngState   == original.RngState);
+    CHECK(restored->Generation == original.Generation);
+    REQUIRE(restored->Population.size() == original.Population.size());
     for (std::size_t i = 0; i < original.Population.size(); ++i) {
-        CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+        CHECK(IndividualsEqual(original.Population[i], restored->Population[i]));
     }
-    REQUIRE(restored.WorkerRngStates.size() == original.WorkerRngStates.size());
+    REQUIRE(restored->WorkerRngStates.size() == original.WorkerRngStates.size());
     for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
-        CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
+        CHECK(restored->WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
 
     std::error_code cleanupEc;
@@ -214,6 +221,8 @@ TEST_CASE("Checkpoint BEVE rejects wrong magic", "[serialization]")
     Operon::Serialization::Checkpoint cp;
     cp.RngState   = rng.state();
     cp.Generation = 0;
+    // Population size ≥ 2 ensures the BEVE payload is large enough for std::search
+    // to locate the 4-byte magic pattern without hitting end-of-buffer prematurely.
     cp.Population.resize(2);
     for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
 
@@ -228,7 +237,7 @@ TEST_CASE("Checkpoint BEVE rejects wrong magic", "[serialization]")
     *it ^= static_cast<char>(0xFF);
 
     auto bad = Operon::Serialization::CheckpointFromBeve(beve);
-    CHECK(bad.Population.empty());
+    CHECK(!bad);
 }
 
 TEST_CASE("Checkpoint BEVE rejects wrong version", "[serialization]")
@@ -257,7 +266,7 @@ TEST_CASE("Checkpoint BEVE rejects wrong version", "[serialization]")
     *versionIt = static_cast<char>(0x02); // bump version to 2
 
     auto bad = Operon::Serialization::CheckpointFromBeve(beve);
-    CHECK(bad.Population.empty());
+    CHECK(!bad);
 }
 
 TEST_CASE("Checkpoint BEVE preserves WorkerRngStates for CLI validation", "[serialization]")
@@ -276,15 +285,17 @@ TEST_CASE("Checkpoint BEVE preserves WorkerRngStates for CLI validation", "[seri
 
     auto beve     = Operon::Serialization::ToBeve(cp);
     auto restored = Operon::Serialization::CheckpointFromBeve(beve);
-    CHECK(restored.WorkerRngStates.size() == 3);
-    CHECK(restored.Population.size() == 4);
+    REQUIRE(restored);
+    CHECK(restored->WorkerRngStates.size() == 3);
+    CHECK(restored->Population.size() == 4);
 }
 
 TEST_CASE("TreeFromJson returns empty tree for empty node list", "[serialization]")
 {
     // Previously: UB crash via UpdateNodes() touching nodes_.back() on empty vector.
     auto tree = Operon::Serialization::TreeFromJson(R"({"nodes":[]})");
-    CHECK(tree.Length() == 0);
+    REQUIRE(tree);
+    CHECK(tree->Length() == 0);
 }
 
 TEST_CASE("TreeFromBeve returns empty tree for empty node list", "[serialization]")
@@ -294,7 +305,8 @@ TEST_CASE("TreeFromBeve returns empty tree for empty node list", "[serialization
     Operon::Tree emptyTree;
     auto beve     = Operon::Serialization::ToBeve(emptyTree);
     auto restored = Operon::Serialization::TreeFromBeve(beve);
-    CHECK(restored.Length() == 0);
+    REQUIRE(restored);
+    CHECK(restored->Length() == 0);
 }
 
 #ifndef _WIN32
@@ -346,7 +358,8 @@ TEST_CASE("SaveCheckpoint is crash-safe: second save overwrites first", "[serial
     Operon::Serialization::SaveCheckpoint(second, path);
 
     auto restored = Operon::Serialization::LoadCheckpoint(path);
-    CHECK(restored.Generation == 2);
+    REQUIRE(restored);
+    CHECK(restored->Generation == 2);
 
     std::error_code ec;
     std::filesystem::remove(path, ec);

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -149,6 +149,11 @@ TEST_CASE("Checkpoint BEVE round-trip", "[serialization]")
     original.Generation = 42;
     original.Population.resize(50);
     for (auto& ind : original.Population) { ind = MakeIndividual(rng); }
+    original.WorkerRngStates.resize(8);
+    for (auto& s : original.WorkerRngStates) {
+        for (auto i = 0; i < 100; ++i) { (void)rng(); }
+        s = rng.state();
+    }
 
     auto beve     = Operon::Serialization::ToBeve(original);
     auto restored = Operon::Serialization::CheckpointFromBeve(beve);
@@ -158,6 +163,10 @@ TEST_CASE("Checkpoint BEVE round-trip", "[serialization]")
     REQUIRE(restored.Population.size() == original.Population.size());
     for (std::size_t i = 0; i < original.Population.size(); ++i) {
         CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+    }
+    REQUIRE(restored.WorkerRngStates.size() == original.WorkerRngStates.size());
+    for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
+        CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
 }
 
@@ -171,6 +180,11 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     original.Generation = 10;
     original.Population.resize(20);
     for (auto& ind : original.Population) { ind = MakeIndividual(rng); }
+    original.WorkerRngStates.resize(4);
+    for (auto& s : original.WorkerRngStates) {
+        for (auto i = 0; i < 100; ++i) { (void)rng(); }
+        s = rng.state();
+    }
 
     auto const path = std::string{"/tmp/operon_test_checkpoint.beve"};
     Operon::Serialization::SaveCheckpoint(original, path);
@@ -181,6 +195,10 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     REQUIRE(restored.Population.size() == original.Population.size());
     for (std::size_t i = 0; i < original.Population.size(); ++i) {
         CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+    }
+    REQUIRE(restored.WorkerRngStates.size() == original.WorkerRngStates.size());
+    for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
+        CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
 }
 

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -203,6 +203,9 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
         CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
+
+    std::error_code cleanupEc;
+    std::filesystem::remove(path, cleanupEc);
 }
 
 TEST_CASE("Checkpoint BEVE rejects wrong magic", "[serialization]")

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <filesystem>
 #include <span>
 #include <string>
 #include <vector>
@@ -186,7 +187,7 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
         s = rng.state();
     }
 
-    auto const path = std::string{"/tmp/operon_test_checkpoint.beve"};
+    auto const path = (std::filesystem::temp_directory_path() / "operon_test_checkpoint.beve").string();
     Operon::Serialization::SaveCheckpoint(original, path);
     auto restored = Operon::Serialization::LoadCheckpoint(path);
 

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -297,6 +297,33 @@ TEST_CASE("TreeFromBeve returns empty tree for empty node list", "[serialization
     CHECK(restored.Length() == 0);
 }
 
+#ifndef _WIN32
+TEST_CASE("SaveCheckpoint preserves destination on non-file rename failure", "[serialization]")
+{
+    // Place a directory at the checkpoint path so rename(tmp, path) fails with
+    // EISDIR — not the "dest is an existing file" case.  The directory must
+    // survive: SaveCheckpoint must not remove it and must not crash.
+    auto const blockPath = std::filesystem::temp_directory_path() / "operon_test_rename_fail_block";
+    std::filesystem::create_directories(blockPath);
+
+    Operon::RandomGenerator rng(77);
+    Operon::Serialization::Checkpoint cp;
+    cp.RngState   = rng.state();
+    cp.Generation = 1;
+    cp.Population.resize(2);
+    for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
+
+    Operon::Serialization::SaveCheckpoint(cp, blockPath.string()); // must not crash or delete the dir
+
+    CHECK(std::filesystem::is_directory(blockPath)); // directory still intact
+
+    std::error_code ec;
+    std::filesystem::remove_all(blockPath, ec);
+    // clean up the .tmp file if it was left behind
+    std::filesystem::remove(blockPath.string() + ".tmp", ec);
+}
+#endif
+
 TEST_CASE("SaveCheckpoint is crash-safe: second save overwrites first", "[serialization]")
 {
     Operon::RandomGenerator rng(11);

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -246,6 +246,8 @@ TEST_CASE("Checkpoint BEVE rejects wrong version", "[serialization]")
     auto magicIt = std::search(beve.begin(), beve.end(), MagicLE.begin(), MagicLE.end());
     REQUIRE(magicIt != beve.end());
 
+    // Generation=0 avoids a false match; assumes BEVE writes fields in
+    // declaration order with no other \x01\x00\x00\x00 between magic and version.
     constexpr std::array<char, 4> VersionLE{ '\x01', '\x00', '\x00', '\x00' };
     auto versionIt = std::search(magicIt + 4, beve.end(), VersionLE.begin(), VersionLE.end());
     REQUIRE(versionIt != beve.end());

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -3,6 +3,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <filesystem>
@@ -203,49 +205,72 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     }
 }
 
-TEST_CASE("Checkpoint BEVE rejects wrong magic/version", "[serialization]")
+TEST_CASE("Checkpoint BEVE rejects wrong magic", "[serialization]")
 {
     Operon::RandomGenerator rng(3);
     Operon::Serialization::Checkpoint cp;
     cp.RngState   = rng.state();
-    cp.Generation = 1;
+    cp.Generation = 0;
     cp.Population.resize(2);
     for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
 
     auto beve = Operon::Serialization::ToBeve(cp);
     REQUIRE(!beve.empty());
 
-    // Corrupt the first 4 bytes (magic field) and verify graceful failure.
-    // The corrupted bytes produce a non-zero but wrong magic value; FromProxy
-    // should return an empty Checkpoint (Population.empty()).
-    beve[0] = static_cast<char>(0xDE);
-    beve[1] = static_cast<char>(0xAD);
-    beve[2] = static_cast<char>(0xBE);
-    beve[3] = static_cast<char>(0xEF);
+    // Locate the magic value (0x4F50434B, LE: 4B 43 50 4F) in the BEVE
+    // payload and flip one byte so FromProxy rejects it.
+    constexpr std::array<char, 4> MagicLE{ '\x4B', '\x43', '\x50', '\x4F' };
+    auto it = std::search(beve.begin(), beve.end(), MagicLE.begin(), MagicLE.end());
+    REQUIRE(it != beve.end()); // sanity: magic must be present in valid checkpoint
+    *it ^= static_cast<char>(0xFF);
+
     auto bad = Operon::Serialization::CheckpointFromBeve(beve);
     CHECK(bad.Population.empty());
 }
 
-TEST_CASE("ResumeFromCheckpoint throws on WorkerRngStates size mismatch", "[serialization]")
+TEST_CASE("Checkpoint BEVE rejects wrong version", "[serialization]")
 {
-    // Verify that CheckpointProxy validation catches a corrupt/mismatched
-    // WorkerRngStates vector without needing to wire up a full algorithm.
+    Operon::RandomGenerator rng(3);
+    Operon::Serialization::Checkpoint cp;
+    cp.RngState   = rng.state();
+    cp.Generation = 0; // keep 0 so \x01\x00\x00\x00 uniquely identifies version
+    cp.Population.resize(2);
+    for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
+
+    auto beve = Operon::Serialization::ToBeve(cp);
+    REQUIRE(!beve.empty());
+
+    // Magic is at some position; version=1 (LE: 01 00 00 00) follows it.
+    // Search starting after the magic bytes so we land on the version value.
+    constexpr std::array<char, 4> MagicLE{ '\x4B', '\x43', '\x50', '\x4F' };
+    auto magicIt = std::search(beve.begin(), beve.end(), MagicLE.begin(), MagicLE.end());
+    REQUIRE(magicIt != beve.end());
+
+    constexpr std::array<char, 4> VersionLE{ '\x01', '\x00', '\x00', '\x00' };
+    auto versionIt = std::search(magicIt + 4, beve.end(), VersionLE.begin(), VersionLE.end());
+    REQUIRE(versionIt != beve.end());
+    *versionIt = static_cast<char>(0x02); // bump version to 2
+
+    auto bad = Operon::Serialization::CheckpointFromBeve(beve);
+    CHECK(bad.Population.empty());
+}
+
+TEST_CASE("Checkpoint BEVE preserves WorkerRngStates for CLI validation", "[serialization]")
+{
+    // The size-mismatch check lives in the CLI layer (ResumeFromCheckpoint),
+    // not in the serialization layer.  Verify the payload survives the BEVE
+    // round-trip intact so the CLI check can fire on the correct values.
     Operon::RandomGenerator rng(5);
     Operon::Serialization::Checkpoint cp;
     cp.RngState   = rng.state();
     cp.Generation = 2;
     cp.Population.resize(4);
     for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
-    // Put 3 worker states where 4 would be expected (max of popSize/poolSize).
-    cp.WorkerRngStates.resize(3);
+    cp.WorkerRngStates.resize(3); // intentionally mismatched (3 vs popSize 4)
     for (auto& s : cp.WorkerRngStates) { s = rng.state(); }
 
-    // Round-trip through BEVE so we have a realistic serialized payload.
     auto beve     = Operon::Serialization::ToBeve(cp);
     auto restored = Operon::Serialization::CheckpointFromBeve(beve);
-    // The deserialization itself succeeds; the size-mismatch check is in
-    // the CLI layer (ResumeFromCheckpoint).  Here we verify the payload is
-    // faithfully preserved so the CLI check can fire correctly.
     CHECK(restored.WorkerRngStates.size() == 3);
     CHECK(restored.Population.size() == 4);
 }

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "operon/core/individual.hpp"
+#include "operon/core/pset.hpp"
+#include "operon/core/serialization.hpp"
+#include "operon/core/types.hpp"
+#include "operon/operators/creator.hpp"
+#include "operon/operators/initializer.hpp"
+
+namespace Operon::Test {
+namespace {
+
+// Minimal variable hash used across all tree-building helpers.
+static constexpr Operon::Hash VarHash = 1234567890ULL;
+
+auto MakeTree(Operon::RandomGenerator& rng) -> Operon::Tree
+{
+    Operon::PrimitiveSet pset;
+    pset.SetConfig(PrimitiveSet::Arithmetic);
+    std::vector<Operon::Hash> vars{ VarHash };
+    Operon::BalancedTreeCreator creator{ &pset, vars, /*bias=*/0.0, /*maxLength=*/20 };
+    Operon::UniformTreeInitializer treeInit(&creator);
+    treeInit.ParameterizeDistribution(5UL, 20UL);
+    treeInit.SetMaxDepth(6);
+    Operon::UniformCoefficientInitializer coeffInit;
+    coeffInit.ParameterizeDistribution(Operon::Scalar{-5}, Operon::Scalar{+5});
+    auto tree = treeInit(rng);
+    coeffInit(rng, tree);
+    return tree;
+}
+
+auto MakeIndividual(Operon::RandomGenerator& rng, std::size_t nObjectives = 2) -> Operon::Individual
+{
+    Operon::Individual ind;
+    ind.Genotype = MakeTree(rng);
+    ind.Fitness.resize(nObjectives);
+    std::uniform_real_distribution<Operon::Scalar> dist{-1, 1};
+    for (auto& f : ind.Fitness) { f = dist(rng); }
+    ind.Rank     = 0;
+    ind.Distance = Operon::Scalar{1};
+    return ind;
+}
+
+auto TreesEqual(Operon::Tree const& a, Operon::Tree const& b) -> bool
+{
+    if (a.Length() != b.Length()) { return false; }
+    for (std::size_t i = 0; i < a.Length(); ++i) {
+        auto const& na = a[i];
+        auto const& nb = b[i];
+        if (na.Type      != nb.Type)      { return false; }
+        if (na.HashValue != nb.HashValue) { return false; }
+        if (na.IsEnabled != nb.IsEnabled) { return false; }
+        if (na.Optimize  != nb.Optimize)  { return false; }
+        if (na.RefTo     != nb.RefTo)     { return false; }
+        if (std::abs(na.Value - nb.Value) > Operon::Scalar{1e-6}) { return false; }
+    }
+    return true;
+}
+
+auto IndividualsEqual(Operon::Individual const& a, Operon::Individual const& b) -> bool
+{
+    if (!TreesEqual(a.Genotype, b.Genotype))       { return false; }
+    if (a.Fitness.size() != b.Fitness.size())      { return false; }
+    for (std::size_t i = 0; i < a.Fitness.size(); ++i) {
+        if (std::abs(a.Fitness[i] - b.Fitness[i]) > Operon::Scalar{1e-6}) { return false; }
+    }
+    return a.Rank == b.Rank && std::abs(a.Distance - b.Distance) < Operon::Scalar{1e-6};
+}
+
+} // namespace
+
+TEST_CASE("Tree JSON round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(42);
+    for (auto i = 0; i < 20; ++i) {
+        auto original = MakeTree(rng);
+        auto json     = Operon::Serialization::ToJson(original);
+        auto restored = Operon::Serialization::TreeFromJson(json);
+        CHECK(TreesEqual(original, restored));
+    }
+}
+
+TEST_CASE("Individual JSON round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(42);
+    for (auto i = 0; i < 20; ++i) {
+        auto original = MakeIndividual(rng);
+        auto json     = Operon::Serialization::ToJson(original);
+        auto restored = Operon::Serialization::IndividualFromJson(json);
+        CHECK(IndividualsEqual(original, restored));
+    }
+}
+
+TEST_CASE("Pareto front JSON round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(42);
+    Operon::Vector<Operon::Individual> front(10);
+    for (auto& ind : front) { ind = MakeIndividual(rng); }
+
+    auto json = Operon::Serialization::ToJson(std::span<Operon::Individual const>(front));
+    CHECK(!json.empty());
+    CHECK(json.front() == '[');
+
+    for (auto const& original : front) {
+        auto elemJson = Operon::Serialization::ToJson(original);
+        auto restored = Operon::Serialization::IndividualFromJson(elemJson);
+        CHECK(IndividualsEqual(original, restored));
+    }
+}
+
+TEST_CASE("Tree BEVE round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(42);
+    for (auto i = 0; i < 20; ++i) {
+        auto original = MakeTree(rng);
+        auto beve     = Operon::Serialization::ToBeve(original);
+        auto restored = Operon::Serialization::TreeFromBeve(beve);
+        CHECK(TreesEqual(original, restored));
+    }
+}
+
+TEST_CASE("Individual BEVE round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(42);
+    for (auto i = 0; i < 20; ++i) {
+        auto original = MakeIndividual(rng);
+        auto beve     = Operon::Serialization::ToBeve(original);
+        auto restored = Operon::Serialization::IndividualFromBeve(beve);
+        CHECK(IndividualsEqual(original, restored));
+    }
+}
+
+TEST_CASE("Checkpoint BEVE round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(99);
+    for (auto i = 0; i < 1000; ++i) { (void)rng(); }
+
+    Operon::Serialization::Checkpoint original;
+    original.RngState   = rng.state();
+    original.Generation = 42;
+    original.Population.resize(50);
+    for (auto& ind : original.Population) { ind = MakeIndividual(rng); }
+
+    auto beve     = Operon::Serialization::ToBeve(original);
+    auto restored = Operon::Serialization::CheckpointFromBeve(beve);
+
+    CHECK(restored.RngState   == original.RngState);
+    CHECK(restored.Generation == original.Generation);
+    REQUIRE(restored.Population.size() == original.Population.size());
+    for (std::size_t i = 0; i < original.Population.size(); ++i) {
+        CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+    }
+}
+
+TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
+{
+    Operon::RandomGenerator rng(7);
+    for (auto i = 0; i < 500; ++i) { (void)rng(); }
+
+    Operon::Serialization::Checkpoint original;
+    original.RngState   = rng.state();
+    original.Generation = 10;
+    original.Population.resize(20);
+    for (auto& ind : original.Population) { ind = MakeIndividual(rng); }
+
+    auto const path = std::string{"/tmp/operon_test_checkpoint.beve"};
+    Operon::Serialization::SaveCheckpoint(original, path);
+    auto restored = Operon::Serialization::LoadCheckpoint(path);
+
+    CHECK(restored.RngState   == original.RngState);
+    CHECK(restored.Generation == original.Generation);
+    REQUIRE(restored.Population.size() == original.Population.size());
+    for (std::size_t i = 0; i < original.Population.size(); ++i) {
+        CHECK(IndividualsEqual(original.Population[i], restored.Population[i]));
+    }
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -21,7 +21,7 @@ namespace Operon::Test {
 namespace {
 
 // Minimal variable hash used across all tree-building helpers.
-static constexpr Operon::Hash VarHash = 1234567890ULL;
+constexpr Operon::Hash VarHash = 1234567890ULL;
 
 auto MakeTree(Operon::RandomGenerator& rng) -> Operon::Tree
 {
@@ -201,6 +201,53 @@ TEST_CASE("Checkpoint file save/load round-trip", "[serialization]")
     for (std::size_t i = 0; i < original.WorkerRngStates.size(); ++i) {
         CHECK(restored.WorkerRngStates[i] == original.WorkerRngStates[i]);
     }
+}
+
+TEST_CASE("Checkpoint BEVE rejects wrong magic/version", "[serialization]")
+{
+    Operon::RandomGenerator rng(3);
+    Operon::Serialization::Checkpoint cp;
+    cp.RngState   = rng.state();
+    cp.Generation = 1;
+    cp.Population.resize(2);
+    for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
+
+    auto beve = Operon::Serialization::ToBeve(cp);
+    REQUIRE(!beve.empty());
+
+    // Corrupt the first 4 bytes (magic field) and verify graceful failure.
+    // The corrupted bytes produce a non-zero but wrong magic value; FromProxy
+    // should return an empty Checkpoint (Population.empty()).
+    beve[0] = static_cast<char>(0xDE);
+    beve[1] = static_cast<char>(0xAD);
+    beve[2] = static_cast<char>(0xBE);
+    beve[3] = static_cast<char>(0xEF);
+    auto bad = Operon::Serialization::CheckpointFromBeve(beve);
+    CHECK(bad.Population.empty());
+}
+
+TEST_CASE("ResumeFromCheckpoint throws on WorkerRngStates size mismatch", "[serialization]")
+{
+    // Verify that CheckpointProxy validation catches a corrupt/mismatched
+    // WorkerRngStates vector without needing to wire up a full algorithm.
+    Operon::RandomGenerator rng(5);
+    Operon::Serialization::Checkpoint cp;
+    cp.RngState   = rng.state();
+    cp.Generation = 2;
+    cp.Population.resize(4);
+    for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
+    // Put 3 worker states where 4 would be expected (max of popSize/poolSize).
+    cp.WorkerRngStates.resize(3);
+    for (auto& s : cp.WorkerRngStates) { s = rng.state(); }
+
+    // Round-trip through BEVE so we have a realistic serialized payload.
+    auto beve     = Operon::Serialization::ToBeve(cp);
+    auto restored = Operon::Serialization::CheckpointFromBeve(beve);
+    // The deserialization itself succeeds; the size-mismatch check is in
+    // the CLI layer (ResumeFromCheckpoint).  Here we verify the payload is
+    // faithfully preserved so the CLI check can fire correctly.
+    CHECK(restored.WorkerRngStates.size() == 3);
+    CHECK(restored.Population.size() == 4);
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -280,4 +280,49 @@ TEST_CASE("Checkpoint BEVE preserves WorkerRngStates for CLI validation", "[seri
     CHECK(restored.Population.size() == 4);
 }
 
+TEST_CASE("TreeFromJson returns empty tree for empty node list", "[serialization]")
+{
+    // Previously: UB crash via UpdateNodes() touching nodes_.back() on empty vector.
+    auto tree = Operon::Serialization::TreeFromJson(R"({"nodes":[]})");
+    CHECK(tree.Length() == 0);
+}
+
+TEST_CASE("TreeFromBeve returns empty tree for empty node list", "[serialization]")
+{
+    // A default-constructed Tree serializes with an empty node array; deserializing
+    // it must return a zero-length tree, not crash via UpdateNodes() on nodes_.back().
+    Operon::Tree emptyTree;
+    auto beve     = Operon::Serialization::ToBeve(emptyTree);
+    auto restored = Operon::Serialization::TreeFromBeve(beve);
+    CHECK(restored.Length() == 0);
+}
+
+TEST_CASE("SaveCheckpoint is crash-safe: second save overwrites first", "[serialization]")
+{
+    Operon::RandomGenerator rng(11);
+
+    auto makeCp = [&](std::size_t gen) {
+        Operon::Serialization::Checkpoint cp;
+        cp.RngState   = rng.state();
+        cp.Generation = gen;
+        cp.Population.resize(4);
+        for (auto& ind : cp.Population) { ind = MakeIndividual(rng); }
+        return cp;
+    };
+
+    auto const path = (std::filesystem::temp_directory_path() / "operon_test_overwrite.beve").string();
+
+    auto first  = makeCp(1);
+    auto second = makeCp(2);
+
+    Operon::Serialization::SaveCheckpoint(first, path);
+    Operon::Serialization::SaveCheckpoint(second, path);
+
+    auto restored = Operon::Serialization::LoadCheckpoint(path);
+    CHECK(restored.Generation == 2);
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}
+
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary

- **glaze** added to flake and `operon.nix` (SSL disabled via `override { enableSSL = false; }`; C++23 isolated to `serialization.cpp` via per-source `COMPILE_OPTIONS`, rest of project stays C++20)
- **fluky** updated: `state()`/`set_state()` + `jump()`/`long_jump()` for `splitmix64` and `pcg64_dxsm`, `jumpable_rng` concept
- **JSON serialization** (`ToJson`/`TreeFromJson`/`IndividualFromJson`) for `Tree`, `Individual`, and Pareto front — glaze kept entirely out of public headers
- **BEVE serialization** (`ToBeve`/`TreeFromBeve`/`IndividualFromBeve`) — same proxy machinery, binary format
- **Checkpoint** struct (`RngState`, `Generation`, `Population`, `WorkerRngStates`) with BEVE save/load; per-thread worker RNG states moved from local in `Run()` to `GeneticAlgorithmBase::workerRngs_` so resumed runs are bit-exact from the checkpoint forward
- **CLI**: `--checkpoint-interval N`, `--checkpoint-file PATH`, `--resume PATH` added to both `operon_gp` and `operon_nsgp`
- **7 test cases** (182 assertions) covering JSON and BEVE round-trips for Tree, Individual, Pareto front, Checkpoint in-memory, and Checkpoint file save/load

## Out of scope (deferred)

- Phase 3: generational log (append-only BEVE stream per generation)
- Phase 4: genealogy graph (requires parent tracking in `Individual`)

## Test plan

- [ ] `operon_test "[serialization]"` — all 7 cases pass
- [ ] `operon_gp ... --checkpoint-interval 10 --checkpoint-file cp.beve` produces a file after 10 generations
- [ ] `operon_gp ... --resume cp.beve` picks up at the saved generation with identical RNG state