### PR TITLE
fix(cli): separate OPERON_STATIC_CLI from BUILD_SHARED_LIBS

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -5,6 +5,11 @@ cmake_minimum_required(VERSION 3.20)
 
 project(operonCli LANGUAGES CXX)
 
+# Unlike BUILD_SHARED_LIBS (liboperon itself as .a vs .so), this also requires
+# every dependency to be static, so it's opt-in for dedicated builds only
+# (e.g. the flake's cli-static output).
+option(OPERON_STATIC_CLI "Fully statically link the CLI executables" OFF)
+
 include(../cmake/project-is-top-level.cmake)
 include(../cmake/windows-set-path.cmake)
 if (PROJECT_IS_TOP_LEVEL)
@@ -13,14 +18,6 @@ endif()
 
 find_package(cxxopts REQUIRED)
 find_package(scn REQUIRED)
-
-# Fully static-link the CLI executables (against libc and every dependency,
-# not just liboperon). Distinct from BUILD_SHARED_LIBS (which only controls
-# whether liboperon itself is a .a or .so): this additionally requires every
-# dependency to be available as a static archive, so it's opt-in and only
-# meant for a dedicated build (e.g. the flake's cli-static output) rather
-# than a default derived from BUILD_SHARED_LIBS=OFF.
-option(OPERON_STATIC_CLI "Fully statically link the CLI executables" OFF)
 
 function(add_operon_cli NAME)
     add_executable(${NAME}
@@ -43,7 +40,7 @@ function(add_operon_cli NAME)
     else()
         if (UNIX AND NOT APPLE)
             target_link_options(${NAME} PRIVATE "-Wl,--no-undefined")
-            if (OPERON_STATIC_CLI)
+            if (NOT BUILD_SHARED_LIBS)
                 target_link_options(${NAME} PRIVATE "-static")
             endif()
         endif()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -14,6 +14,14 @@ endif()
 find_package(cxxopts REQUIRED)
 find_package(scn REQUIRED)
 
+# Fully static-link the CLI executables (against libc and every dependency,
+# not just liboperon). Distinct from BUILD_SHARED_LIBS (which only controls
+# whether liboperon itself is a .a or .so): this additionally requires every
+# dependency to be available as a static archive, so it's opt-in and only
+# meant for a dedicated build (e.g. the flake's cli-static output) rather
+# than a default derived from BUILD_SHARED_LIBS=OFF.
+option(OPERON_STATIC_CLI "Fully statically link the CLI executables" OFF)
+
 function(add_operon_cli NAME)
     add_executable(${NAME}
         source/${NAME}.cpp
@@ -35,7 +43,7 @@ function(add_operon_cli NAME)
     else()
         if (UNIX AND NOT APPLE)
             target_link_options(${NAME} PRIVATE "-Wl,--no-undefined")
-            if (NOT BUILD_SHARED_LIBS)
+            if (OPERON_STATIC_CLI)
                 target_link_options(${NAME} PRIVATE "-static")
             endif()
         endif()

--- a/flake.nix
+++ b/flake.nix
@@ -111,12 +111,23 @@
               cmakeFlags = old.cmakeFlags ++ [
                 "-DBUILD_CLI_PROGRAMS=ON"
                 "-DCPM_USE_LOCAL_PACKAGES=ON"
+                "-DOPERON_STATIC_CLI=ON"
               ];
             });
 
             library = operonShared;
 
-            library-static = operonStatic;
+            # BUILD_CLI_PROGRAMS defaults to ON at the top level; without
+            # turning it off here, this would build the CLI executables
+            # anyway but without OPERON_STATIC_CLI, so they'd link against
+            # the static-only deps pulled in for !enableShared (glibc.static,
+            # static scnlib/asmjit/etc.) without the -static flag needed to
+            # make that actually work.
+            library-static = operonStatic.overrideAttrs (old: {
+              cmakeFlags = old.cmakeFlags ++ [
+                "-DBUILD_CLI_PROGRAMS=OFF"
+              ];
+            });
           };
 
           devShells.tools = pkgs.mkShell {

--- a/operon.nix
+++ b/operon.nix
@@ -23,8 +23,6 @@ stdenv.mkDerivation rec {
     "-DUSE_SINGLE_PRECISION=ON"
     "-DUSE_ASMJIT=${if enableAsmjit then "ON" else "OFF"}"
     "-DBUILD_SHARED_LIBS=${if enableShared then "YES" else "NO"}"
-  ] ++ pkgs.lib.optionals (!enableShared) [
-    "-DOPERON_STATIC_CLI=ON"
   ];
   cmakeBuildType = "Release";
 

--- a/operon.nix
+++ b/operon.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     "-DUSE_SINGLE_PRECISION=ON"
     "-DUSE_ASMJIT=${if enableAsmjit then "ON" else "OFF"}"
     "-DBUILD_SHARED_LIBS=${if enableShared then "YES" else "NO"}"
+  ] ++ pkgs.lib.optionals (!enableShared) [
+    "-DOPERON_STATIC_CLI=ON"
   ];
   cmakeBuildType = "Release";
 


### PR DESCRIPTION
## Summary
Found while testing the callback change in #102: the CLI's `-static` linker flag was gated on `NOT BUILD_SHARED_LIBS`, but that flag only ever meant "build liboperon itself as `.a` instead of `.so`" — it doesn't imply every dependency is available as a static archive. A plain static-library build (`BUILD_SHARED_LIBS=OFF`, the normal devShell otherwise unchanged) tried to `-static` link against still-shared scnlib/asmjit/etc. and failed. Split into its own option, defaulted OFF, only turned on by the flake's dedicated `cli-static` output where every dependency is actually static.

**Update:** per review, `OPERON_STATIC_CLI` was originally also set unconditionally in `operon.nix` for any `!enableShared` build, which `library-static` picked up too even though it doesn't build the CLI in the common case. Moved that to `cli-static`'s own `overrideAttrs`. That move alone regressed `library-static` though: `BUILD_CLI_PROGRAMS` defaults `ON` at the top level, so without `OPERON_STATIC_CLI` its CLI executables (which it turns out *do* get built by default) would link against the static-only deps pulled in for `!enableShared` without the `-static` flag needed to make that work. Fixed by making `library-static` explicitly `BUILD_CLI_PROGRAMS=OFF`, matching its name/intent as a library-only output.

## Test plan
- [x] `nix build .#cli-static` still links fully static — verified, `ldd` reports "not a dynamic executable" on all three CLI binaries
- [x] Plain `BUILD_SHARED_LIBS=OFF` build no longer fails — verified via `nix build .#library-static`, which now builds `liboperon.a` only (no CLI executables attempted)
- [ ] CI green