### PR TITLE
feat(algorithms): let the report callback request early termination

### DIFF
--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -239,9 +239,10 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(evaluator.get());
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, nullptr, evaluator.get());
-        gp.Run(executor, random, [&]() -> void {
+        gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);
             Operon::MaybeSaveCheckpoint(gp, random, result);
+            return false;
         }, warmStart);
         Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -368,9 +368,10 @@ auto main(int argc, char** argv) -> int
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector), &evaluator);
         auto const warmStart = Operon::ResumeFromCheckpoint(gp, random, result);
-        gp.Run(executor, random, [&]() {
+        gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);
             Operon::MaybeSaveCheckpoint(gp, random, result);
+            return false;
         }, warmStart);
         Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();

--- a/example/custom_primitives.cpp
+++ b/example/custom_primitives.cpp
@@ -169,15 +169,16 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
     tf::Executor executor(std::thread::hardware_concurrency());
 
     size_t gen = 0;
-    auto report = [&]() -> void {
+    auto report = [&]() -> bool {
         ++gen;
-        if (gen % 10 != 0) { return; }
+        if (gen % 10 != 0) { return false; }
         auto const* first = gp.Individuals().data();
         auto const* last  = first + config.PopulationSize;
         auto const* best  = std::min_element(first, last,
             [](auto const& a, auto const& b) -> auto { return a[0] < b[0]; });
         fmt::print("  gen {:4d}  MSE(train)={:.6f}  len={}\n",
             gen, best->Fitness[0], best->Genotype.Length());
+        return false;
     };
 
     fmt::print("Running GP ({} generations, population {})...\n\n",

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -123,8 +123,8 @@ public:
     // algorithm's own stop condition ORs this in. Atomic so it's also safe to
     // call RequestStop() from outside the callback (e.g. another thread, a
     // signal handler) while Run() is in progress.
-    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(); }
-    auto RequestStop() -> void { stopRequested_.store(true); }
+    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(std::memory_order_acquire); }
+    auto RequestStop() -> void { stopRequested_.store(true, std::memory_order_release); }
 
     // Valid to call between runs only. The PhaseTimer observer owns its own
     // totals and is recreated each Run(), so Reset() mid-run would cause the
@@ -133,7 +133,7 @@ public:
     {
         generation_ = 0;
         elapsed_ = 0;
-        stopRequested_.store(false);
+        stopRequested_.store(false, std::memory_order_release);
         phaseTimes_.clear();
         GetGenerator()->Evaluator()->Reset();
     }

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -19,6 +19,12 @@ class ReinserterBase;
 struct CoefficientInitializerBase;
 struct TreeInitializerBase;
 
+// Invoked once per generation by every algorithm's Run() to report progress.
+// Returning true requests early termination; each algorithm's own stop
+// condition ORs StopRequested() in alongside its evaluator-budget,
+// generation-count, and time-limit checks.
+using ReportCallback = std::function<bool()>;
+
 class GeneticAlgorithmBase {
 public:
     virtual ~GeneticAlgorithmBase() = default;
@@ -73,6 +79,11 @@ public:
     [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
     auto IsFitted() -> bool& { return isFitted_; }
 
+    // Set by an algorithm's Run() when its ReportCallback returns true; each
+    // algorithm's own stop condition ORs this in.
+    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_; }
+    auto StopRequested() -> bool& { return stopRequested_; }
+
     // Valid to call between runs only. The PhaseTimer observer owns its own
     // totals and is recreated each Run(), so Reset() mid-run would cause the
     // next reportProgress sync to overwrite the cleared map with stale data.
@@ -80,6 +91,7 @@ public:
     {
         generation_ = 0;
         elapsed_ = 0;
+        stopRequested_ = false;
         phaseTimes_.clear();
         GetGenerator()->Evaluator()->Reset();
     }
@@ -111,6 +123,7 @@ private:
     double elapsed_{0};
     Operon::Map<std::string, double> phaseTimes_;
     bool isFitted_{false};
+    bool stopRequested_{false};
 };
 
 } // namespace Operon

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -5,6 +5,7 @@
 #ifndef GA_BASE_HPP
 #define GA_BASE_HPP
 
+#include <atomic>
 #include <functional>
 #include <string>
 #include <operon/operon_export.hpp>
