### PR TITLE
fix(cli): separate OPERON_STATIC_CLI from BUILD_SHARED_LIBS

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -14,6 +14,14 @@ endif()
 find_package(cxxopts REQUIRED)
 find_package(scn REQUIRED)
 
+# Fully static-link the CLI executables (against libc and every dependency,
+# not just liboperon). Distinct from BUILD_SHARED_LIBS (which only controls
+# whether liboperon itself is a .a or .so): this additionally requires every
+# dependency to be available as a static archive, so it's opt-in and only
+# meant for a dedicated build (e.g. the flake's cli-static output) rather
+# than a default derived from BUILD_SHARED_LIBS=OFF.
+option(OPERON_STATIC_CLI "Fully statically link the CLI executables" OFF)
+
 function(add_operon_cli NAME)
     add_executable(${NAME}
         source/${NAME}.cpp
@@ -35,7 +43,7 @@ function(add_operon_cli NAME)
     else()
         if (UNIX AND NOT APPLE)
             target_link_options(${NAME} PRIVATE "-Wl,--no-undefined")
-            if (NOT BUILD_SHARED_LIBS)
+            if (OPERON_STATIC_CLI)
                 target_link_options(${NAME} PRIVATE "-static")
             endif()
         endif()

--- a/operon.nix
+++ b/operon.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     "-DUSE_SINGLE_PRECISION=ON"
     "-DUSE_ASMJIT=${if enableAsmjit then "ON" else "OFF"}"
     "-DBUILD_SHARED_LIBS=${if enableShared then "YES" else "NO"}"
+  ] ++ pkgs.lib.optionals (!enableShared) [
+    "-DOPERON_STATIC_CLI=ON"
   ];
   cmakeBuildType = "Release";
 


### PR DESCRIPTION
## Summary
Found while testing the callback change in #102: the CLI's `-static` linker flag was gated on `NOT BUILD_SHARED_LIBS`, but that flag only ever meant "build liboperon itself as `.a` instead of `.so`" — it doesn't imply every dependency is available as a static archive. A plain static-library build (`BUILD_SHARED_LIBS=OFF`, the normal devShell otherwise unchanged) tried to `-static` link against still-shared scnlib/asmjit/etc. and failed. Split into its own option, defaulted OFF, only turned on by the flake's dedicated `cli-static`/`library-static` outputs where every dependency is actually static.

## Test plan
- [ ] CI green
- [ ] `nix build .#cli-static` still links fully static
- [ ] Plain `BUILD_SHARED_LIBS=OFF` build no longer fails