### PR TITLE
feat(core): content hash + Grammar for exhaustive expression enumeration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(
     source/formatter/infix.cpp
     source/formatter/postfix.cpp
     source/formatter/tree.cpp
+    source/hash/content_hash.cpp
     source/hash/hash.cpp
     source/hash/metrohash64.cpp
     source/hash/zobrist.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(
     source/algorithms/solution_archive.cpp
     source/core/dataset.cpp
     source/core/distance.cpp
+    source/core/grammar.cpp
     source/core/node.cpp
     source/core/pset.cpp
     source/core/tree.cpp

--- a/include/operon/core/grammar.hpp
+++ b/include/operon/core/grammar.hpp
@@ -29,10 +29,12 @@ namespace Operon {
 //
 // Deviates from symreg-cpp in one respect: symreg-cpp's InvFactor/InvExpr/
 // InvTerm (a dedicated 1/x reciprocal wrapper) has no corresponding operon
-// NodeType - operon's Div is already an n-ary/binary operator, so the same
-// expressive need (e.g. 1/x) is already reachable at the RecurringFactor
-// level via Div(Constant, SimpleExpr) when Div is enabled, without a
-// dedicated nonterminal.
+// NodeType, and no corresponding production either - this grammar currently
+// only produces Add/Mul (plus the five unary wraps below), so Div/Sub/Pow
+// (and thus 1/x) aren't reachable yet. Production has no way to express a
+// fixed-constant operand (e.g. a Div's numerator) mixed with a nonterminal
+// operand, so adding this isn't a drop-in rule - it's tracked as follow-up
+// work once the current enumeration stack lands.
 enum class GrammarSymbol : uint8_t {
     Expression,      // Constant*Term + Constant | Constant*Term + Expression
     Term,            // RecurringFactor | Term * Term (flattened by Tree::Reduce())

--- a/include/operon/core/grammar.hpp
+++ b/include/operon/core/grammar.hpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_CORE_GRAMMAR_HPP
+#define OPERON_CORE_GRAMMAR_HPP
+
+#include <array>
+#include <span>
+#include <vector>
+
+#include "operon/core/node.hpp"
+#include "operon/core/types.hpp"
+#include "operon/operon_export.hpp"
+
+namespace Operon {
+
+// Nonterminal categories for exhaustive grammar enumeration, reproducing the
+// language of symreg-cpp's grammar (a sum of weighted products of "recurring
+// factors", where each unary transcendental wraps a shallow, non-recursive
+// sub-grammar) using operon's NodeType vocabulary. See grammar.cpp for the
+// concrete production list.
+//
+// SimpleExpr/SimpleTerm are the cut-down sub-grammar used inside unary-
+// function arguments: SimpleTerm bottoms out at bare variables only (no
+// RecurringFactor/unary recursion), which is what actually keeps unary
+// nesting shallow (e.g. no log(sin(...))) - not a restriction on how many
+// weighted terms SimpleExpr itself may sum.
+//
+// Deviates from symreg-cpp in one respect: symreg-cpp's InvFactor/InvExpr/
+// InvTerm (a dedicated 1/x reciprocal wrapper) has no corresponding operon
+// NodeType - operon's Div is already an n-ary/binary operator, so the same
+// expressive need (e.g. 1/x) is already reachable at the RecurringFactor
+// level via Div(Constant, SimpleExpr) when Div is enabled, without a
+// dedicated nonterminal.
+enum class GrammarSymbol : uint8_t {
+    Expression,      // Constant*Term + Constant | Constant*Term + Expression
+    Term,            // RecurringFactor | Term * Term (flattened by Tree::Reduce())
+    RecurringFactor, // Variable | unary(SimpleExpr) for each enabled unary NodeType
+    SimpleExpr,      // Constant*SimpleTerm + Constant | Constant*SimpleTerm + SimpleExpr
+    SimpleTerm,      // Variable | SimpleTerm * SimpleTerm (flattened by Tree::Reduce())
+};
+
+struct GrammarSymbols {
+    static constexpr auto Count = static_cast<std::size_t>(GrammarSymbol::SimpleTerm) + 1UL;
+    static constexpr auto GetIndex(GrammarSymbol s) -> std::size_t { return static_cast<std::size_t>(s); }
+};
+
+// A production is a recipe for building one new Tree from already-built
+// operand subtrees (drawn from lower-budget DP buckets - see
+// algorithms/enumeration.hpp), not a literal CFG string-rewrite rule: the
+// enumeration engine only ever expands one level at a time, so there is no
+// need for symreg-cpp's generic grammar-string worklist machinery.
+struct Production {
+    // Operator Node appended when combining Operands. NodeTypes::NoType marks
+    // a pure coercion (e.g. Term -> RecurringFactor): the operand's tree is
+    // used as-is, no new node is appended, and no complexity is added.
+    NodeType Op{NodeTypes::NoType};
+    // Nonterminal categories combined, in order. A self-combine (e.g.
+    // {Term, Term} for Op=Mul) relies on Tree::Reduce() to flatten the
+    // resulting nested Mul into one flat n-ary node, so it enumerates the
+    // same language as a strictly right-recursive "Factor * Term" rule would,
+    // via the more DP-natural "split the budget between two same-category
+    // operands" recurrence.
+    std::vector<GrammarSymbol> Operands;
+    // Whether the first Operand gets an implicit "* Constant" (a free,
+    // optimizable weight) prepended before combining via Op. Only ever true
+    // for Expression/SimpleExpr's Term/SimpleTerm operand - the recursive
+    // continuation operand (Expression/SimpleExpr itself) is never
+    // reweighted, since it will contribute its own weight further down.
+    bool WeightFirstOperand{false};
+    // Whether an implicit trailing "+ Constant" bias leaf is appended as one
+    // more Add operand. Affects Tree::Length() but not Complexity (constants
+    // are excluded from the complexity count - see Grammar::MinComplexity).
+    bool TrailingConstant{false};
+
+    [[nodiscard]] auto IsCoercion() const noexcept -> bool { return Op == NodeTypes::NoType; }
+};
+
+// Queryable, config/dataset-parameterized grammar for exhaustive expression
+// enumeration - plays the same role for the enumeration algorithm that
+// PrimitiveSet plays for stochastic tree generation.
+class OPERON_EXPORT Grammar {
+public:
+    // Equivalent to Grammar(PrimitiveSetConfig{}, {}): Rebuild() still runs, so
+    // MinComplexity() consistently reports Unreachable everywhere rather than
+    // leaving minComplexity_ zero-initialized (which would misreport every
+    // nonterminal as trivially achievable at complexity 0).
+    Grammar() : Grammar(PrimitiveSetConfig{}, {}) {}
+    Grammar(PrimitiveSetConfig enabledFunctions, std::vector<Operon::Hash> variableHashes);
+
+    // (Re)builds the unary-wrap productions on RecurringFactor from a
+    // PrimitiveSetConfig bitset - the same bitset type as
+    // PrimitiveSet::Config(), so a Grammar can be constructed straight from
+    // Problem::GetPrimitiveSet().Config().
+    auto Configure(PrimitiveSetConfig config) -> Grammar&;
+
+    // (Re)builds which variable hashes seed RecurringFactor's/SimpleTerm's
+    // terminal (budget-1) buckets, without touching function-derived rules.
+    auto SetVariables(std::vector<Operon::Hash> variableHashes) -> Grammar&;
+
+    [[nodiscard]] auto Productions(GrammarSymbol nt) const -> std::span<Production const> {
+        return rules_.at(GrammarSymbols::GetIndex(nt));
+    }
+
+    [[nodiscard]] auto VariableHashes() const -> std::span<Operon::Hash const> { return variables_; }
+    [[nodiscard]] auto Config() const -> PrimitiveSetConfig { return config_; }
+
+    // Whether `nt` terminates directly in a Variable leaf (i.e. whether the
+    // DP engine's terminal-seeding step should populate this nonterminal's
+    // budget-1 bucket with one Variable-leaf tree per VariableHashes() entry).
+    [[nodiscard]] auto AllowsVariable(GrammarSymbol nt) const -> bool {
+        return nt == GrammarSymbol::RecurringFactor || nt == GrammarSymbol::SimpleTerm;
+    }
+
+    // Minimum achievable Complexity (see Grammar::MinComplexity's definition:
+    // count of all non-Constant nodes) for a nonterminal - a fixed point over
+    // the production table, computed once in Configure()/SetVariables(). Used
+    // by the DP engine to skip budget/operand splits that could never be
+    // satisfied by any derivable expression.
+    [[nodiscard]] auto MinComplexity(GrammarSymbol nt) const -> size_t {
+        return minComplexity_.at(GrammarSymbols::GetIndex(nt));
+    }
+
+private:
+    void Rebuild();
+
+    std::array<std::vector<Production>, GrammarSymbols::Count> rules_;
+    std::array<size_t, GrammarSymbols::Count> minComplexity_{};
+    std::vector<Operon::Hash> variables_;
+    PrimitiveSetConfig config_;
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/hash/content_hash.hpp
+++ b/include/operon/hash/content_hash.hpp
@@ -26,6 +26,12 @@ namespace Operon {
 // than Tree::Hash()'s concatenate-then-XXH64, since this is called on a fixed,
 // tiny number of already-64-bit values per node - a general-purpose streaming
 // hash function is unnecessary overhead here.
+//
+// Two semantic decisions carried over from Tree::Hash(): a node's Optimize
+// flag is masked out (weights are re-fit, not distinct symbols for dedup
+// purposes), and NodeType::Ref nodes inherit their target's hash rather than
+// hashing the Ref node itself, so structurally equivalent subexpressions hash
+// identically regardless of whether they're expressed via Ref sharing.
 
 // Working buffers for the scratch overload below, both sized >= tree.Nodes().size()
 // (Indices holds a node's child indices - a node's Arity is always < its own node

--- a/include/operon/hash/content_hash.hpp
+++ b/include/operon/hash/content_hash.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_HASH_CONTENT_HASH_HPP
+#define OPERON_HASH_CONTENT_HASH_HPP
+
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "operon/hash/zobrist.hpp"
+#include "operon/operon_export.hpp"
+
+namespace Operon {
+
+// Cheap, position-independent (content-addressed) structural hash for a Tree,
+// intended for subexpression memoization/dedup rather than Zobrist's whole-tree
+// transposition-cache role (which is deliberately position-*dependent* and has
+// no notion of combining children into a parent's hash at all).
+//
+// Computed bottom-up like Tree::Hash(): each node's hash folds in its children's
+// already-computed hashes (sorted first when the node IsCommutative(), so e.g.
+// x+y and y+x hash identically), seeded per node by zobrist.ComputeHash(node, 0)
+// - reusing Zobrist's existing random table purely as a per-node-type/per-
+// variable salt (pos is always 0: this hash has no array-position dimension).
+// The combine step is a cheap splitmix64/boost::hash_combine-style mixer rather
+// than Tree::Hash()'s concatenate-then-XXH64, since this is called on a fixed,
+// tiny number of already-64-bit values per node - a general-purpose streaming
+// hash function is unnecessary overhead here.
+
+// Computes one content-hash per node into `scratch` (sized >= tree.Nodes().size()),
+// bottom-up; returns the root's (last node's) hash. Exposed so callers processing
+// many candidates can reuse one scratch buffer instead of allocating per call.
+[[nodiscard]] OPERON_EXPORT auto ComputeContentHash(
+    Operon::Tree const& tree,
+    Operon::Zobrist const& zobrist,
+    Operon::Span<Operon::Hash> scratch
+) noexcept -> Operon::Hash;
+
+// Convenience overload allocating its own scratch buffer.
+[[nodiscard]] OPERON_EXPORT auto ComputeContentHash(
+    Operon::Tree const& tree,
+    Operon::Zobrist const& zobrist
+) -> Operon::Hash;
+
+} // namespace Operon
+
+#endif

--- a/include/operon/hash/content_hash.hpp
+++ b/include/operon/hash/content_hash.hpp
@@ -27,13 +27,21 @@ namespace Operon {
 // tiny number of already-64-bit values per node - a general-purpose streaming
 // hash function is unnecessary overhead here.
 
-// Computes one content-hash per node into `scratch` (sized >= tree.Nodes().size()),
-// bottom-up; returns the root's (last node's) hash. Exposed so callers processing
-// many candidates can reuse one scratch buffer instead of allocating per call.
+// Working buffers for the scratch overload below, both sized >= tree.Nodes().size()
+// (Indices holds a node's child indices - a node's Arity is always < its own node
+// count). Bundled into one struct so callers processing many candidates can carry
+// and reuse both as a unit instead of allocating per call.
+struct ContentHashScratch {
+    Operon::Span<Operon::Hash> Hashes;
+    Operon::Span<std::size_t> Indices;
+};
+
+// Computes one content-hash per node into `scratch.Hashes`, bottom-up; returns the
+// root's (last node's) hash.
 [[nodiscard]] OPERON_EXPORT auto ComputeContentHash(
     Operon::Tree const& tree,
     Operon::Zobrist const& zobrist,
-    Operon::Span<Operon::Hash> scratch
+    ContentHashScratch scratch
 ) noexcept -> Operon::Hash;
 
 // Convenience overload allocating its own scratch buffer.

--- a/source/core/grammar.cpp
+++ b/source/core/grammar.cpp
@@ -77,8 +77,10 @@ void Grammar::Rebuild()
     minComplexity_.fill(Unreachable);
 
     if (!variables_.empty()) {
+        // Both nonterminals here return true from AllowsVariable() by
+        // construction (see grammar.hpp) - no guard needed.
         for (auto nt : { GrammarSymbol::RecurringFactor, GrammarSymbol::SimpleTerm }) {
-            if (AllowsVariable(nt)) { minComplexity_[GrammarSymbols::GetIndex(nt)] = 1; }
+            minComplexity_[GrammarSymbols::GetIndex(nt)] = 1;
         }
     }
 

--- a/source/core/grammar.cpp
+++ b/source/core/grammar.cpp
@@ -4,7 +4,6 @@
 
 #include "operon/core/grammar.hpp"
 
-#include <algorithm>
 #include <limits>
 
 namespace Operon {
@@ -83,7 +82,8 @@ void Grammar::Rebuild()
         }
     }
 
-    for (std::size_t pass = 0; pass < GrammarSymbols::Count; ++pass) {
+    for (bool changed = true; changed;) {
+        changed = false;
         for (std::size_t i = 0; i < GrammarSymbols::Count; ++i) {
             for (auto const& p : rules_[i]) {
                 bool reachable = true;
@@ -93,8 +93,9 @@ void Grammar::Rebuild()
                     if (c == Unreachable) { reachable = false; break; }
                     total += c;
                 }
-                if (reachable) {
-                    minComplexity_[i] = std::min(minComplexity_[i], total);
+                if (reachable && total < minComplexity_[i]) {
+                    minComplexity_[i] = total;
+                    changed = true;
                 }
             }
         }

--- a/source/core/grammar.cpp
+++ b/source/core/grammar.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/core/grammar.hpp"
+
+#include <algorithm>
+#include <limits>
+
+namespace Operon {
+
+namespace {
+    // Unary NodeTypes that may wrap a SimpleExpr as a RecurringFactor, gated
+    // by whether each is enabled in the configured PrimitiveSetConfig.
+    // Mirrors symreg-cpp's grammar.cpp (LogFactor/ExpFactor/SinFactor/
+    // SqrtFactor/CbrtFactor); InvFactor is intentionally not reproduced (see
+    // grammar.hpp's GrammarSymbol comment).
+    constexpr std::array UnaryWraps { NodeType::Log, NodeType::Exp, NodeType::Sin, NodeType::Sqrt, NodeType::Cbrt };
+} // namespace
+
+Grammar::Grammar(PrimitiveSetConfig enabledFunctions, std::vector<Operon::Hash> variableHashes)
+    : variables_(std::move(variableHashes))
+    , config_(enabledFunctions)
+{
+    Rebuild();
+}
+
+auto Grammar::Configure(PrimitiveSetConfig config) -> Grammar&
+{
+    config_ = config;
+    Rebuild();
+    return *this;
+}
+
+auto Grammar::SetVariables(std::vector<Operon::Hash> variableHashes) -> Grammar&
+{
+    variables_ = std::move(variableHashes);
+    Rebuild();
+    return *this;
+}
+
+void Grammar::Rebuild()
+{
+    for (auto& r : rules_) { r.clear(); }
+
+    auto& recurringFactor = rules_[GrammarSymbols::GetIndex(GrammarSymbol::RecurringFactor)];
+    for (auto op : UnaryWraps) {
+        if (config_.Test(NodeTypes::GetIndex(op))) {
+            recurringFactor.push_back(Production{ .Op = op, .Operands = { GrammarSymbol::SimpleExpr } });
+        }
+    }
+
+    rules_[GrammarSymbols::GetIndex(GrammarSymbol::Term)] = {
+        Production{ .Op = NodeTypes::NoType, .Operands = { GrammarSymbol::RecurringFactor } }, // coercion
+        Production{ .Op = NodeType::Mul, .Operands = { GrammarSymbol::Term, GrammarSymbol::Term } },
+    };
+
+    rules_[GrammarSymbols::GetIndex(GrammarSymbol::SimpleTerm)] = {
+        Production{ .Op = NodeType::Mul, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleTerm } },
+    };
+
+    rules_[GrammarSymbols::GetIndex(GrammarSymbol::Expression)] = {
+        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::Term }, .WeightFirstOperand = true, .TrailingConstant = true },
+        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::Term, GrammarSymbol::Expression }, .WeightFirstOperand = true, .TrailingConstant = false },
+    };
+
+    rules_[GrammarSymbols::GetIndex(GrammarSymbol::SimpleExpr)] = {
+        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::SimpleTerm }, .WeightFirstOperand = true, .TrailingConstant = true },
+        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleExpr }, .WeightFirstOperand = true, .TrailingConstant = false },
+    };
+
+    // Fixed-point over the production table for MinComplexity. Complexity
+    // counts every non-Constant node (see grammar.hpp), so a coercion or a
+    // weighted-operand production contributes: 1 per non-coercion Op node,
+    // plus 1 more for the implicit Mul introduced by WeightFirstOperand
+    // (TrailingConstant never adds complexity - constants are excluded).
+    constexpr auto Unreachable = std::numeric_limits<size_t>::max();
+    minComplexity_.fill(Unreachable);
+
+    if (!variables_.empty()) {
+        for (auto nt : { GrammarSymbol::RecurringFactor, GrammarSymbol::SimpleTerm }) {
+            if (AllowsVariable(nt)) { minComplexity_[GrammarSymbols::GetIndex(nt)] = 1; }
+        }
+    }
+
+    for (std::size_t pass = 0; pass < GrammarSymbols::Count; ++pass) {
+        for (std::size_t i = 0; i < GrammarSymbols::Count; ++i) {
+            for (auto const& p : rules_[i]) {
+                bool reachable = true;
+                size_t total = p.IsCoercion() ? 0 : (1 + (p.WeightFirstOperand ? 1 : 0));
+                for (auto operand : p.Operands) {
+                    auto c = minComplexity_[GrammarSymbols::GetIndex(operand)];
+                    if (c == Unreachable) { reachable = false; break; }
+                    total += c;
+                }
+                if (reachable) {
+                    minComplexity_[i] = std::min(minComplexity_[i], total);
+                }
+            }
+        }
+    }
+}
+
+} // namespace Operon

