### PR TITLE
Add JacRevVariable/JacFwdVariable for per-variable derivatives

### DIFF
--- a/include/operon/interpreter/interpreter.hpp
+++ b/include/operon/interpreter/interpreter.hpp
@@ -98,11 +98,19 @@ struct Interpreter : public InterpreterBase<T> {
         trace_ = Backend::Buffer<T, S>(S, nn);
         Backend::Fill<T, S>(trace_, nn-1, T{1});
 
+        std::size_t j = 0;
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoColumn; });
+
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(jacobian.data(), len, coeff.size());
+        // No zero-init needed: each Optimize node maps to a unique column
+        // (built via BuildColumns above), so every column is written
+        // exactly once (Accumulate=false, plain `=`).
 
         for (auto row = 0L; row < len; row += S) {
             ForwardPass(range, row, /*trace=*/true);
-            ReverseTrace(range, row, jac);
+            ReverseTraceGeneric<false>(range, row, cols.colOf,
+                [](std::size_t i, auto const& primal, T w) { return primal.col(static_cast<Eigen::Index>(i)) / w; },
+                jac);
         }
     }
 
@@ -122,11 +130,17 @@ struct Interpreter : public InterpreterBase<T> {
         trace_ = Backend::Buffer<T, BatchSize>(BatchSize, nNodes);
         Backend::Fill<T, BatchSize>(trace_, nNodes-1, T{1});
 
+        std::size_t j = 0;
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoColumn; });
+
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(jacobian.data(), nRows, coeff.size());
+        // No zero-init needed — see JacRev.
 
         for (int row = 0; row < nRows; row += BatchSize) {
             ForwardPass(range, row, /*trace=*/true);
-            ForwardTrace(range, row, jac);
+            ForwardTraceGeneric<false>(range, row, cols.seeds,
+                [](std::size_t i, auto const& primal, T w) { return primal.col(static_cast<Eigen::Index>(i)) / w; },
+                jac);
         }
     }
 
@@ -135,6 +149,71 @@ struct Interpreter : public InterpreterBase<T> {
         Eigen::Array<T, -1, -1> jacobian(nRows, coeff.size());
         JacFwd(coeff, range, { jacobian.data(), static_cast<size_t>(jacobian.size()) });
         return jacobian;
+    }
+
+    // Reverse-mode derivative of the tree output w.r.t. the raw value of
+    // one input Variable (identified by hash), summed over every
+    // occurrence of that variable in the tree via the multivariate chain
+    // rule. Complements JacRev, which differentiates w.r.t. Node::Optimize
+    // coefficients (weights) rather than variable values — same underlying
+    // adjoint sweep (ReverseTraceGeneric), different extraction point.
+    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void {
+        InitContext(coeff, range);
+        auto const len{ static_cast<int64_t>(range.Size()) };
+        auto const& nodes = tree_->Nodes();
+        auto const nn { std::ssize(nodes) };
+
+        constexpr int64_t S{ BatchSize };
+        trace_ = Backend::Buffer<T, S>(S, nn);
+        Backend::Fill<T, S>(trace_, nn-1, T{1});
+
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoColumn; });
+
+        Eigen::Map<Eigen::Array<T, -1, -1>> jac(result.data(), len, 1);
+        jac.setZero(); // needed: multiple occurrences of `variable` can share column 0 (Accumulate=true) — cheap, single-column buffer
+
+        for (auto row = 0L; row < len; row += S) {
+            ForwardPass(range, row, /*trace=*/true);
+            ReverseTraceGeneric<true>(range, row, cols.colOf,
+                [](std::size_t /*i*/, auto const& /*primal*/, T w) { return Eigen::Array<T, S, 1>::Constant(w); },
+                jac);
+        }
+    }
+
+    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> {
+        Operon::Vector<T> result(range.Size());
+        JacRevVariable(coeff, range, variable, { result.data(), result.size() });
+        return result;
+    }
+
+    // Forward-mode counterpart to JacRevVariable — same relationship as
+    // JacFwd has to JacRev.
+    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void {
+        InitContext(coeff, range);
+        auto const& nodes = tree_->Nodes();
+        auto const nNodes = std::ssize(nodes);
+        auto const nRows  = static_cast<int>(range.Size());
+
+        trace_ = Backend::Buffer<T, BatchSize>(BatchSize, nNodes);
+        Backend::Fill<T, BatchSize>(trace_, nNodes-1, T{1});
+
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoColumn; });
+
+        Eigen::Map<Eigen::Array<T, -1, -1>> jac(result.data(), nRows, 1);
+        jac.setZero(); // needed — see JacRevVariable
+
+        for (int row = 0; row < nRows; row += BatchSize) {
+            ForwardPass(range, row, /*trace=*/true);
+            ForwardTraceGeneric<true>(range, row, cols.seeds,
+                [](std::size_t /*i*/, auto const& /*primal*/, T w) { return Eigen::Array<T, BatchSize, 1>::Constant(w); },
+                jac);
+        }
+    }
+
+    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> {
+        Operon::Vector<T> result(range.Size());
+        JacFwdVariable(coeff, range, variable, { result.data(), result.size() });
+        return result;
     }
 
     // Evaluate the full tree and extract values at multiple node indices.