@@ -28,9 +29,48 @@ using ReportCallback = std::function<bool()>;
 class GeneticAlgorithmBase {
 public:
     virtual ~GeneticAlgorithmBase() = default;
-    GeneticAlgorithmBase(const GeneticAlgorithmBase&) = default;
+    // std::atomic<bool> isn't copyable, so stopRequested_ needs manual
+    // handling; every other member is copied exactly as the defaulted
+    // versions would have done.
+    GeneticAlgorithmBase(GeneticAlgorithmBase const& other)
+        : config_(other.config_)
+        , problem_(other.problem_)
+        , treeInit_(other.treeInit_)
+        , coeffInit_(other.coeffInit_)
+        , generator_(other.generator_)
+        , reinserter_(other.reinserter_)
+        , individuals_(other.individuals_)
+        , parents_(other.parents_)
+        , offspring_(other.offspring_)
+        , workerRngs_(other.workerRngs_)
+        , generation_(other.generation_)
+        , elapsed_(other.elapsed_)
+        , phaseTimes_(other.phaseTimes_)
+        , isFitted_(other.isFitted_)
+        , stopRequested_(other.stopRequested_.load())
+    {
+    }
     GeneticAlgorithmBase(GeneticAlgorithmBase&&) = delete;
-    auto operator=(const GeneticAlgorithmBase&) -> GeneticAlgorithmBase& = default;
+    auto operator=(GeneticAlgorithmBase const& other) -> GeneticAlgorithmBase&
+    {
+        if (this == &other) { return *this; }
+        config_ = other.config_;
+        problem_ = other.problem_;
+        treeInit_ = other.treeInit_;
+        coeffInit_ = other.coeffInit_;
+        generator_ = other.generator_;
+        reinserter_ = other.reinserter_;
+        individuals_ = other.individuals_;
+        parents_ = other.parents_;
+        offspring_ = other.offspring_;
+        workerRngs_ = other.workerRngs_;
+        generation_ = other.generation_;
+        elapsed_ = other.elapsed_;
+        phaseTimes_ = other.phaseTimes_;
+        isFitted_ = other.isFitted_;
+        stopRequested_.store(other.stopRequested_.load());
+        return *this;
+    }
     auto operator=(GeneticAlgorithmBase&&) -> GeneticAlgorithmBase& = delete;
 
     GeneticAlgorithmBase(GeneticAlgorithmConfig config, gsl::not_null<Problem const*> problem, gsl::not_null<TreeInitializerBase const*> treeInit, gsl::not_null<CoefficientInitializerBase const*> coeffInit, gsl::not_null<OffspringGeneratorBase const*> generator, gsl::not_null<ReinserterBase const*> reinserter)
@@ -80,9 +120,11 @@ public:
     auto IsFitted() -> bool& { return isFitted_; }
 
     // Set by an algorithm's Run() when its ReportCallback returns true; each
-    // algorithm's own stop condition ORs this in.
-    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_; }
-    auto StopRequested() -> bool& { return stopRequested_; }
+    // algorithm's own stop condition ORs this in. Atomic so it's also safe to
+    // call RequestStop() from outside the callback (e.g. another thread, a
+    // signal handler) while Run() is in progress.
+    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(); }
+    auto RequestStop() -> void { stopRequested_.store(true); }
 
     // Valid to call between runs only. The PhaseTimer observer owns its own
     // totals and is recreated each Run(), so Reset() mid-run would cause the
@@ -91,7 +133,7 @@ public:
     {
         generation_ = 0;
         elapsed_ = 0;
-        stopRequested_ = false;
+        stopRequested_.store(false);
         phaseTimes_.clear();
         GetGenerator()->Evaluator()->Reset();
     }
@@ -123,7 +165,7 @@ private:
     double elapsed_{0};
     Operon::Map<std::string, double> phaseTimes_;
     bool isFitted_{false};
-    bool stopRequested_{false};
+    std::atomic<bool> stopRequested_{false};
 };
 
 } // namespace Operon

--- a/include/operon/algorithms/gp.hpp
+++ b/include/operon/algorithms/gp.hpp
@@ -33,8 +33,8 @@ public:
     {
     }
 
-    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
-    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/ = 0, /*warmStart*/ bool = false) -> void;
+    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator& /*rng*/, Operon::ReportCallback /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
+    auto Run(Operon::RandomGenerator& /*rng*/, Operon::ReportCallback /*report*/ = nullptr, size_t /*threads*/ = 0, /*warmStart*/ bool = false) -> void;
 };
 } // namespace Operon
 

