### PR TITLE
chore: drop k-prefix Hungarian notation from constant/variable names

### DIFF
--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -81,13 +81,13 @@ struct CompileMeta {
 // Lifetime rule: must outlive every CompileMeta that was produced from it.
 // JitZobrist declares pool_ before cache_, guaranteeing correct destruction order.
 struct JitRuntimePool {
-    static constexpr int kPoolSize = 8;
+    static constexpr int PoolSize = 8;
 
-    mutable std::array<asmjit::JitRuntime, kPoolSize> runtimes;
+    mutable std::array<asmjit::JitRuntime, PoolSize> runtimes;
     mutable std::atomic<unsigned> next{0};
 
     auto pick() const noexcept -> asmjit::JitRuntime& {
-        return runtimes[next.fetch_add(1U, std::memory_order_relaxed) % static_cast<unsigned>(kPoolSize)];
+        return runtimes[next.fetch_add(1U, std::memory_order_relaxed) % static_cast<unsigned>(PoolSize)];
     }
 
     [[nodiscard]] auto HasAVX2() const noexcept -> bool {

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -15,12 +15,12 @@ using std::string;
 
 namespace Operon {
 namespace {
-    Operon::Map<Operon::Hash, pair<string, string>> kDynDesc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    Operon::Map<Operon::Hash, pair<string, string>> DynDesc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 } // namespace
 
     void Node::RegisterName(Operon::Hash hash, string name, string desc)
     {
-        kDynDesc[hash] = { std::move(name), std::move(desc) };
+        DynDesc[hash] = { std::move(name), std::move(desc) };
     }
 
     static const Operon::Map<NodeType, pair<string, string>> NodeDesc = {
@@ -62,7 +62,7 @@ namespace {
     auto Node::Name() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
         if (Type == NodeType::Dynamic) {
-            if (auto it = kDynDesc.find(HashValue); it != kDynDesc.end()) {
+            if (auto it = DynDesc.find(HashValue); it != DynDesc.end()) {
                 return it->second.first;
             }
         }
@@ -72,7 +72,7 @@ namespace {
     auto Node::Desc() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
         if (Type == NodeType::Dynamic) {
-            if (auto it = kDynDesc.find(HashValue); it != kDynDesc.end()) {
+            if (auto it = DynDesc.find(HashValue); it != DynDesc.end()) {
                 return it->second.second;
             }
         }


### PR DESCRIPTION
## Summary
- Project convention is PascalCase for constants/constexpr members (no Hungarian `k` prefix), per existing code (`NodeType::NoType`, `Count`, `IsNary`, etc.), but two first-party spots slipped through: `JitRuntimePool::kPoolSize` and `node.cpp`'s `kDynDesc` global map.
- Renamed to `PoolSize`/`DynDesc`. Left asmjit's own enum members (`RoundImm::kUp`, `Error::kOk`, etc.) untouched — those are the external library's naming, not ours to rename.

## Test plan
- [x] `operon_test "[jit]"` — 12814 assertions / 19 cases pass