--- a/source/hash/content_hash.cpp
+++ b/source/hash/content_hash.cpp
@@ -35,7 +35,15 @@ auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<O
 
     for (std::size_t i = 0; i < nodes.size(); ++i) {
         auto const& n = nodes[i];
-        auto h = zobrist.ComputeHash(n, /*pos=*/0);
+
+        // Optimize is masked out: two structurally-identical subtrees that
+        // differ only in which leaves are marked optimizable should collide
+        // here, since weights are re-fit rather than treated as distinct
+        // symbols (unlike Zobrist::ComputeHash's whole-tree role, where
+        // Optimize legitimately participates - see zobrist.hpp).
+        auto masked = n;
+        masked.Optimize = false;
+        auto h = zobrist.ComputeHash(masked, /*pos=*/0);
 
         if (!n.IsLeaf()) {
             std::ranges::copy(Tree::Indices(nodes, i), std::back_inserter(childIndices));

--- a/source/hash/content_hash.cpp
+++ b/source/hash/content_hash.cpp
@@ -36,6 +36,15 @@ auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<O
     for (std::size_t i = 0; i < nodes.size(); ++i) {
         auto const& n = nodes[i];
 
+        if (n.IsRef()) {
+            // A Ref inherits its target's hash, same as Tree::Hash() (see
+            // tree.cpp), so structurally equivalent subexpressions hash
+            // identically regardless of whether they're shared via Ref.
+            EXPECT(n.RefTo < i); // must be a backward reference
+            scratch[i] = scratch[n.RefTo];
+            continue;
+        }
+
         // Optimize is masked out: two structurally-identical subtrees that
         // differ only in which leaves are marked optimizable should collide
         // here, since weights are re-fit rather than treated as distinct

--- a/source/hash/content_hash.cpp
+++ b/source/hash/content_hash.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/hash/content_hash.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace Operon {
+
+namespace {
+    // splitmix64/boost::hash_combine-style: cheap, no allocation, no table
+    // lookups - unlike Tree::Hash()'s combine step, which concatenates children's
+    // hashes into a byte buffer and runs a general-purpose streaming hash
+    // (Operon::Hasher/XXH64) over it, overkill for folding in one 64-bit value.
+    // Internal-only: not part of the public API, just ComputeContentHash's combine step.
+    auto MixHash(Operon::Hash a, Operon::Hash b) noexcept -> Operon::Hash
+    {
+        constexpr Operon::Hash Mul = 0x9E3779B97F4A7C15ULL; // golden-ratio odd constant
+        a ^= b + Mul + (a << 6UL) + (a >> 2UL);
+        return a;
+    }
+} // namespace
+
+auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<Operon::Hash> scratch) noexcept -> Operon::Hash
+{
+    auto const& nodes = tree.Nodes();
+    EXPECT(scratch.size() >= nodes.size());
+
+    if (nodes.empty()) { return 0; } // matches Tree::HashValue()'s empty-tree convention
+
+    std::vector<std::size_t> childIndices;
+    childIndices.reserve(nodes.size());
+
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
+        auto const& n = nodes[i];
+        auto h = zobrist.ComputeHash(n, /*pos=*/0);
+
+        if (!n.IsLeaf()) {
+            std::ranges::copy(Tree::Indices(nodes, i), std::back_inserter(childIndices));
+            auto begin = childIndices.begin();
+            auto end = begin + n.Arity;
+            if (n.IsCommutative()) {
+                std::sort(begin, end, [&](auto a_, auto b_) { return scratch[a_] < scratch[b_]; });
+            }
+            for (auto it = begin; it != end; ++it) { h = MixHash(h, scratch[*it]); }
+            childIndices.clear();
+        }
+
+        scratch[i] = h;
+    }
+
+    return scratch[nodes.size() - 1];
+}
+
+auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist) -> Operon::Hash
+{
+    std::vector<Operon::Hash> scratch(tree.Nodes().size());
+    return ComputeContentHash(tree, zobrist, scratch);
+}
+
+} // namespace Operon