@@ -248,7 +327,50 @@ private:
         }
     }
 
-    auto ForwardTrace(Operon::Range range, int row, Eigen::Ref<Eigen::Array<T, -1, -1>> jac) const -> void {
+    // Sentinel meaning "this node doesn't contribute to any output column",
+    // used by BuildColumns/*TraceGeneric below.
+    static constexpr std::size_t NoColumn = std::numeric_limits<std::size_t>::max();
+
+    // Built once per JacRev/JacFwd/JacRevVariable/JacFwdVariable call (not
+    // per row-batch — it only depends on tree structure, not on which rows
+    // are being processed): `colOf[i]` is the output column node i
+    // contributes to, or NoColumn — used by ReverseTraceGeneric, which
+    // visits every node anyway so an O(1) lookup is free. `seeds` is the
+    // compact list of (node, column) pairs with colOf[i] != NoColumn — used
+    // by ForwardTraceGeneric, which should only iterate actual targets
+    // instead of scanning every node in the tree.
+    struct Columns {
+        Operon::Vector<std::size_t> colOf;
+        Operon::Vector<std::pair<std::size_t, std::size_t>> seeds;
+    };
+
+    template <typename Predicate>
+    auto BuildColumns(Predicate predicate) const -> Columns {
+        auto const nNodes = static_cast<std::size_t>(tree_->Nodes().size());
+        Columns cols;
+        cols.colOf.assign(nNodes, NoColumn);
+        for (std::size_t i = 0; i < nNodes; ++i) {
+            if (auto const col = predicate(i); col != NoColumn) {
+                cols.colOf[i] = col;
+                cols.seeds.emplace_back(i, col);
+            }
+        }
+        return cols;
+    }
+
+    // Shared forward-mode sweep behind JacFwd/JacFwdVariable. `seeds`: the
+    // (node, column) pairs to seed-and-propagate (see BuildColumns).
+    // `factor(i, primal, w)`: the local d(primal_i)/d(target) multiplier
+    // converting the node's root-adjoint into the derivative w.r.t.
+    // whatever `target` is for this call (a coefficient's weight, or a
+    // variable's raw value) — e.g. primal_i/w for a coefficient target
+    // (primal_i = w * x_i), or w for a variable target. `Accumulate`:
+    // false writes `=` (the coefficient case — each column has exactly one
+    // contributing node, so no zero-init is needed by the caller); true
+    // writes `+=` (the variable case, where multiple nodes/occurrences can
+    // share one column — caller must zero-init `jac` first).
+    template <bool Accumulate, typename LocalFactor>
+    auto ForwardTraceGeneric(Operon::Range range, int row, Operon::Vector<std::pair<std::size_t, std::size_t>> const& seeds, LocalFactor factor, Eigen::Ref<Eigen::Array<T, -1, -1>> jac) const -> void {
         auto const rangeSize     = static_cast<int64_t>(range.Size());
         auto const& nodes        = tree_->Nodes();
         auto const nNodes        = std::ssize(nodes);
@@ -256,19 +378,15 @@ private:
         auto const remainingRows = std::min(S, rangeSize - row);
 
         Eigen::Array<T, S, -1> dot(S, nNodes);
-        Operon::Vector<int64_t> cidx(jac.cols());
 
         Eigen::Map<Eigen::Array<T, S, -1>> primal(primal_.data(), S, nNodes);
         Eigen::Map<Eigen::Array<T, S, -1>> trace(trace_.data(), S, nNodes);
 
-        for (auto i = 0L, j = 0L; i < nNodes; ++i) {
-            if (nodes[i].Optimize) { cidx[j++] = i; }
-        }
+        for (auto const& [c, col] : seeds) {
+            auto const cc = static_cast<int64_t>(c);
 
-        auto k{0};
-        for (auto c : cidx) {
             dot.topRows(remainingRows).setConstant(T{0});
-            dot.col(c).head(remainingRows).setConstant(T{1});
+            dot.col(cc).head(remainingRows).setConstant(T{1});
 
             for (auto i = 0; i < nNodes; ++i) {
                 if (nodes[i].IsRef()) {
@@ -279,31 +397,49 @@ private:
                 if (nodes[i].IsLeaf()) { continue; }
                 for (auto x : Tree::Indices(nodes, i)) {
                     auto j{ static_cast<int64_t>(x) };
-                    if (nodes[j].IsLeaf() && j != c) { continue; }
+                    if (nodes[j].IsLeaf() && j != cc) { continue; }
                     dot.col(i).head(remainingRows) += dot.col(j).head(remainingRows) * trace.col(j).head(remainingRows) * std::get<0>(context_[i]);
                 }
             }
 
-            jac.col(k++).segment(row, remainingRows) = dot.col(nNodes-1).head(remainingRows) * primal.col(c).head(remainingRows) / std::get<0>(context_[c]);
+            auto const w = std::get<0>(context_[c]);
+            auto const contribution = dot.col(nNodes-1).head(remainingRows) * factor(c, primal, w).head(remainingRows);
+            if constexpr (Accumulate) {
+                jac.col(static_cast<Eigen::Index>(col)).segment(row, remainingRows) += contribution;
+            } else {
+                jac.col(static_cast<Eigen::Index>(col)).segment(row, remainingRows) = contribution;
+            }
         }
     }
 
-    auto ReverseTrace(Operon::Range range, int row, Eigen::Ref<Eigen::Array<T, -1, -1>> jac) const -> void {
+    // Shared reverse-mode sweep behind JacRev/JacRevVariable — see
+    // ForwardTraceGeneric above for the `factor`/`Accumulate` contract.
+    // `colOf`: per-node column lookup (see BuildColumns). One backward pass
+    // computes every node's root-adjoint regardless of how many columns are
+    // extracted, unlike the forward-mode sweep above (one seeded pass per
+    // column) — this is why reverse mode is preferred when there are many
+    // targets (JacRev vs JacFwd for coefficients).
+    template <bool Accumulate, typename LocalFactor>
+    auto ReverseTraceGeneric(Operon::Range range, int row, Operon::Vector<std::size_t> const& colOf, LocalFactor factor, Eigen::Ref<Eigen::Array<T, -1, -1>> jac) const -> void {
         auto const rangeSize     = static_cast<int64_t>(range.Size());
         auto const& nodes        = tree_->Nodes();
         auto const nNodes        = std::ssize(nodes);
         constexpr int64_t S      = BatchSize;
         auto const remainingRows = std::min(S, rangeSize - row);
 
-        auto k{jac.cols()};
         Eigen::Map<Eigen::Array<T, S, -1>> primal(primal_.data(), S, nNodes);
         Eigen::Map<Eigen::Array<T, S, -1>> trace(trace_.data(), S, nNodes);
 
         for (auto i = nNodes-1; i >= 0L; --i) {
             auto w = std::get<0>(context_[i]);
 
-            if (nodes[i].Optimize) {
-                jac.col(--k).segment(row, remainingRows) = trace.col(i).head(remainingRows) * primal.col(i).head(remainingRows) / w;
+            if (auto const col = colOf[static_cast<std::size_t>(i)]; col != NoColumn) {
+                auto const contribution = trace.col(i).head(remainingRows) * factor(static_cast<std::size_t>(i), primal, w).head(remainingRows);
+                if constexpr (Accumulate) {
+                    jac.col(static_cast<Eigen::Index>(col)).segment(row, remainingRows) += contribution;
+                } else {
+                    jac.col(static_cast<Eigen::Index>(col)).segment(row, remainingRows) = contribution;
+                }
             }
 
             if (nodes[i].IsRef()) {
@@ -321,6 +457,7 @@ private:
             }
         }
     }
+
 
     // Full bind: allocate primal_, build context_ with function/derivative pointers
     // and variable data spans. Called once per unique (tree, range) pair.

--- a/include/operon/interpreter/interpreter.hpp
+++ b/include/operon/interpreter/interpreter.hpp
@@ -44,6 +44,16 @@ struct InterpreterBase {
     virtual auto JacFwd(Operon::Span<T const> coeff, Operon::Range range, Operon::Span<T> jacobian) const -> void = 0;
     virtual auto JacFwd(Operon::Span<T const> coeff, Operon::Range range) const -> Eigen::Array<T, -1, -1> = 0;
 
+    // evaluate model derivative w.r.t. a single input variable's raw value
+    // (identified by hash), summed over every occurrence of that variable
+    // in the tree — reverse mode
+    virtual auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void = 0;
+    virtual auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> = 0;
+
+    // same as above, forward mode
+    virtual auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void = 0;
+    virtual auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> = 0;
+
     // getters
     [[nodiscard]] virtual auto GetTree() const -> Operon::Tree const* = 0;
     [[nodiscard]] virtual auto GetDataset() const -> Operon::Dataset const* = 0;
@@ -99,7 +109,7 @@ struct Interpreter : public InterpreterBase<T> {
         Backend::Fill<T, S>(trace_, nn-1, T{1});
 
         std::size_t j = 0;
-        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoColumn; });
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoIndex; });
 
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(jacobian.data(), len, coeff.size());
         // No zero-init needed: each Optimize node maps to a unique column
@@ -131,7 +141,7 @@ struct Interpreter : public InterpreterBase<T> {
         Backend::Fill<T, BatchSize>(trace_, nNodes-1, T{1});
 
         std::size_t j = 0;
-        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoColumn; });
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return nodes[i].Optimize ? j++ : NoIndex; });
 
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(jacobian.data(), nRows, coeff.size());
         // No zero-init needed — see JacRev.