--- a/include/operon/algorithms/nsga2.hpp
+++ b/include/operon/algorithms/nsga2.hpp
@@ -49,8 +49,8 @@ public:
 
     [[nodiscard]] auto Best() const -> Operon::Span<Individual const> { return { best_.data(), best_.size() }; }
 
-    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, std::function<void()> /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
-    auto Run(Operon::RandomGenerator& /*rng*/, std::function<void()> /*report*/ = nullptr, size_t /*threads*/= 0, /*warmStart*/ bool = false) -> void;
+    auto Run(tf::Executor& /*executor*/, Operon::RandomGenerator&/*rng*/, Operon::ReportCallback /*report*/ = nullptr, /*warmStart*/ bool = false) -> void;
+    auto Run(Operon::RandomGenerator& /*rng*/, Operon::ReportCallback /*report*/ = nullptr, size_t /*threads*/= 0, /*warmStart*/ bool = false) -> void;
 };
 } // namespace Operon
 

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -80,7 +80,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report && std::invoke(report)) { StopRequested() = true; }
+                                             if (report && std::invoke(report)) { RequestStop(); }
                                          }).name("report progress");
 
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
@@ -132,7 +132,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report && std::invoke(report)) { StopRequested() = true; }
+                                             if (report && std::invoke(report)) { RequestStop(); }
                                          }).name("report progress");
 
             // set-up subflow graph

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -23,7 +23,7 @@
 #include "operon/operators/reinserter.hpp"
 
 namespace Operon {
-auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report, bool warmStart) -> void
+auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon::ReportCallback report, bool warmStart) -> void
 {
     auto const savedGeneration = Generation();
     Reset();
@@ -64,7 +64,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
 
     auto stop = [&]() -> bool {
         Elapsed() = computeElapsed();
-        return generator->Terminate() || Generation() == config.Generations || Elapsed() > static_cast<double>(config.TimeLimit);
+        return StopRequested() || generator->Terminate() || Generation() == config.Generations || Elapsed() > static_cast<double>(config.TimeLimit);
     };
 
     auto parents = Parents();
@@ -80,7 +80,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto prepareEval = subflow.emplace([&]() -> void { evaluator->Prepare(parents); }).name("prepare evaluator");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report) { std::invoke(report); }
+                                             if (report && std::invoke(report)) { StopRequested() = true; }
                                          }).name("report progress");
 
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
@@ -132,7 +132,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report) { std::invoke(report); }
+                                             if (report && std::invoke(report)) { StopRequested() = true; }
                                          }).name("report progress");
 
             // set-up subflow graph
@@ -163,7 +163,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     executor.remove_observer(std::move(timer));
 }
 
-auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads, bool warmStart) -> void
+auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, Operon::ReportCallback report, size_t threads, bool warmStart) -> void
 {
     if (threads == 0) {
         threads = std::thread::hardware_concurrency();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -153,7 +153,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{SortTaskName});
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report && std::invoke(report)) { StopRequested() = true; }
+                                             if (report && std::invoke(report)) { RequestStop(); }
                                          })
                                       .name("report progress");
             nonDominatedSort.precede(reportProgress);
@@ -207,7 +207,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report && std::invoke(report)) { StopRequested() = true; }
+                                             if (report && std::invoke(report)) { RequestStop(); }
                                          }).name("report progress");
 
             // set-up subflow graph

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -95,7 +95,7 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     std::transform(fronts_.front().begin(), fronts_.front().end(), std::back_inserter(best_), [&](auto i) -> auto { return pop[i]; });
 }
 
-auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::function<void()> report, bool warmStart) -> void // NOLINT(readability-function-cognitive-complexity)
+auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon::ReportCallback report, bool warmStart) -> void // NOLINT(readability-function-cognitive-complexity)
 {
     auto const savedGeneration = Generation();
     Reset();
@@ -135,7 +135,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
 
     auto stop = [&]() -> bool {
         Elapsed() = computeElapsed();
-        return generator->Terminate() || Generation() == config.Generations || Elapsed() > static_cast<double>(config.TimeLimit);
+        return StopRequested() || generator->Terminate() || Generation() == config.Generations || Elapsed() > static_cast<double>(config.TimeLimit);
     };
 
     auto& individuals = Individuals();
@@ -153,9 +153,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(parents); }).name(std::string{SortTaskName});
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report) {
-                                                 std::invoke(report);
-                                             }
+                                             if (report && std::invoke(report)) { StopRequested() = true; }
                                          })
                                       .name("report progress");
             nonDominatedSort.precede(reportProgress);
