### PR TITLE
fix(build): default build-linux/build-osx presets to BUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,6 +88,9 @@
             "environment": {
                 "CXX_WARNINGS": "-Wall -Wextra -Werror -pedantic",
                 "CXX_OPT": "-fsized-deallocation -fno-math-errno -march=x86-64-v3"
+            },
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": "ON"
             }
         },
         {
@@ -98,6 +101,9 @@
             "environment": {
                 "CXX_WARNINGS": "-Wall -Wextra -pedantic",
                 "CXX_OPT": "-fsized-deallocation -fno-math-errno"
+            },
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": "ON"
             }
         }
     ]

--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -16,6 +16,7 @@
 #include "operon/core/tree.hpp"
 #include "operon/core/tree_diff.hpp"
 #include "operon/core/types.hpp"
+#include "operon/operon_export.hpp"
 
 namespace Operon::JIT {
 
@@ -96,7 +97,7 @@ struct JitRuntimePool {
 
 // Stateless JIT code generator. All runtime state lives in the JitRuntimePool
 // provided at construction; TreeCompiler can be destroyed before the pool.
-class TreeCompiler {
+class OPERON_EXPORT TreeCompiler {
 public:
     explicit TreeCompiler(JitRuntimePool const* pool) : pool_(pool) {}
 


### PR DESCRIPTION
## Summary
- The presets defaulted to CMake's static-linking default while the nix devShell only provides a shared `scn`, causing `attempted static link of dynamic object .../libscn.so` for any CLI target built from the presets.
- Sets `BUILD_SHARED_LIBS=ON` as the cache variable default on both `build-linux` and `build-osx` presets so preset builds match what the devShell actually provides.
- Flipping the default surfaced a second, pre-existing bug: `Operon::JIT::TreeCompiler` was missing `OPERON_EXPORT`, so its methods were invisible across the shared-lib boundary and `operon_test` failed to link once `BUILD_SHARED_LIBS=ON`. Fixed by exporting the class.

## Test plan
- [x] Configured with `--preset build-linux` (`BUILD_SHARED_LIBS=ON` picked up from the preset) and built `operon_test` locally with `-Doperon_DEVELOPER_MODE=ON`; links cleanly.
- [x] CI (linux/macos/windows) exercises the same preset-based build+test.