@@ -157,7 +167,7 @@ struct Interpreter : public InterpreterBase<T> {
     // rule. Complements JacRev, which differentiates w.r.t. Node::Optimize
     // coefficients (weights) rather than variable values — same underlying
     // adjoint sweep (ReverseTraceGeneric), different extraction point.
-    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void {
+    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void final {
         InitContext(coeff, range);
         auto const len{ static_cast<int64_t>(range.Size()) };
         auto const& nodes = tree_->Nodes();
@@ -167,7 +177,7 @@ struct Interpreter : public InterpreterBase<T> {
         trace_ = Backend::Buffer<T, S>(S, nn);
         Backend::Fill<T, S>(trace_, nn-1, T{1});
 
-        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoColumn; });
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoIndex; });
 
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(result.data(), len, 1);
         jac.setZero(); // needed: multiple occurrences of `variable` can share column 0 (Accumulate=true) — cheap, single-column buffer
@@ -180,7 +190,7 @@ struct Interpreter : public InterpreterBase<T> {
         }
     }
 
-    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> {
+    auto JacRevVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> final {
         Operon::Vector<T> result(range.Size());
         JacRevVariable(coeff, range, variable, { result.data(), result.size() });
         return result;
@@ -188,7 +198,7 @@ struct Interpreter : public InterpreterBase<T> {
 
     // Forward-mode counterpart to JacRevVariable — same relationship as
     // JacFwd has to JacRev.
-    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void {
+    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable, Operon::Span<T> result) const -> void final {
         InitContext(coeff, range);
         auto const& nodes = tree_->Nodes();
         auto const nNodes = std::ssize(nodes);
@@ -197,7 +207,7 @@ struct Interpreter : public InterpreterBase<T> {
         trace_ = Backend::Buffer<T, BatchSize>(BatchSize, nNodes);
         Backend::Fill<T, BatchSize>(trace_, nNodes-1, T{1});
 
-        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoColumn; });
+        auto const cols = BuildColumns([&](std::size_t i) -> std::size_t { return (nodes[i].IsVariable() && nodes[i].HashValue == variable) ? 0 : NoIndex; });
 
         Eigen::Map<Eigen::Array<T, -1, -1>> jac(result.data(), nRows, 1);
         jac.setZero(); // needed — see JacRevVariable
@@ -210,7 +220,7 @@ struct Interpreter : public InterpreterBase<T> {
         }
     }
 
-    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> {
+    auto JacFwdVariable(Operon::Span<T const> coeff, Operon::Range range, Operon::Hash variable) const -> Operon::Vector<T> final {
         Operon::Vector<T> result(range.Size());
         JacFwdVariable(coeff, range, variable, { result.data(), result.size() });
         return result;
@@ -226,25 +236,24 @@ struct Interpreter : public InterpreterBase<T> {
         auto const len    = static_cast<int64_t>(range.Size());
         auto const nRoots = static_cast<Eigen::Index>(roots.size());
         constexpr int64_t S = BatchSize;
-        constexpr auto NoRoot = std::numeric_limits<std::size_t>::max();
 
         // Not zero-initialized: every row is written exactly once by the
-        // batch loop below; NoRoot columns are zeroed explicitly.
+        // batch loop below; NoIndex columns are zeroed explicitly.
         Eigen::Array<T, -1, -1> result(len, nRoots);
         for (Eigen::Index k = 0; k < nRoots; ++k) {
-            if (roots[k] == NoRoot) { result.col(k).setZero(); }
+            if (roots[k] == NoIndex) { result.col(k).setZero(); }
         }
 
         auto const nNodes = static_cast<std::size_t>(tree_->Nodes().size());
         for (Eigen::Index k = 0; k < nRoots; ++k) {
-            EXPECT(roots[k] == NoRoot || roots[k] < nNodes);
+            EXPECT(roots[k] == NoIndex || roots[k] < nNodes);
         }
 
         for (auto row = 0L; row < len; row += S) {
             ForwardPass(range, row, /*trace=*/false);
             auto const rem = std::min(S, len - row);
             for (Eigen::Index k = 0; k < nRoots; ++k) {
-                if (roots[k] == NoRoot) { continue; }
+                if (roots[k] == NoIndex) { continue; }
                 auto const* src = primal_.data() + (static_cast<int64_t>(roots[k]) * S);
                 std::copy_n(src, rem, result.col(k).data() + row);
             }
@@ -327,16 +336,18 @@ private:
         }
     }
 
-    // Sentinel meaning "this node doesn't contribute to any output column",
-    // used by BuildColumns/*TraceGeneric below.
-    static constexpr std::size_t NoColumn = std::numeric_limits<std::size_t>::max();
+    // Sentinel meaning "no such node/column/root index" — used both by
+    // BuildColumns/*TraceGeneric below (a node not contributing to any
+    // output column) and by EvaluateRoots (a root slot that should be
+    // zero-filled instead of extracted).
+    static constexpr std::size_t NoIndex = std::numeric_limits<std::size_t>::max();
 
     // Built once per JacRev/JacFwd/JacRevVariable/JacFwdVariable call (not
     // per row-batch — it only depends on tree structure, not on which rows
     // are being processed): `colOf[i]` is the output column node i
-    // contributes to, or NoColumn — used by ReverseTraceGeneric, which
+    // contributes to, or NoIndex — used by ReverseTraceGeneric, which
     // visits every node anyway so an O(1) lookup is free. `seeds` is the
-    // compact list of (node, column) pairs with colOf[i] != NoColumn — used
+    // compact list of (node, column) pairs with colOf[i] != NoIndex — used
     // by ForwardTraceGeneric, which should only iterate actual targets
     // instead of scanning every node in the tree.
     struct Columns {
@@ -348,9 +359,9 @@ private:
     auto BuildColumns(Predicate predicate) const -> Columns {
         auto const nNodes = static_cast<std::size_t>(tree_->Nodes().size());
         Columns cols;
-        cols.colOf.assign(nNodes, NoColumn);
+        cols.colOf.assign(nNodes, NoIndex);
         for (std::size_t i = 0; i < nNodes; ++i) {
-            if (auto const col = predicate(i); col != NoColumn) {
+            if (auto const col = predicate(i); col != NoIndex) {
                 cols.colOf[i] = col;
                 cols.seeds.emplace_back(i, col);
             }
@@ -397,7 +408,12 @@ private:
                 if (nodes[i].IsLeaf()) { continue; }
                 for (auto x : Tree::Indices(nodes, i)) {
                     auto j{ static_cast<int64_t>(x) };
-                    if (nodes[j].IsLeaf() && j != cc) { continue; }
+                    // A leaf child other than the seeded node cc has a zero
+                    // tangent and can be skipped — except a Ref, which is a
+                    // leaf by arity but an alias: its dot was already copied
+                    // from its (possibly seeded) target above and must not
+                    // be dropped just because j != cc.
+                    if (nodes[j].IsLeaf() && !nodes[j].IsRef() && j != cc) { continue; }
                     dot.col(i).head(remainingRows) += dot.col(j).head(remainingRows) * trace.col(j).head(remainingRows) * std::get<0>(context_[i]);
                 }
             }
@@ -433,7 +449,7 @@ private:
         for (auto i = nNodes-1; i >= 0L; --i) {
             auto w = std::get<0>(context_[i]);
 
-            if (auto const col = colOf[static_cast<std::size_t>(i)]; col != NoColumn) {
+            if (auto const col = colOf[static_cast<std::size_t>(i)]; col != NoIndex) {
                 auto const contribution = trace.col(i).head(remainingRows) * factor(static_cast<std::size_t>(i), primal, w).head(remainingRows);
                 if constexpr (Accumulate) {
                     jac.col(static_cast<Eigen::Index>(col)).segment(row, remainingRows) += contribution;
@@ -457,7 +473,6 @@ private:
             }
         }
     }
-
 
     // Full bind: allocate primal_, build context_ with function/derivative pointers
     // and variable data spans. Called once per unique (tree, range) pair.

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -3,7 +3,9 @@
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 
+#include <cmath>
 #include <random>
 
 #include "../operon_test.hpp"
@@ -138,6 +140,84 @@ TEST_CASE("Autodiff forward vs reverse consistency", "[autodiff]")
     constexpr auto maxDivergeRate{0.02};
     CHECK(finiteMismatch == 0);
     CHECK(static_cast<double>(finiteDiverge) / static_cast<double>(total) < maxDivergeRate);
+}
+
+TEST_CASE("Autodiff variable-wise derivative", "[autodiff]")
+{
+    Operon::Dataset ds(std::vector<std::string>{"x", "y"},
+                       std::vector<std::vector<Operon::Scalar>>{{1.3F, -0.6F, 2.0F}, {0.4F, 1.1F, -0.9F}});
+    Operon::DispatchTable<Operon::Scalar> dtable;
+    Operon::Range const range{0, ds.Rows<std::size_t>()};
+    auto const xHash = ds.GetVariable("x")->Hash;
+    auto const yHash = ds.GetVariable("y")->Hash;
+
+    // JacRevVariable/JacFwdVariable against hand-derived analytic derivatives.
+    auto checkAnalytic = [&](std::string const& expr, Operon::Hash variable, auto analytic) -> void {
+        auto tree = Operon::InfixParser::Parse(expr, ds, /*reduce=*/false);
+        auto coeff = tree.GetCoefficients();
+        Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>> const interpreter{&dtable, &ds, &tree};
+
+        auto rev = interpreter.JacRevVariable(coeff, range, variable);
+        auto fwd = interpreter.JacFwdVariable(coeff, range, variable);
+
+        auto const xs = ds.GetValues("x");
+        auto const ys = ds.GetValues("y");
+        for (std::size_t i = 0; i < range.Size(); ++i) {
+            auto const expected = analytic(xs[i], ys[i]);
+            CHECK(rev[i] == Catch::Approx(expected).margin(1e-4));
+            CHECK(fwd[i] == Catch::Approx(expected).margin(1e-4));
+        }
+    };
+
+    SECTION("d/dx(x^2) = 2x") {
+        checkAnalytic("x ^ 2", xHash, [](auto x, auto /*y*/) { return 2 * x; });
+    }
+    SECTION("d/dx(sin(x)) = cos(x)") {
+        checkAnalytic("sin(x)", xHash, [](auto x, auto /*y*/) { return std::cos(x); });
+    }
+    SECTION("d/dx(x*y) w.r.t. x = y") {
+        checkAnalytic("x * y", xHash, [](auto /*x*/, auto y) { return y; });
+    }
+    SECTION("d/dx(x + x*x) = 1 + 2x (multiple occurrences summed)") {
+        checkAnalytic("x + x * x", xHash, [](auto x, auto /*y*/) { return 1 + 2 * x; });
+    }
+    SECTION("d/dy(x*y) w.r.t. y = x") {
+        checkAnalytic("x * y", yHash, [](auto x, auto /*y*/) { return x; });
+    }
+
+    // Cross-check against central finite differences on a larger expression,
+    // as a sanity net beyond the hand-derived cases above.
+    SECTION("central finite-difference cross-check") {
+        // Separate all-positive-x dataset — the check expression below uses
+        // log(x), which is NaN for the negative x row in the outer `ds`.
+        Operon::Dataset dsPos(std::vector<std::string>{"x", "y"},
+                              std::vector<std::vector<Operon::Scalar>>{{1.3F, 0.6F, 2.0F}, {0.4F, 1.1F, -0.9F}});
+        Operon::Range const rangePos{0, dsPos.Rows<std::size_t>()};
+
+        auto tree = Operon::InfixParser::Parse("log(x) + x * y - sin(y) + exp(x * 0.3)", dsPos, /*reduce=*/false);
+        auto coeff = tree.GetCoefficients();
+        Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>> const interpreter{&dtable, &dsPos, &tree};
+        auto rev = interpreter.JacRevVariable(coeff, rangePos, xHash);
+
+        constexpr Operon::Scalar h = 1e-3F;
+        auto const xs = dsPos.GetValues("x");
+        std::vector<Operon::Scalar> xPlus(xs.begin(), xs.end());
+        std::vector<Operon::Scalar> xMinus(xs.begin(), xs.end());
+        for (auto& v : xPlus) { v += h; }
+        for (auto& v : xMinus) { v -= h; }
+        auto const ys = dsPos.GetValues("y");
+        Operon::Dataset dsPlus(std::vector<std::string>{"x", "y"}, std::vector<std::vector<Operon::Scalar>>{xPlus, std::vector<Operon::Scalar>(ys.begin(), ys.end())});
+        Operon::Dataset dsMinus(std::vector<std::string>{"x", "y"}, std::vector<std::vector<Operon::Scalar>>{xMinus, std::vector<Operon::Scalar>(ys.begin(), ys.end())});
+
+        using Interp = Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>>;
+        auto fPlus = Interp::Evaluate(tree, dsPlus, rangePos, coeff);
+        auto fMinus = Interp::Evaluate(tree, dsMinus, rangePos, coeff);
+
+        for (std::size_t i = 0; i < rangePos.Size(); ++i) {
+            auto const fd = (fPlus[i] - fMinus[i]) / (2 * h);
+            CHECK(rev[i] == Catch::Approx(fd).margin(1e-2));
+        }
+    }
 }
 
 TEST_CASE("Autodiff poly-10 expression", "[autodiff]")

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -185,6 +185,40 @@ TEST_CASE("Autodiff variable-wise derivative", "[autodiff]")
         checkAnalytic("x * y", yHash, [](auto x, auto /*y*/) { return x; });
     }
 
+    // InfixParser produces one Variable node per textual occurrence — the
+    // "multiple occurrences" case above never exercises the IsRef branch in
+    // ReverseTraceGeneric/ForwardTraceGeneric (a shared-subtree occurrence
+    // accumulating into the referenced node's trace/dot column instead of
+    // its own). Build x * Ref(x) by hand to close that gap: node 0 is the
+    // only Variable node (and thus the only one BuildColumns assigns a
+    // column to); node 1 is a Ref to node 0, so its contribution must flow
+    // back through the Ref-accumulation path for the result to match d/dx(x^2).
+    SECTION("d/dx(x*Ref(x)) = 2x (shared subtree via Ref node)") {
+        Operon::Vector<Operon::Node> nodes;
+        Operon::Node v(Operon::NodeType::Variable);
+        v.HashValue = v.CalculatedHashValue = xHash;
+        v.Value = 1.0F;
+        Operon::Node ref = Operon::Node::Ref(0);
+        Operon::Node mul(Operon::NodeType::Mul);
+        mul.Length = 2;
+        nodes.push_back(v);
+        nodes.push_back(ref);
+        nodes.push_back(mul);
+        Operon::Tree tree{nodes};
+
+        auto coeff = tree.GetCoefficients();
+        Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>> const interpreter{&dtable, &ds, &tree};
+        auto rev = interpreter.JacRevVariable(coeff, range, xHash);
+        auto fwd = interpreter.JacFwdVariable(coeff, range, xHash);
+
+        auto const xs = ds.GetValues("x");
+        for (std::size_t i = 0; i < range.Size(); ++i) {
+            auto const expected = 2 * xs[i];
+            CHECK(rev[i] == Catch::Approx(expected).margin(1e-4));
+            CHECK(fwd[i] == Catch::Approx(expected).margin(1e-4));
+        }
+    }
+
     // Cross-check against central finite differences on a larger expression,
     // as a sanity net beyond the hand-derived cases above.
     SECTION("central finite-difference cross-check") {


### PR DESCRIPTION
## Summary
- Adds `JacRevVariable`/`JacFwdVariable` to `Interpreter`, generalizing the existing coefficient-Jacobian machinery (`JacRev`/`JacFwd`) to compute the tree output's derivative w.r.t. the raw value of any input variable (identified by hash), summed via the chain rule over every occurrence of that variable in the tree.
- Refactors `ForwardTrace`/`ReverseTrace` into shared `ForwardTraceGeneric`/`ReverseTraceGeneric` templates parameterized by a column-selection predicate (`BuildColumns`) and a per-node local-derivative factor, with an `Accumulate` flag distinguishing the coefficient case (one column per node) from the variable case (multiple nodes can share a column).
- As a side effect, removes a per-row-batch column-index allocation that existed in the old `ForwardTrace` — it's now computed once per call instead of once per batch of rows.

## Test plan
- [x] New unit tests in `test/source/implementation/autodiff.cpp`: `JacRevVariable`/`JacFwdVariable` checked against hand-derived analytic derivatives (`x^2`, `sin(x)`, `x*y` w.r.t. both variables, `x + x*x` for the multi-occurrence accumulate path) and a central finite-difference cross-check.
- [x] Verified no performance regression for the existing `JacRev`/`JacFwd` paths: nanobench sweep across 31 tree sizes shows aggregate elapsed time within ~0.2% of the pre-refactor baseline (noise level), instruction counts +0.1-0.4%.