### PR TITLE
Unify MDL/FBF into shared information_criteria functions

### DIFF
--- a/cli/source/pareto_front.cpp
+++ b/cli/source/pareto_front.cpp
@@ -92,7 +92,7 @@ auto WriteParetoFront(std::string const& path,
         auto const maeTrain  =  MAE{}(estimTrain, targetTrain);
         auto const maeTest   =  MAE{}(estimTest, targetTest);
 
-        auto const [k, fCompl] = WeightedComplexity(ind->Genotype);
+        auto const k = WeightedComplexity(ind->Genotype).first; // fComplexity: computed internally by MDL/FBF below
 
         auto const n        = static_cast<double>(trainRange.Size());
         auto const sigmaArr = std::array<Scalar, 1>{static_cast<Scalar>(std::sqrt(mseTrain))};

--- a/cli/source/pareto_front.cpp
+++ b/cli/source/pareto_front.cpp
@@ -133,12 +133,19 @@ auto WriteParetoFront(std::string const& path,
         auto estimTrain = interp.Evaluate(ind->Genotype.GetCoefficients(), trainRange);
         auto estimTest  = interp.Evaluate(ind->Genotype.GetCoefficients(), testRange);
 
+        // Scale factor for the raw tree's Jacobian: the reported model is
+        // y = a * tree(x; coeffs) + b when linear scaling is on, so
+        // d(y)/d(coeffs) = a * d(tree)/d(coeffs) — this must multiply the
+        // Jacobian used for the MDL Fisher-information term below, or the
+        // parameter-cost term is biased by a missing a^2 factor whenever
+        // the fitted slope isn't ~1.
+        auto scale = Scalar{1};
         if (linearScaling) {
             auto [a, b] = FitLeastSquares(Span<Scalar const>{estimTrain}, Span<Scalar const>{targetTrain});
-            auto const as = static_cast<Scalar>(a);
+            scale = static_cast<Scalar>(a);
             auto const bs = static_cast<Scalar>(b);
-            for (auto& v : estimTrain) { v = (v * as) + bs; }
-            for (auto& v : estimTest)  { v = (v * as) + bs; }
+            for (auto& v : estimTrain) { v = (v * scale) + bs; }
+            for (auto& v : estimTest)  { v = (v * scale) + bs; }
         }
 
         auto const r2Train   = -R2{}(estimTrain, targetTrain);
@@ -163,7 +170,8 @@ auto WriteParetoFront(std::string const& path,
         auto const fbf = ComputeFBF(nll, n, p, fCompl);
 
         auto const coeffs  = ind->Genotype.GetCoefficients();
-        auto const jac     = interp.JacRev(coeffs, trainRange);
+        auto jac           = interp.JacRev(coeffs, trainRange);
+        jac *= scale; // d(a*tree)/d(coeffs) = a * d(tree)/d(coeffs); scale == 1 when linearScaling is off
         auto const nrows   = static_cast<Eigen::Index>(trainRange.Size());
         auto const ncols   = static_cast<Eigen::Index>(coeffs.size());
         Eigen::Map<Eigen::Matrix<Scalar, -1, -1> const> const jacMap(jac.data(), nrows, ncols);

--- a/cli/source/pareto_front.cpp
+++ b/cli/source/pareto_front.cpp
@@ -11,8 +11,9 @@
 
 #include <fmt/os.h>
 
-#include "operon/core/node.hpp"
 #include "operon/core/types.hpp"
+#include "operon/error_metrics/error_metrics.hpp"
+#include "operon/information_criteria/information_criteria.hpp"
 #include "operon/formatter/formatter.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/operators/evaluator.hpp"
@@ -21,72 +22,6 @@
 namespace Operon {
 
 namespace {
-
-// A weighted variable node expands to (weight * variable), contributing
-// three logical symbols: Mul, Constant, Variable.
-constexpr auto kWeightedNodeCost = 3.0;
-
-// Uniform-prior precision: di = sqrt(12 / fi) comes from Var(Uniform[-c,c]) = (2c)²/12.
-constexpr auto kUniformPriorScale = 12.0;
-
-auto ComputeWeightedComplexity(Tree const& tree) -> std::pair<double, double>
-{
-    static auto const MulHash   = Node{NodeType::Mul}.HashValue;
-    static auto const ParamHash = Node{NodeType::Constant}.HashValue;
-    Set<Hash> uniqueSymbols;
-    auto k = 0.0;
-    for (auto const& node : tree.Nodes()) {
-        auto const isWeighted = node.IsVariable() && node.Value != Scalar{1};
-        k += isWeighted ? kWeightedNodeCost : 1.0;
-        uniqueSymbols.insert(node.HashValue);
-        if (isWeighted) {
-            uniqueSymbols.insert(MulHash);
-            uniqueSymbols.insert(ParamHash);
-        }
-    }
-    auto const q      = static_cast<double>(uniqueSymbols.size());
-    auto const fCompl = q > 0.0 ? k * std::log(q) : 0.0;
-    return {k, fCompl};
-}
-
-auto ComputeFBF(double nll, double n, double p, double fCompl) -> double
-{
-    auto const b             = 1.0 / std::sqrt(n);
-    auto const fbfParams     = (p / 2.0) * ((0.5 * std::log(n)) + std::log(Math::Tau) + 1.0 - std::log(3.0)); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-    auto const fbfLikelihood = (1.0 - b) * nll;
-    auto const fbf           = fCompl + fbfParams + fbfLikelihood;
-    return std::isfinite(fbf) ? fbf : std::numeric_limits<double>::quiet_NaN();
-}
-
-template<typename JacMap>
-auto ComputeMDL(JacMap const& jacMap, Scalar sigma2, Span<Scalar const> coeffs,
-                Tree const& tree, double p, double fCompl, double nll) -> double
-{
-    constexpr auto eps    = std::numeric_limits<Scalar>::epsilon();
-    auto const fisherDiag = (jacMap.colwise().squaredNorm().transpose().array() / sigma2);
-
-    auto cComplexity = fCompl;
-    auto cParameters = 0.0;
-    auto pi          = 0;
-    for (auto const& node : tree.Nodes()) {
-        if (node.Optimize) {
-            auto const fi = static_cast<double>(fisherDiag(pi));
-            auto const di = std::sqrt(kUniformPriorScale / fi);
-            auto const ci = std::abs(static_cast<double>(coeffs[pi]));
-            if (std::isfinite(ci) && std::isfinite(di) && ci / di >= 1.0) {
-                cParameters += (0.5 * std::log(fi)) + std::log(ci); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-            }
-            ++pi;
-        } else {
-            if (std::abs(node.Value) >= static_cast<double>(eps)) {
-                cComplexity += std::log(std::abs(node.Value));
-            }
-        }
-    }
-    cParameters -= (p / 2.0) * std::log(3.0); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-    auto const mdl = cComplexity + cParameters + nll;
-    return std::isfinite(mdl) ? mdl : std::numeric_limits<double>::quiet_NaN();
-}
 
 auto EscapeJson(std::string const& s) -> std::string
 {
@@ -157,25 +92,25 @@ auto WriteParetoFront(std::string const& path,
         auto const maeTrain  =  MAE{}(estimTrain, targetTrain);
         auto const maeTest   =  MAE{}(estimTest, targetTest);
 
-        auto const [k, fCompl] = ComputeWeightedComplexity(ind->Genotype);
+        auto const [k, fCompl] = WeightedComplexity(ind->Genotype);
 
         auto const n        = static_cast<double>(trainRange.Size());
         auto const sigmaArr = std::array<Scalar, 1>{static_cast<Scalar>(std::sqrt(mseTrain))};
-        auto const p        = static_cast<double>(ind->Genotype.GetCoefficients().size());
         auto const nll      = static_cast<double>(GaussianLikelihood<Scalar>::ComputeLikelihood(
                                   {estimTrain.data(), estimTrain.size()},
                                   targetTrain,
                                   {sigmaArr.data(), sigmaArr.size()}));
 
-        auto const fbf = ComputeFBF(nll, n, p, fCompl);
+        auto const fbf = FractionalBayesFactor(ind->Genotype, n, nll);
 
         auto const coeffs  = ind->Genotype.GetCoefficients();
         auto jac           = interp.JacRev(coeffs, trainRange);
         jac *= scale; // d(a*tree)/d(coeffs) = a * d(tree)/d(coeffs); scale == 1 when linearScaling is off
-        auto const nrows   = static_cast<Eigen::Index>(trainRange.Size());
-        auto const ncols   = static_cast<Eigen::Index>(coeffs.size());
-        Eigen::Map<Eigen::Matrix<Scalar, -1, -1> const> const jacMap(jac.data(), nrows, ncols);
-        auto const mdl = ComputeMDL(jacMap, static_cast<Scalar>(mseTrain), coeffs, ind->Genotype, p, fCompl, nll);
+        auto fisherMatrix  = GaussianLikelihood<Scalar>::ComputeFisherMatrix(
+                                  {estimTrain.data(), estimTrain.size()},
+                                  {jac.data(), static_cast<std::size_t>(jac.size())},
+                                  {sigmaArr.data(), sigmaArr.size()});
+        auto const mdl = MinimumDescriptionLength(ind->Genotype, coeffs, fisherMatrix.diagonal().array(), nll);
 
         std::string objArr = "[";
         for (auto j = 0UL; j < ind->Fitness.size(); ++j) {

--- a/include/operon/information_criteria/fractional_bayes_factor.hpp
+++ b/include/operon/information_criteria/fractional_bayes_factor.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_INFORMATION_CRITERIA_FRACTIONAL_BAYES_FACTOR_HPP
+#define OPERON_INFORMATION_CRITERIA_FRACTIONAL_BAYES_FACTOR_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "operon/core/constants.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "weighted_complexity.hpp"
+
+namespace Operon {
+
+// Fractional Bayes Factor model-selection score (O'Hagan 1995 FBF +
+// Bartlett et al. 2023, arXiv:2304.06333, Sec 2.3: structural complexity
+// term shared with MinimumDescriptionLength, parameter-width term from a
+// rectangular quantizing lattice with b = 1/sqrt(n), and the (1-b)-weighted
+// negative log-likelihood).
+inline auto FractionalBayesFactor(Tree const& tree, double n, double nll) -> double
+{
+    auto const p = static_cast<double>(std::count_if(tree.Nodes().begin(), tree.Nodes().end(),
+                                                       [](auto const& node) -> bool { return node.Optimize; }));
+    auto [k, fCompl] = WeightedComplexity(tree);
+    (void)k;
+
+    auto const b             = 1.0 / std::sqrt(n);
+    auto const fbfParams     = (p / 2.0) * ((0.5 * std::log(n)) + std::log(Operon::Math::Tau) + 1.0 - std::log(3.0)); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+    auto const fbfLikelihood = (1.0 - b) * nll;
+    auto const fbf           = fCompl + fbfParams + fbfLikelihood;
+    return std::isfinite(fbf) ? fbf : std::numeric_limits<double>::quiet_NaN();
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/information_criteria/fractional_bayes_factor.hpp
+++ b/include/operon/information_criteria/fractional_bayes_factor.hpp
@@ -23,6 +23,8 @@ namespace Operon {
 // negative log-likelihood).
 inline auto FractionalBayesFactor(Tree const& tree, double n, double nll) -> double
 {
+    if (!(n > 0.0) || !std::isfinite(n)) { return std::numeric_limits<double>::quiet_NaN(); }
+
     auto const p = static_cast<double>(std::count_if(tree.Nodes().begin(), tree.Nodes().end(),
                                                        [](auto const& node) -> bool { return node.Optimize; }));
     auto [k, fCompl] = WeightedComplexity(tree);

--- a/include/operon/information_criteria/information_criteria.hpp
+++ b/include/operon/information_criteria/information_criteria.hpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_INFORMATION_CRITERIA_HPP
+#define OPERON_INFORMATION_CRITERIA_HPP
+
+#include "operon/information_criteria/fractional_bayes_factor.hpp"
+#include "operon/information_criteria/minimum_description_length.hpp"
+#include "operon/information_criteria/weighted_complexity.hpp"
+
+#endif

--- a/include/operon/information_criteria/minimum_description_length.hpp
+++ b/include/operon/information_criteria/minimum_description_length.hpp
@@ -35,6 +35,12 @@ auto MinimumDescriptionLength(Tree const& tree, Operon::Span<Operon::Scalar cons
 {
     constexpr auto eps               = std::numeric_limits<Operon::Scalar>::epsilon();
     constexpr auto uniformPriorScale = 12.0; // di = sqrt(12 / fi) comes from Var(Uniform[-c,c]) = (2c)²/12.
+    // Generous floating-point safety margin for the Fisher diagonal's PSD
+    // invariant (J^T J / sigma^2 is PSD in exact arithmetic, but near-zero
+    // entries can round slightly negative) — not a statistical/physical
+    // bound, just noise tolerance. Matches the eigenvalue guard used for
+    // the same reason in the (experimental) joint-Fisher-matrix variant.
+    constexpr auto fisherNoiseFloor  = -1e-8;
 
     auto [k, fCompl] = WeightedComplexity(tree);
     (void)k;
@@ -45,7 +51,18 @@ auto MinimumDescriptionLength(Tree const& tree, Operon::Span<Operon::Scalar cons
     auto pi          = 0;
     for (auto const& node : tree.Nodes()) {
         if (node.Optimize) {
-            auto const fi = static_cast<double>(fisherDiag(pi));
+            auto fi = static_cast<double>(fisherDiag(pi));
+            // fi == 0 is legitimate (a parameter with zero Fisher information
+            // truly carries no cost — handled below via the ordinary
+            // isfinite(di) quantization check, since sqrt(12/0) = inf).
+            // Non-finite, or negative beyond plausible rounding noise, instead
+            // violates the Fisher diagonal's PSD invariant and signals
+            // invalid/corrupted input upstream, not "no information" — flag
+            // rather than silently charging zero cost. A tiny negative value
+            // within the noise floor is clamped to 0 and falls through to the
+            // same legitimate-zero-info handling.
+            if (!std::isfinite(fi) || fi < fisherNoiseFloor) { return std::numeric_limits<double>::quiet_NaN(); }
+            fi = std::max(fi, 0.0);
             auto const di = std::sqrt(uniformPriorScale / fi);
             auto const ci = std::abs(static_cast<double>(coeffs[pi]));
             if (std::isfinite(ci) && std::isfinite(di) && ci / di >= 1.0) {

--- a/include/operon/information_criteria/minimum_description_length.hpp
+++ b/include/operon/information_criteria/minimum_description_length.hpp
@@ -36,10 +36,11 @@ auto MinimumDescriptionLength(Tree const& tree, Operon::Span<Operon::Scalar cons
     constexpr auto eps               = std::numeric_limits<Operon::Scalar>::epsilon();
     constexpr auto uniformPriorScale = 12.0; // di = sqrt(12 / fi) comes from Var(Uniform[-c,c]) = (2c)²/12.
     // Generous floating-point safety margin for the Fisher diagonal's PSD
-    // invariant (J^T J / sigma^2 is PSD in exact arithmetic, but near-zero
-    // entries can round slightly negative) — not a statistical/physical
-    // bound, just noise tolerance. Matches the eigenvalue guard used for
-    // the same reason in the (experimental) joint-Fisher-matrix variant.
+    // invariant: J^T J / sigma^2 is PSD in exact arithmetic, but a
+    // near-zero entry can round slightly negative under floating-point
+    // rounding. Not a statistical/physical bound — just noise tolerance,
+    // chosen well below any Fisher magnitude that would plausibly arise
+    // from real (non-degenerate) coefficients/data.
     constexpr auto fisherNoiseFloor  = -1e-8;
 
     auto [k, fCompl] = WeightedComplexity(tree);

--- a/include/operon/information_criteria/minimum_description_length.hpp
+++ b/include/operon/information_criteria/minimum_description_length.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_INFORMATION_CRITERIA_MINIMUM_DESCRIPTION_LENGTH_HPP
+#define OPERON_INFORMATION_CRITERIA_MINIMUM_DESCRIPTION_LENGTH_HPP
+
+#include <cmath>
+#include <limits>
+
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "weighted_complexity.hpp"
+
+namespace Operon {
+
+// Minimum Description Length of a fitted tree (Bartlett et al. 2023,
+// arXiv:2304.06333, Sec 2.2, Eq. 5): codelength of the tree structure
+// (WeightedComplexity) plus a per-parameter uniform-prior quantization cost
+// derived from the diagonal Fisher information, plus the negative
+// log-likelihood.
+//
+// `fisherDiag` is the diagonal of the Fisher information matrix for
+// `coeffs`, in the same order as the tree's Optimize-flagged nodes —
+// likelihood-agnostic: pass whatever Fisher diagonal your likelihood model
+// produces (see GaussianLikelihood/PoissonLikelihood::ComputeFisherMatrix).
+// This function does not itself know how the model was scaled to produce
+// its predictions (e.g. GP's linear-scaling a,b) — if the caller applies
+// such a scaling, the Jacobian/Fisher matrix used to derive `fisherDiag`
+// must reflect it (d(a*tree)/d(coeffs) = a * d(tree)/d(coeffs)), or the
+// parameter cost will be biased by the missing scale factor.
+template<typename FisherDiag>
+auto MinimumDescriptionLength(Tree const& tree, Operon::Span<Operon::Scalar const> coeffs,
+                              FisherDiag const& fisherDiag, double nll) -> double
+{
+    constexpr auto eps               = std::numeric_limits<Operon::Scalar>::epsilon();
+    constexpr auto uniformPriorScale = 12.0; // di = sqrt(12 / fi) comes from Var(Uniform[-c,c]) = (2c)²/12.
+
+    auto [k, fCompl] = WeightedComplexity(tree);
+    (void)k;
+    auto const p = static_cast<double>(coeffs.size());
+
+    auto cComplexity = fCompl;
+    auto cParameters = 0.0;
+    auto pi          = 0;
+    for (auto const& node : tree.Nodes()) {
+        if (node.Optimize) {
+            auto const fi = static_cast<double>(fisherDiag(pi));
+            auto const di = std::sqrt(uniformPriorScale / fi);
+            auto const ci = std::abs(static_cast<double>(coeffs[pi]));
+            if (std::isfinite(ci) && std::isfinite(di) && ci / di >= 1.0) {
+                cParameters += (0.5 * std::log(fi)) + std::log(ci); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+            }
+            ++pi;
+        } else {
+            if (std::abs(node.Value) >= static_cast<double>(eps)) {
+                cComplexity += std::log(std::abs(node.Value));
+            }
+        }
+    }
+    cParameters -= (p / 2.0) * std::log(3.0); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+    auto const mdl = cComplexity + cParameters + nll;
+    return std::isfinite(mdl) ? mdl : std::numeric_limits<double>::quiet_NaN();
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/information_criteria/weighted_complexity.hpp
+++ b/include/operon/information_criteria/weighted_complexity.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_METRICS_WEIGHTED_COMPLEXITY_HPP
+#define OPERON_METRICS_WEIGHTED_COMPLEXITY_HPP
+
+#include <cmath>
+#include <utility>
+
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+
+namespace Operon {
+
+// Weighted node/symbol count used by MinimumDescriptionLength and
+// FractionalBayesFactor (Bartlett et al. 2023, arXiv:2304.06333, Sec 2.2/2.3;
+// matches Julia's func_compl / aifeyn_complexity). A weighted variable node
+// (Value != 1) expands to (weight * variable), contributing three logical
+// symbols: Mul, Constant, Variable; everything else counts as one node/symbol.
+// Returns {k, fComplexity} where k is the weighted node count and
+// fComplexity = k * log(q), q = number of unique symbol types.
+inline auto WeightedComplexity(Tree const& tree) -> std::pair<double, double>
+{
+    static auto const MulHash   = Node{NodeType::Mul}.HashValue;
+    static auto const ParamHash = Node{NodeType::Constant}.HashValue;
+    Operon::Set<Operon::Hash> uniqueSymbols;
+    auto k = 0.0;
+    for (auto const& node : tree.Nodes()) {
+        auto const isWeighted = node.IsVariable() && node.Value != Operon::Scalar{1};
+        k += isWeighted ? 3.0 : 1.0; // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+        uniqueSymbols.insert(node.HashValue);
+        if (isWeighted) {
+            uniqueSymbols.insert(MulHash);
+            uniqueSymbols.insert(ParamHash);
+        }
+    }
+    auto const q           = static_cast<double>(uniqueSymbols.size());
+    auto const fComplexity = q > 0.0 ? k * std::log(q) : 0.0;
+    return {k, fComplexity};
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/information_criteria/weighted_complexity.hpp
+++ b/include/operon/information_criteria/weighted_complexity.hpp
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
-#ifndef OPERON_METRICS_WEIGHTED_COMPLEXITY_HPP
-#define OPERON_METRICS_WEIGHTED_COMPLEXITY_HPP
+#ifndef OPERON_INFORMATION_CRITERIA_WEIGHTED_COMPLEXITY_HPP
+#define OPERON_INFORMATION_CRITERIA_WEIGHTED_COMPLEXITY_HPP
 
 #include <cmath>
 #include <utility>

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -14,6 +14,9 @@
 #include "operon/core/operator.hpp"
 #include "operon/core/problem.hpp"
 #include "operon/core/types.hpp"
+#include "operon/information_criteria/fractional_bayes_factor.hpp"
+#include "operon/information_criteria/minimum_description_length.hpp"
+#include "operon/information_criteria/weighted_complexity.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/operon_export.hpp"
 #include "operon/optimizer/likelihood/gaussian_likelihood.hpp"
@@ -383,7 +386,6 @@ public:
         auto const* dtable = Base::GetDispatchTable();
         auto const* problem = Base::GetProblem();
         auto const* dataset = problem->GetDataset();
-        auto const& nodes = ind.Genotype.Nodes();
 
         // this call will optimize the tree coefficients and compute the SSE
         auto const& tree = ind.Genotype;
@@ -415,63 +417,14 @@ public:
             ? std::span<Operon::Scalar const>{&profiledSigma, 1}  // profiled
             : std::span<Operon::Scalar const>{sigma_};             // fixed scalar, per-sample, or empty (Poisson unweighted)
 
-        // codelength of the complexity
-        // count number of unique functions
-        // - count weight * variable as three nodes
-        // - compute complexity c of the remaining numerical values
-        //   (that are not part of the coefficients that are optimized)
-        static auto const MulHash   = Node{NodeType::Mul}.HashValue;
-        static auto const ParamHash = Node{NodeType::Constant}.HashValue;
-        Operon::Set<Operon::Hash> uniqueFunctions; // to count the number of unique symbol types
-        auto k{0.0}; // number of nodes
-        auto cComplexity { 0.0 };
-
-        // codelength of the parameters
         ++Base::JacobianEvaluations;
         Eigen::Matrix<Operon::Scalar, -1, -1> jac = interpreter.JacRev(parameters, trainingRange); // jacobian
         auto fisherMatrix = Lik::ComputeFisherMatrix(estimatedValues, {jac.data(), static_cast<std::size_t>(jac.size())}, effectiveSigma);
         auto fisherDiag   = fisherMatrix.diagonal().array();
         ENSURE(fisherDiag.size() == p);
 
-        auto cParameters { 0.0 };
-        auto constexpr eps = std::numeric_limits<Operon::Scalar>::epsilon(); // machine epsilon for zero comparison
-
-        for (auto i = 0, pi = 0; i < std::ssize(nodes); ++i) {
-            auto const& n = nodes[i];
-
-            // weighted variables count as 3 symbol types: the variable itself, plus implicit MUL and PARAM
-            // unit-weight variables count as 1 (interpreter skips the multiplication, expression is equivalent)
-            auto const isWeighted = n.IsVariable() && n.Value != Operon::Scalar{1};
-            k += isWeighted ? 3 : 1;
-            uniqueFunctions.insert(n.HashValue);
-            if (isWeighted) {
-                uniqueFunctions.insert(MulHash);
-                uniqueFunctions.insert(ParamHash);
-            }
-
-            if (n.Optimize) {
-                // DL of the parameters to be optimized
-                auto const di = std::sqrt(12 / fisherDiag(pi));
-                auto const ci = std::abs(parameters[pi]);
-
-                if (std::isfinite(ci) && std::isfinite(di) && ci / di >= 1) {
-                    cParameters += (0.5 * std::log(fisherDiag(pi))) + std::log(ci);
-                }
-                ++pi;
-            } else {
-                // DL of the remaining tree structure
-                if (std::abs(n.Value) < eps) { continue; }
-                cComplexity += std::log(std::abs(n.Value));
-            }
-        }
-
-        auto q { static_cast<double>(uniqueFunctions.size()) };
-        if (q > 0) { cComplexity += k * std::log(q); }
-
-        cParameters -= p/2 * std::log(3);
-
-        auto cLikelihood  = Lik::ComputeLikelihood(estimatedValues, targetValues, effectiveSigma);
-        auto mdl = cComplexity + cParameters + cLikelihood;
+        auto cLikelihood = Lik::ComputeLikelihood(estimatedValues, targetValues, effectiveSigma);
+        auto mdl = Operon::MinimumDescriptionLength(tree, parameters, fisherDiag, static_cast<double>(cLikelihood));
         if (!std::isfinite(mdl)) { mdl = EvaluatorBase::ErrMax; }
         return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(mdl) };
     }
@@ -504,13 +457,11 @@ public:
         auto const* dtable  = Base::GetDispatchTable();
         auto const* problem = Base::GetProblem();
         auto const* dataset = problem->GetDataset();
-        auto const& nodes   = ind.Genotype.Nodes();
         auto const& tree    = ind.Genotype;
 
         Operon::Interpreter<Operon::Scalar, DTable> interpreter{dtable, dataset, &tree};
         auto parameters = tree.GetCoefficients();
 
-        auto const p { static_cast<double>(parameters.size()) };
         auto const trainingRange = problem->TrainingRange();
         auto const n { static_cast<double>(trainingRange.Size()) };
         ENSURE(buf.size() >= trainingRange.Size());
@@ -537,41 +488,13 @@ public:
             ? std::span<Operon::Scalar const>{&profiledSigma, 1}  // profiled
             : std::span<Operon::Scalar const>{sigma_};             // fixed scalar, per-sample, or empty (Poisson unweighted)
 
-        // structural complexity: k * log(q), matching Julia func_compl
-        static auto const MulHash   = Node{NodeType::Mul}.HashValue;
-        static auto const ParamHash = Node{NodeType::Constant}.HashValue;
-        Operon::Set<Operon::Hash> uniqueSymbols;
-        auto k { 0.0 };
-        for (auto const& node : nodes) {
-            // weighted variables count as 3 symbol types: the variable itself, plus implicit MUL and PARAM
-            // unit-weight variables count as 1 (interpreter skips the multiplication, expression is equivalent)
-            auto const isWeighted = node.IsVariable() && node.Value != Operon::Scalar{1};
-            k += isWeighted ? 3 : 1;
-            uniqueSymbols.insert(node.HashValue);
-            if (isWeighted) {
-                uniqueSymbols.insert(MulHash);
-                uniqueSymbols.insert(ParamHash);
-            }
-        }
-        auto const q { static_cast<double>(uniqueSymbols.size()) };
-        auto const fComplexity = q > 0 ? k * std::log(q) : 0.0;
-
-        // parameter term: (p/2) * (-log(b) + log(2π·nup))
-        // b = 1/sqrt(n)  =>  -log(b) = 0.5·log(n)
-        // nup = exp(1 - log(3))  =>  log(nup) = 1 - log(3)
-        // combined: (p/2) * (0.5·log(n) + log(2π) + 1 - log(3))
-        auto const b { 1.0 / std::sqrt(n) };
-        auto const cParameters = (p / 2.0) * (0.5 * std::log(n) + std::log(Operon::Math::Tau) + 1.0 - std::log(3.0));
-
-        // fractional likelihood: (1 - b) * NLL
         // Profiled case: use pre-computed NLL (avoids second O(n) pass inside ComputeLikelihood).
         // Fixed scalar or per-sample: delegate to ComputeLikelihood.
         auto const nll = (sigma_.empty() && Lik::UsesSigma)
             ? mlNLL
             : static_cast<double>(Lik::ComputeLikelihood(estimatedValues, targetValues, effectiveSigma));
-        auto const cLikelihood = (1.0 - b) * nll;
 
-        auto fbf = fComplexity + cParameters + cLikelihood;
+        auto fbf = Operon::FractionalBayesFactor(tree, n, nll);
         if (!std::isfinite(fbf)) { fbf = EvaluatorBase::ErrMax; }
         return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(fbf) };
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(operon_test
     source/implementation/dispatch_table.cpp
     source/implementation/evaluation.cpp
     source/implementation/error_metrics.cpp
+    source/implementation/information_criteria.cpp
     source/implementation/hashing.cpp
     source/implementation/zobrist.cpp
     source/implementation/infix_parser.cpp

--- a/test/source/implementation/information_criteria.cpp
+++ b/test/source/implementation/information_criteria.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "../operon_test.hpp"
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/information_criteria/information_criteria.hpp"
+#include "operon/interpreter/interpreter.hpp"
+#include "operon/optimizer/likelihood/gaussian_likelihood.hpp"
+
+namespace Operon::Test {
+
+// Regression test for the linear-scaling MDL bug (fixed in 6a709bf2): when
+// a fitted model is y = a * tree(x; coeffs) + b, the Jacobian used to
+// derive the Fisher information must be scaled by `a`
+// (d(a*tree)/d(coeffs) = a * d(tree)/d(coeffs)) before it reaches
+// MinimumDescriptionLength, or the parameter-cost term silently loses a
+// log(a) contribution per significant parameter. This locks in that
+// invariant directly against MinimumDescriptionLength/GaussianLikelihood::
+// ComputeFisherMatrix, independent of any CLI/evaluator glue code.
+TEST_CASE("Minimum description length reflects Jacobian scale", "[information-criteria][mdl]")
+{
+    Operon::Dataset ds(std::vector<std::string>{"x1"},
+                       std::vector<std::vector<Operon::Scalar>>{
+                           {-1.8F, -1.1F, -0.4F, 0.3F, 1.0F, 1.7F}});
+    Operon::DispatchTable<Operon::Scalar> dtable;
+    Operon::Range const range{0, ds.Rows<std::size_t>()};
+    auto const x1Hash = ds.GetVariable("x1")->Hash;
+
+    // A single weighted-variable leaf node (Value = weight != 1) is one
+    // Optimize-flagged parameter — built manually rather than via
+    // InfixParser, which expands written multiplication ("15 * x1") into a
+    // separate Mul(Constant, Variable) subtree with two parameters instead
+    // of folding it into the variable's own weight.
+    Operon::Node v(Operon::NodeType::Variable);
+    v.HashValue = v.CalculatedHashValue = x1Hash;
+    v.Value = 15.0F;
+    Operon::Tree tree{ Operon::Vector<Operon::Node>{v} };
+
+    auto coeffs = tree.GetCoefficients();
+    REQUIRE(coeffs.size() == 1);
+
+    using Interp = Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>>;
+    Interp const interpreter{&dtable, &ds, &tree};
+
+    auto pred = interpreter.Evaluate(coeffs, range);
+    auto jac  = interpreter.JacRev(coeffs, range); // d(tree)/d(coeffs), unscaled
+
+    // Trivial fit (target == prediction) so nll is identical whether or not
+    // the Jacobian is scaled — isolates the effect on the Fisher/parameter
+    // cost term, which is what the fix touches.
+    constexpr Operon::Scalar sigma = 0.1F;
+    auto const sigmaArr = std::array<Operon::Scalar, 1>{sigma};
+    auto const nll = static_cast<double>(Operon::GaussianLikelihood<Operon::Scalar>::ComputeLikelihood(
+        {pred.data(), pred.size()}, {pred.data(), pred.size()}, {sigmaArr.data(), sigmaArr.size()}));
+
+    auto const fisherUnscaled = Operon::GaussianLikelihood<Operon::Scalar>::ComputeFisherMatrix(
+        {pred.data(), pred.size()}, {jac.data(), static_cast<std::size_t>(jac.size())}, {sigmaArr.data(), sigmaArr.size()});
+    auto const mdlUnscaled = Operon::MinimumDescriptionLength(tree, coeffs, fisherUnscaled.diagonal().array(), nll);
+
+    constexpr auto a = Operon::Scalar{3.0F};
+    auto jacScaled = jac;
+    jacScaled *= a; // what WriteParetoFront's "jac *= scale" does for a fitted y = a*tree(x;coeffs)+b
+    auto const fisherScaled = Operon::GaussianLikelihood<Operon::Scalar>::ComputeFisherMatrix(
+        {pred.data(), pred.size()}, {jacScaled.data(), static_cast<std::size_t>(jacScaled.size())}, {sigmaArr.data(), sigmaArr.size()});
+    auto const mdlScaled = Operon::MinimumDescriptionLength(tree, coeffs, fisherScaled.diagonal().array(), nll);
+
+    // fisherScaled = a^2 * fisherUnscaled, so the (single, well above its
+    // quantization threshold at this sigma/coefficient magnitude)
+    // significant parameter's 0.5*log(fi) term grows by 0.5*log(a^2) = log(a).
+    auto const expectedDelta = static_cast<double>(coeffs.size()) * std::log(static_cast<double>(a));
+    CHECK(mdlScaled - mdlUnscaled == Catch::Approx(expectedDelta).margin(1e-6));
+
+    // The bug this guards against: silently using the unscaled Jacobian
+    // (as if `a` were 1) must NOT reproduce the correctly-scaled MDL.
+    CHECK(mdlScaled != Catch::Approx(mdlUnscaled).margin(1e-3));
+}
+
+} // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Fixes a real bug found along the way (already on `main` via `6a709bf2`): `WriteParetoFront`'s MDL Fisher-information term didn't scale the Jacobian by the linear-scaling slope `a`, biasing the parameter-cost term whenever the fitted slope wasn't ~1.
- That fix revealed `MinimumDescriptionLength`/`FractionalBayesFactor` were each independently implemented twice — once in `cli/source/pareto_front.cpp` (JSON export), once inline in `MinimumDescriptionLengthEvaluator`/`FractionalBayesFactorEvaluator` (`include/operon/operators/evaluator.hpp`, the fitness-evaluator path). Both also duplicated the weighted-complexity/unique-symbol computation.
- Extracts the shared math into pure functions under a new `include/operon/information_criteria/` (not `error_metrics/` — these are model-selection criteria combining fit + complexity penalty, not prediction-accuracy metrics):
  - `WeightedComplexity(tree)`
  - `MinimumDescriptionLength(tree, coeffs, fisherDiag, nll)` — likelihood-agnostic (takes a precomputed Fisher diagonal, preserving `MinimumDescriptionLengthEvaluator`'s Poisson-likelihood support)
  - `FractionalBayesFactor(tree, n, nll)`
- Both evaluators and `WriteParetoFront` now call these instead of maintaining private copies; `WriteParetoFront` also reuses `GaussianLikelihood::ComputeFisherMatrix` instead of a third hand-rolled `J^T J / σ²`.

## Test plan
- [x] New regression test (`test/source/implementation/information_criteria.cpp`) for the linear-scaling MDL bug, exercised directly against `MinimumDescriptionLength` + `GaussianLikelihood::ComputeFisherMatrix` (no CLI-reaching-in — the test project only links the installed library).
- [x] Full build (lib + CLI + test project) clean.
- [x] Full test suite: 139/142 — same 3 pre-existing, unrelated failures present in every run this session, before this change too (Sin/Cos ULP accuracy near zero-crossings; JIT-vs-interpreter fitness tolerance on random trees).
- [x] Existing `[evaluator]`-tagged MDL/FBF tests (Gaussian + Poisson likelihood variants) still pass.