@@ -209,7 +207,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();
-                                             if (report) { std::invoke(report); }
+                                             if (report && std::invoke(report)) { StopRequested() = true; }
                                          }).name("report progress");
 
             // set-up subflow graph
@@ -240,7 +238,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, std::fu
     executor.remove_observer(std::move(timer));
 }
 
-auto NSGA2::Run(Operon::RandomGenerator& random, std::function<void()> report, size_t threads, bool warmStart) -> void
+auto NSGA2::Run(Operon::RandomGenerator& random, Operon::ReportCallback report, size_t threads, bool warmStart) -> void
 {
     if (threads == 0U) {
         threads = std::thread::hardware_concurrency();

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <numeric>
+#include <random>
 #include <vector>
 
 #include "operon/algorithms/config.hpp"
@@ -65,6 +66,7 @@ struct GaBaseFixture {
     DTable Dtable;
     Operon::Evaluator<DTable>             Evaluator{ &Problem, &Dtable };
     Operon::SubtreeCrossover              Crossover{ 0.9, /*maxDepth=*/6, /*maxLength=*/20 };
+    Operon::OnePointMutation<std::normal_distribution<Operon::Scalar>> OnePoint;
     Operon::MultiMutation                 Mutator;
     Operon::TournamentSelector            FemSel{ Operon::SingleObjectiveComparison{0} };
     Operon::TournamentSelector            MaleSel{ Operon::SingleObjectiveComparison{0} };
@@ -81,6 +83,12 @@ struct GaBaseFixture {
         Problem.SetTrainingRange({0, 10});
         Problem.SetTestRange({0, 10});
         Problem.SetTarget("Y");
+        // Unparameterized, TreeInit's distribution defaults to an unbounded
+        // param_type, so it can request an arbitrarily large tree length.
+        TreeInit.ParameterizeDistribution(std::size_t{1}, std::size_t{10});
+        OnePoint.ParameterizeDistribution(Operon::Scalar{0}, Operon::Scalar{1});
+        // MultiMutation needs at least one operator or it indexes an empty vector.
+        Mutator.Add(&OnePoint, 1.0);
     }
 };
 
@@ -114,6 +122,32 @@ TEST_CASE("RestoreIndividuals maps parents and offspring spans correctly", "[alg
     for (std::size_t i = 0; i < poolSize; ++i) {
         CHECK(offspring[i].Fitness[0] == static_cast<Operon::Scalar>(popSize + i));
     }
+}
+
+TEST_CASE("ReportCallback returning true stops the run before the next generation", "[algorithms]")
+{
+    GaBaseFixture f; // Config.Generations == 1
+    Operon::RandomGenerator rng{42};
+
+    std::size_t calls = 0;
+    f.Gp.Run(rng, [&]() -> bool { ++calls; return true; }, /*threads=*/1);
+
+    // The report fired during init, before the loop body ever ran, so the
+    // generation counter (only incremented inside the body) never advanced.
+    CHECK(calls == 1);
+    CHECK(f.Gp.Generation() == 0);
+}
+
+TEST_CASE("ReportCallback returning false lets the run reach the configured generations", "[algorithms]")
+{
+    GaBaseFixture f; // Config.Generations == 1
+    Operon::RandomGenerator rng{42};
+
+    std::size_t calls = 0;
+    f.Gp.Run(rng, [&]() -> bool { ++calls; return false; }, /*threads=*/1);
+
+    CHECK(f.Gp.Generation() == f.Config.Generations);
+    CHECK(calls == 2); // one report from init, one from the single generation's body
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -10,6 +10,7 @@
 
 #include "operon/algorithms/config.hpp"
 #include "operon/algorithms/gp.hpp"
+#include "operon/algorithms/nsga2.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/dispatch.hpp"
 #include "operon/core/individual.hpp"
@@ -22,6 +23,7 @@
 #include "operon/operators/generator.hpp"
 #include "operon/operators/initializer.hpp"
 #include "operon/operators/mutation.hpp"
+#include "operon/operators/non_dominated_sorter.hpp"
 #include "operon/operators/reinserter.hpp"
 #include "operon/operators/selector.hpp"
 
@@ -77,6 +79,8 @@ struct GaBaseFixture {
     Operon::UniformCoefficientInitializer CoeffInit;
     Operon::GeneticAlgorithmConfig        Config{ MakeConfig(PopSize, PoolSize) };
     Operon::GeneticProgrammingAlgorithm   Gp{ Config, &Problem, &TreeInit, &CoeffInit, &Generator, &Reinserter };
+    Operon::DeductiveSorter               Sorter;
+    Operon::NSGA2                         Nsga{ Config, &Problem, &TreeInit, &CoeffInit, &Generator, &Reinserter, &Sorter };
 
     GaBaseFixture()
     {
@@ -147,6 +151,30 @@ TEST_CASE("ReportCallback returning false lets the run reach the configured gene
     f.Gp.Run(rng, [&]() -> bool { ++calls; return false; }, /*threads=*/1);
 
     CHECK(f.Gp.Generation() == f.Config.Generations);
+    CHECK(calls == 2); // one report from init, one from the single generation's body
+}
+
+TEST_CASE("NSGA2: ReportCallback returning true stops the run before the next generation", "[algorithms]")
+{
+    GaBaseFixture f; // Config.Generations == 1
+    Operon::RandomGenerator rng{42};
+
+    std::size_t calls = 0;
+    f.Nsga.Run(rng, [&]() -> bool { ++calls; return true; }, /*threads=*/1);
+
+    CHECK(calls == 1);
+    CHECK(f.Nsga.Generation() == 0);
+}
+
+TEST_CASE("NSGA2: ReportCallback returning false lets the run reach the configured generations", "[algorithms]")
+{
+    GaBaseFixture f; // Config.Generations == 1
+    Operon::RandomGenerator rng{42};
+
+    std::size_t calls = 0;
+    f.Nsga.Run(rng, [&]() -> bool { ++calls; return false; }, /*threads=*/1);
+
+    CHECK(f.Nsga.Generation() == f.Config.Generations);
     CHECK(calls == 2); // one report from init, one from the single generation's body
 }
 


### PR DESCRIPTION
## Summary
**Breaking:** `ReportCallback` changes from `std::function<void()>` to `std::function<bool()>` — existing callers of `Run(..., std::function<void()>)` will fail to compile (intentional; pyoperon's pin needs a matching update).

`GeneticProgrammingAlgorithm::Run` and `NSGA2::Run` took a `std::function<void()>` report callback invoked once per generation, with no way for it to signal anything back — early stopping (pyoperon #18) needed C++ changes regardless of algorithm, so this adds the mechanism once, generically, in the shared `GeneticAlgorithmBase` rather than per-algorithm:

- `Operon::ReportCallback = std::function<bool()>`, returning true requests stop
- `GeneticAlgorithmBase::StopRequested()`/`RequestStop()`/`Reset()` holds the shared flag, backed by `std::atomic<bool>` — safe to call `RequestStop()` from outside the callback (another thread, a signal handler, a Jupyter interrupt) for pyoperon's use case, not just from within `ReportCallback`
- both algorithms' own `stop()` conditions OR it in alongside their existing `Terminate()`/generation-count/time-limit checks

Updates all call sites (CLI, example, tests) to the new signature. Also adds regression tests exercising both directions on both GP and NSGA2 (the two algorithms have separate copies of the reportProgress/stop() wiring, so a mirror test catches a regression in either), which along the way surfaced two pre-existing gaps in the `ga_base.cpp` test fixture that had never actually been exercised via `Run()` before: an unparameterized `TreeInit` distribution (defaults to an unbounded range, causing `std::bad_alloc`) and an empty `MultiMutation` (segfaults indexing into no operators).

`std::atomic<bool>` isn't copyable, so `GeneticAlgorithmBase`'s previously-defaulted copy constructor/assignment are now hand-written (every other member copied exactly as `= default` would have done).

## Test plan
- [x] New regression tests in `test/source/implementation/ga_base.cpp` exercise early-stop in both directions, on both GP and NSGA2
- [x] `cmake --build build --target operon_test` + `./operon_test "[algorithms]"` — 8 test cases, 34 assertions, all pass
- [ ] CI green