--- a/source/hash/content_hash.cpp
+++ b/source/hash/content_hash.cpp
@@ -23,15 +23,16 @@ namespace {
     }
 } // namespace
 
-auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<Operon::Hash> scratch) noexcept -> Operon::Hash
+auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, ContentHashScratch scratch) noexcept -> Operon::Hash
 {
     auto const& nodes = tree.Nodes();
-    EXPECT(scratch.size() >= nodes.size());
+    auto& hashes = scratch.Hashes;
+    auto& indices = scratch.Indices;
 
     if (nodes.empty()) { return 0; } // matches Tree::HashValue()'s empty-tree convention
 
-    std::vector<std::size_t> childIndices;
-    childIndices.reserve(nodes.size());
+    EXPECT(hashes.size() >= nodes.size());
+    EXPECT(indices.size() >= nodes.size());
 
     for (std::size_t i = 0; i < nodes.size(); ++i) {
         auto const& n = nodes[i];
@@ -41,7 +42,7 @@ auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<O
             // tree.cpp), so structurally equivalent subexpressions hash
             // identically regardless of whether they're shared via Ref.
             EXPECT(n.RefTo < i); // must be a backward reference
-            scratch[i] = scratch[n.RefTo];
+            hashes[i] = hashes[n.RefTo];
             continue;
         }
 
@@ -55,26 +56,25 @@ auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist, Operon::Span<O
         auto h = zobrist.ComputeHash(masked, /*pos=*/0);
 
         if (!n.IsLeaf()) {
-            std::ranges::copy(Tree::Indices(nodes, i), std::back_inserter(childIndices));
-            auto begin = childIndices.begin();
-            auto end = begin + n.Arity;
+            auto begin = indices.begin();
+            auto end = std::ranges::copy(Tree::Indices(nodes, i), begin).out;
             if (n.IsCommutative()) {
-                std::sort(begin, end, [&](auto a_, auto b_) { return scratch[a_] < scratch[b_]; });
+                std::sort(begin, end, [&](auto a_, auto b_) { return hashes[a_] < hashes[b_]; });
             }
-            for (auto it = begin; it != end; ++it) { h = MixHash(h, scratch[*it]); }
-            childIndices.clear();
+            for (auto it = begin; it != end; ++it) { h = MixHash(h, hashes[*it]); }
         }
 
-        scratch[i] = h;
+        hashes[i] = h;
     }
 
-    return scratch[nodes.size() - 1];
+    return hashes[nodes.size() - 1];
 }
 
 auto ComputeContentHash(Tree const& tree, Zobrist const& zobrist) -> Operon::Hash
 {
-    std::vector<Operon::Hash> scratch(tree.Nodes().size());
-    return ComputeContentHash(tree, zobrist, scratch);
+    std::vector<Operon::Hash> hashes(tree.Nodes().size());
+    std::vector<std::size_t> indices(tree.Nodes().size());
+    return ComputeContentHash(tree, zobrist, ContentHashScratch{ .Hashes = hashes, .Indices = indices });
 }
 
 } // namespace Operon

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(operon_test
     source/implementation/error_metrics.cpp
     source/implementation/information_criteria.cpp
     source/implementation/content_hash.cpp
+    source/implementation/grammar.cpp
     source/implementation/hashing.cpp
     source/implementation/zobrist.cpp
     source/implementation/infix_parser.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(operon_test
     source/implementation/evaluation.cpp
     source/implementation/error_metrics.cpp
     source/implementation/information_criteria.cpp
+    source/implementation/content_hash.cpp
     source/implementation/hashing.cpp
     source/implementation/zobrist.cpp
     source/implementation/infix_parser.cpp

--- a/test/source/implementation/content_hash.cpp
+++ b/test/source/implementation/content_hash.cpp
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <unordered_set>
+
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/pset.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/hash/content_hash.hpp"
+#include "operon/hash/zobrist.hpp"
+#include "operon/operators/creator.hpp"
+#include "operon/operators/initializer.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    constexpr auto Seed      = 42UL;
+    constexpr auto MaxLength = 50;
+
+    auto MakeSetup() {
+        auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+        auto inputs = ds.VariableHashes();
+        std::erase(inputs, ds.GetVariable("Y").value().Hash);
+        PrimitiveSet pset;
+        pset.SetConfig(PrimitiveSet::Arithmetic);
+        return std::make_tuple(std::move(ds), std::move(inputs), std::move(pset));
+    }
+} // namespace
+
+TEST_CASE("ContentHash - determinism", "[content_hash]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    Operon::CoefficientInitializer<std::uniform_real_distribution<Operon::Scalar>> const initializer;
+
+    auto tree = creator(rng, 20, 1, MaxLength);
+    initializer(rng, tree);
+
+    auto h1 = ComputeContentHash(tree, zobrist);
+    auto h2 = ComputeContentHash(tree, zobrist);
+    REQUIRE(h1 == h2);
+}
+
+TEST_CASE("ContentHash - commutative invariance", "[content_hash]")
+{
+    // Add(X, Y) and Add(Y, X) must hash identically - the whole point of this
+    // hash is to collapse commutative reorderings for dedup purposes.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    auto const varX = ds.GetVariable("X1").value();
+    auto const varY = ds.GetVariable("X2").value();
+
+    Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
+    Node nY(NodeType::Variable); nY.HashValue = varY.Hash;
+
+    Tree const treeXY = Tree({ nX, nY, Node(NodeType::Add) }).UpdateNodes();
+    Tree const treeYX = Tree({ nY, nX, Node(NodeType::Add) }).UpdateNodes();
+
+    REQUIRE(ComputeContentHash(treeXY, zobrist) == ComputeContentHash(treeYX, zobrist));
+}
+
+TEST_CASE("ContentHash - non-commutative sensitivity", "[content_hash]")
+{
+    // Sub(X, Y) and Sub(Y, X) are different expressions and must hash
+    // differently - only commutative operators get their children reordered.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    auto const varX = ds.GetVariable("X1").value();
+    auto const varY = ds.GetVariable("X2").value();
+
+    Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
+    Node nY(NodeType::Variable); nY.HashValue = varY.Hash;
+
+    Tree const treeXY = Tree({ nX, nY, Node(NodeType::Sub) }).UpdateNodes();
+    Tree const treeYX = Tree({ nY, nX, Node(NodeType::Sub) }).UpdateNodes();
+
+    REQUIRE(ComputeContentHash(treeXY, zobrist) != ComputeContentHash(treeYX, zobrist));
+}
+
+TEST_CASE("ContentHash - position independence", "[content_hash]")
+{
+    // The same subexpression (x+y) embedded at different absolute array
+    // positions in two different larger trees must hash identically - this is
+    // the key property distinguishing this hash from Zobrist::ComputeHash
+    // (which is deliberately position-*dependent* for its transposition-cache
+    // role). Build (x+y)*z [subtree root at index 2] and z*(x+y) [subtree root
+    // at index 3] and compare the scratch value at each subtree's own root.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    auto const varX = ds.GetVariable("X1").value();
+    auto const varY = ds.GetVariable("X2").value();
+    auto const varZ = ds.GetVariable("X3").value();
+
+    Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
+    Node nY(NodeType::Variable); nY.HashValue = varY.Hash;
+    Node nZ(NodeType::Variable); nZ.HashValue = varZ.Hash;
+
+    // (x+y)*z : postfix [x, y, Add, z, Mul] - subtree root (Add) at index 2
+    Tree const treeA = Tree({ nX, nY, Node(NodeType::Add), nZ, Node(NodeType::Mul) }).UpdateNodes();
+    // z*(x+y) : postfix [z, x, y, Add, Mul] - subtree root (Add) at index 3
+    Tree const treeB = Tree({ nZ, nX, nY, Node(NodeType::Add), Node(NodeType::Mul) }).UpdateNodes();
+
+    std::vector<Operon::Hash> scratchA(treeA.Nodes().size());
+    std::vector<Operon::Hash> scratchB(treeB.Nodes().size());
+    std::ignore = ComputeContentHash(treeA, zobrist, scratchA);
+    std::ignore = ComputeContentHash(treeB, zobrist, scratchB);
+
+    REQUIRE(scratchA[2] == scratchB[3]);
+}
+
+TEST_CASE("ContentHash - scratch overload matches allocating overload", "[content_hash]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 20, 1, MaxLength);
+
+    std::vector<Operon::Hash> scratch(tree.Nodes().size());
+    auto viaScratch = ComputeContentHash(tree, zobrist, scratch);
+    auto viaAlloc = ComputeContentHash(tree, zobrist);
+
+    REQUIRE(viaScratch == viaAlloc);
+}
+
+TEST_CASE("ContentHash - coefficient insensitivity", "[content_hash]")
+{
+    // Mirrors Zobrist's own "different coefficients yield same hash" test:
+    // this hash never looks at Node::Value, only type/variable-identity/
+    // commutative ordering, so structurally identical trees with different
+    // constant values must hash identically (constants are optimizable
+    // weights to be re-fit, not distinct symbols for dedup purposes).
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    Operon::NormalCoefficientInitializer const coeffInit;
+
+    auto tree1 = creator(rng, 20, 1, MaxLength);
+    auto tree2 = tree1; // identical structure
+
+    coeffInit(rng, tree1);
+    coeffInit(rng, tree2); // different coefficients
+
+    REQUIRE(ComputeContentHash(tree1, zobrist) == ComputeContentHash(tree2, zobrist));
+}
+
+TEST_CASE("ContentHash - collision rate sanity check", "[content_hash]")
+{
+    // Coefficient values don't affect this hash (see "coefficient insensitivity"
+    // above), so vary only tree *shape* here - applying random coefficients
+    // would make genuinely-distinct-shape trees collide by design, which isn't
+    // a hash-quality signal, just the intended coefficient-insensitivity.
+    // Size range starts well above 1 so that duplicate *shapes* arising purely
+    // by chance (e.g. two draws both producing a single-variable tree) are
+    // implausible - otherwise an observed "collision" could just mean two
+    // draws produced the same small tree, not that the hash actually collided.
+    size_t const n = 5000;
+    size_t const minLength = 20;
+    size_t const maxLength = 100;
+    size_t const minDepth = 1;
+    size_t const maxDepth = 1000;
+
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rd(1234);
+    Zobrist const zobrist(rd, static_cast<int>(maxLength), inputs);
+
+    std::uniform_int_distribution<size_t> sizeDistribution(minLength, maxLength);
+    auto const btc = BalancedTreeCreator{&pset, inputs, /* bias= */ 0.0, maxLength};
+
+    std::unordered_set<Operon::Hash> seen;
+    for (size_t i = 0; i < n; ++i) {
+        auto tree = btc(rd, sizeDistribution(rd), minDepth, maxDepth);
+        seen.insert(ComputeContentHash(tree, zobrist));
+    }
+
+    auto uniqueRatio = static_cast<double>(seen.size()) / static_cast<double>(n);
+    CHECK(uniqueRatio > 0.98);
+}
+
+TEST_CASE("ContentHash - empty tree returns 0 rather than underflowing", "[content_hash]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    Tree const empty;
+    CHECK(empty.Nodes().empty());
+    CHECK(ComputeContentHash(empty, zobrist) == 0);
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/content_hash.cpp
+++ b/test/source/implementation/content_hash.cpp
@@ -160,6 +160,29 @@ TEST_CASE("ContentHash - coefficient insensitivity", "[content_hash]")
     REQUIRE(ComputeContentHash(tree1, zobrist) == ComputeContentHash(tree2, zobrist));
 }
 
+TEST_CASE("ContentHash - Optimize-flag insensitivity", "[content_hash]")
+{
+    // Unlike Zobrist::ComputeHash (whole-tree transposition cache, where
+    // Optimize legitimately participates), this hash must ignore which
+    // leaves are marked optimizable: two structurally-identical subtrees
+    // differing only in Optimize flags are the same dedup candidate, since
+    // weights are re-fit rather than treated as distinct symbols.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+
+    auto tree1 = creator(rng, 20, 1, MaxLength);
+    auto tree2 = tree1; // identical structure and coefficients
+
+    for (auto& n : tree2.Nodes()) {
+        if (n.IsLeaf()) { n.Optimize = !n.Optimize; }
+    }
+
+    REQUIRE(ComputeContentHash(tree1, zobrist) == ComputeContentHash(tree2, zobrist));
+}
+
 TEST_CASE("ContentHash - collision rate sanity check", "[content_hash]")
 {
     // Coefficient values don't affect this hash (see "coefficient insensitivity"

--- a/test/source/implementation/content_hash.cpp
+++ b/test/source/implementation/content_hash.cpp
@@ -115,8 +115,10 @@ TEST_CASE("ContentHash - position independence", "[content_hash]")
 
     std::vector<Operon::Hash> scratchA(treeA.Nodes().size());
     std::vector<Operon::Hash> scratchB(treeB.Nodes().size());
-    std::ignore = ComputeContentHash(treeA, zobrist, scratchA);
-    std::ignore = ComputeContentHash(treeB, zobrist, scratchB);
+    std::vector<std::size_t> indexScratchA(treeA.Nodes().size());
+    std::vector<std::size_t> indexScratchB(treeB.Nodes().size());
+    std::ignore = ComputeContentHash(treeA, zobrist, { .Hashes = scratchA, .Indices = indexScratchA });
+    std::ignore = ComputeContentHash(treeB, zobrist, { .Hashes = scratchB, .Indices = indexScratchB });
 
     REQUIRE(scratchA[2] == scratchB[3]);
 }
@@ -131,7 +133,8 @@ TEST_CASE("ContentHash - scratch overload matches allocating overload", "[conten
     auto tree = creator(rng, 20, 1, MaxLength);
 
     std::vector<Operon::Hash> scratch(tree.Nodes().size());
-    auto viaScratch = ComputeContentHash(tree, zobrist, scratch);
+    std::vector<std::size_t> indexScratch(tree.Nodes().size());
+    auto viaScratch = ComputeContentHash(tree, zobrist, { .Hashes = scratch, .Indices = indexScratch });
     auto viaAlloc = ComputeContentHash(tree, zobrist);
 
     REQUIRE(viaScratch == viaAlloc);

--- a/test/source/implementation/content_hash.cpp
+++ b/test/source/implementation/content_hash.cpp
@@ -183,6 +183,29 @@ TEST_CASE("ContentHash - Optimize-flag insensitivity", "[content_hash]")
     REQUIRE(ComputeContentHash(tree1, zobrist) == ComputeContentHash(tree2, zobrist));
 }
 
+TEST_CASE("ContentHash - Ref-aware (structural sharing doesn't change the hash)", "[content_hash]")
+{
+    // Mirrors Tree::Hash()'s own Ref-normalization (tree.cpp): x*x built with
+    // an explicit Ref to the first x (structural sharing) must hash the same
+    // as x*x built with two independent Variable nodes (no sharing) - both
+    // are the same expression, and content-hash dedup must not distinguish
+    // them just because one representation happens to use Ref.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const zobrist(rng, MaxLength, inputs);
+
+    auto const varX = ds.GetVariable("X1").value();
+    Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
+
+    // x * x, no sharing: two independent Variable nodes.
+    Tree const noRef = Tree({ nX, nX, Node(NodeType::Mul) }).UpdateNodes();
+
+    // x * Ref(x), sharing the first x via a backward Ref.
+    Tree const withRef = Tree({ nX, Node::Ref(0), Node(NodeType::Mul) }).UpdateNodes();
+
+    REQUIRE(ComputeContentHash(noRef, zobrist) == ComputeContentHash(withRef, zobrist));
+}
+
 TEST_CASE("ContentHash - collision rate sanity check", "[content_hash]")
 {
     // Coefficient values don't affect this hash (see "coefficient insensitivity"

--- a/test/source/implementation/grammar.cpp
+++ b/test/source/implementation/grammar.cpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <limits>
+
+#include "operon/core/grammar.hpp"
+#include "operon/core/pset.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    auto HasUnaryProduction(std::span<Production const> ps, NodeType op) -> bool {
+        return std::ranges::any_of(ps, [&](auto const& p) { return p.Op == op; });
+    }
+} // namespace
+
+TEST_CASE("Grammar - Arithmetic config has no unary RecurringFactor productions", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Arithmetic, { 1, 2, 3 });
+    auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
+    CHECK(ps.empty());
+}
+
+TEST_CASE("Grammar - TypeCoherent config enables Log/Exp/Sin but not Sqrt/Cbrt", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::TypeCoherent, { 1, 2, 3 });
+    auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
+
+    CHECK(HasUnaryProduction(ps, NodeType::Log));
+    CHECK(HasUnaryProduction(ps, NodeType::Exp));
+    CHECK(HasUnaryProduction(ps, NodeType::Sin));
+    CHECK_FALSE(HasUnaryProduction(ps, NodeType::Sqrt));
+    CHECK_FALSE(HasUnaryProduction(ps, NodeType::Cbrt));
+
+    // every RecurringFactor production wraps a SimpleExpr operand
+    for (auto const& p : ps) {
+        REQUIRE(p.Operands.size() == 1);
+        CHECK(p.Operands.front() == GrammarSymbol::SimpleExpr);
+    }
+}
+
+TEST_CASE("Grammar - Full config enables Sqrt/Cbrt too", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Full, { 1, 2, 3 });
+    auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
+
+    CHECK(HasUnaryProduction(ps, NodeType::Log));
+    CHECK(HasUnaryProduction(ps, NodeType::Exp));
+    CHECK(HasUnaryProduction(ps, NodeType::Sin));
+    CHECK(HasUnaryProduction(ps, NodeType::Sqrt));
+    CHECK(HasUnaryProduction(ps, NodeType::Cbrt));
+}
+
+TEST_CASE("Grammar - Configure is independent of Reconfigure order", "[grammar]")
+{
+    Grammar grammar;
+    grammar.Configure(PrimitiveSet::Full);
+    grammar.SetVariables({ 1, 2, 3 });
+    auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
+    CHECK(HasUnaryProduction(ps, NodeType::Sqrt));
+    CHECK(grammar.VariableHashes().size() == 3);
+}
+
+TEST_CASE("Grammar - VariableHashes matches what was set", "[grammar]")
+{
+    std::vector<Operon::Hash> const vars{ 10, 20, 30, 40 };
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    auto got = grammar.VariableHashes();
+    REQUIRE(got.size() == vars.size());
+    CHECK(std::equal(got.begin(), got.end(), vars.begin()));
+}
+
+TEST_CASE("Grammar - AllowsVariable is true only for RecurringFactor/SimpleTerm", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Full, { 1 });
+    CHECK(grammar.AllowsVariable(GrammarSymbol::RecurringFactor));
+    CHECK(grammar.AllowsVariable(GrammarSymbol::SimpleTerm));
+    CHECK_FALSE(grammar.AllowsVariable(GrammarSymbol::Term));
+    CHECK_FALSE(grammar.AllowsVariable(GrammarSymbol::Expression));
+    CHECK_FALSE(grammar.AllowsVariable(GrammarSymbol::SimpleExpr));
+}
+
+TEST_CASE("Grammar - MinComplexity with no variables is unreachable everywhere", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Full, {});
+    constexpr auto Unreachable = std::numeric_limits<size_t>::max();
+    CHECK(grammar.MinComplexity(GrammarSymbol::RecurringFactor) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Term) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Expression) == Unreachable);
+}
+
+TEST_CASE("Grammar - default constructor leaves MinComplexity unreachable everywhere, not zero", "[grammar]")
+{
+    Grammar const grammar; // must behave like Grammar(PrimitiveSetConfig{}, {}), not leave minComplexity_ zero-initialized
+    constexpr auto Unreachable = std::numeric_limits<size_t>::max();
+    CHECK(grammar.MinComplexity(GrammarSymbol::RecurringFactor) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Term) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::SimpleTerm) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Expression) == Unreachable);
+    CHECK(grammar.MinComplexity(GrammarSymbol::SimpleExpr) == Unreachable);
+}
+
+TEST_CASE("Grammar - MinComplexity fixed point with variables present", "[grammar]")
+{
+    // A bare variable (RecurringFactor/SimpleTerm's terminal case) has
+    // complexity 1; Term/SimpleTerm's Mul-self-combine can never beat their
+    // own coercion/terminal base case, so they stay at 1 too. Expression's
+    // and SimpleExpr's cheapest shape is "const*x + const" - a Variable, a
+    // Mul (from the implicit weight), and an Add (from the trailing bias) -
+    // complexity 3 (the two Constant leaves don't count).
+    Grammar grammar(PrimitiveSet::Full, { 1, 2, 3 });
+    CHECK(grammar.MinComplexity(GrammarSymbol::RecurringFactor) == 1);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Term) == 1);
+    CHECK(grammar.MinComplexity(GrammarSymbol::SimpleTerm) == 1);
+    CHECK(grammar.MinComplexity(GrammarSymbol::Expression) == 3);
+    CHECK(grammar.MinComplexity(GrammarSymbol::SimpleExpr) == 3);
+}
+
+TEST_CASE("Grammar - Term and SimpleTerm production shapes", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Arithmetic, { 1 });
+
+    auto term = grammar.Productions(GrammarSymbol::Term);
+    REQUIRE(term.size() == 2);
+    CHECK(term[0].IsCoercion());
+    CHECK(term[0].Operands == std::vector{ GrammarSymbol::RecurringFactor });
+    CHECK(term[1].Op == NodeType::Mul);
+    CHECK(term[1].Operands == std::vector{ GrammarSymbol::Term, GrammarSymbol::Term });
+
+    auto simpleTerm = grammar.Productions(GrammarSymbol::SimpleTerm);
+    REQUIRE(simpleTerm.size() == 1);
+    CHECK(simpleTerm[0].Op == NodeType::Mul);
+    CHECK(simpleTerm[0].Operands == std::vector{ GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleTerm });
+}
+
+TEST_CASE("Grammar - Expression and SimpleExpr production shapes", "[grammar]")
+{
+    Grammar grammar(PrimitiveSet::Arithmetic, { 1 });
+
+    auto expr = grammar.Productions(GrammarSymbol::Expression);
+    REQUIRE(expr.size() == 2);
+    CHECK(expr[0].Op == NodeType::Add);
+    CHECK(expr[0].WeightFirstOperand);
+    CHECK(expr[0].TrailingConstant);
+    CHECK(expr[0].Operands == std::vector{ GrammarSymbol::Term });
+    CHECK(expr[1].Op == NodeType::Add);
+    CHECK(expr[1].WeightFirstOperand);
+    CHECK_FALSE(expr[1].TrailingConstant);
+    CHECK(expr[1].Operands == std::vector{ GrammarSymbol::Term, GrammarSymbol::Expression });
+
+    auto simpleExpr = grammar.Productions(GrammarSymbol::SimpleExpr);
+    REQUIRE(simpleExpr.size() == 2);
+    CHECK(simpleExpr[0].Operands == std::vector{ GrammarSymbol::SimpleTerm });
+    CHECK(simpleExpr[1].Operands == std::vector{ GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleExpr });
+}
+
+} // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Adds `Operon::ComputeContentHash` (`hash/content_hash.hpp`), a cheap structural hash used for subexpression dedup, distinct from `Tree::Hash()`'s position-dependent transposition hash. Its internal combine helper (`MixHash`) is now file-local rather than exported public API, since nothing outside this file calls it.
- Adds `Operon::Grammar` (`core/grammar.hpp`, `core/grammar.cpp`): a typed grammar (`Expression`/`Term`/`RecurringFactor`/`SimpleExpr`/`SimpleTerm` nonterminals + `Production` rules) over a dataset's primitive set and variables, with a bottom-up fixed-point `MinComplexity` computation per nonterminal.
- First two commits of the `operon_enum` feature stack (grammar-based deterministic enumeration search) — no algorithm or CLI yet, just the foundational types the DP engine (next PR) builds on.
- Dropped k-prefix Hungarian notation from a few local constants (`Mul`/`UnaryWraps`/`Unreachable`), matching project convention. (Pre-existing stragglers + a `.clang-tidy` fix to enforce this automatically are in a separate PR.)

## Fixes from review
- `ComputeContentHash` underflowed (`nodes.size() - 1` on an empty tree) causing an out-of-bounds read; now returns `0`, matching `Tree::HashValue()`'s existing empty-tree convention.
- `Grammar`'s default constructor left `minComplexity_` zero-initialized (misreporting every nonterminal as trivially achievable at complexity 0) instead of running `Rebuild()`; now delegates to `Grammar(PrimitiveSetConfig{}, {})` so default-constructed state consistently reports `Unreachable`.
- Member-initializer list used in `Grammar`'s constructor instead of body assignment.

## Test plan
- [x] `operon_test "[content_hash]"` — includes new empty-tree regression test
- [x] `operon_test "[grammar]"` — includes new default-constructed-Grammar regression test
- [x] `operon_test "[content_hash],[grammar]"` — 68 assertions / 19 cases pass