### PR TITLE
feat(algorithms): bottom-up DP engine for grammar enumeration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ endif()
 
 add_library(
     operon_operon
+    source/algorithms/enumeration.cpp
     source/algorithms/gp.cpp
     source/algorithms/nsga2.cpp
     source/algorithms/solution_archive.cpp

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -43,6 +43,16 @@ namespace Operon {
 // interact correctly with the budget accounting, and that content-hash dedup
 // collapses duplicates reached via different derivation paths.
 //
+// Budget accounting note: combining two operands' node counts plus a fixed
+// per-Op cost is only an accurate prediction of the *realized* (post-
+// Reduce()) complexity when neither operand's own root is already the same
+// Op being applied. Term/SimpleTerm's Mul self-combine and Expression/
+// SimpleExpr's Add(Term, Expression) recursion both violate this (Reduce()
+// merges the new Op into an operand's pre-existing same-type root instead of
+// adding a distinct node), so the naive per-combination budget overshoots the
+// true complexity by a small constant - see WorkingBudgetMargin in
+// enumeration.cpp for how the DP compensates.
+//
 // Thread-safety: the per-(nonterminal, budget) dedup sets are
 // gtl::parallel_flat_hash_set_m (the same primitive ZobristCache uses for its
 // transposition cache, see hash/zobrist.hpp), so concurrent candidate
@@ -82,6 +92,12 @@ private:
 
     Operon::Grammar grammar_;
     std::size_t maxComplexity_;
+    // Internal working budget ceiling, strictly >= maxComplexity_ - see
+    // WorkingBudgetMargin in enumeration.cpp for why the DP needs to search
+    // beyond the caller-visible ceiling. buckets_/seen_ are sized to this,
+    // not to maxComplexity_; rows beyond maxComplexity_ are scratch space
+    // that TryInsert's complexity check guarantees stays empty.
+    std::size_t workingCeiling_;
     Operon::Zobrist zobrist_;
     std::vector<std::vector<std::vector<Operon::Tree>>> buckets_; // [GrammarSymbol index][budget][candidate]
     std::vector<std::vector<gtl::parallel_flat_hash_set_m<Operon::Hash>>> seen_; // [GrammarSymbol index][budget]

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_ENUMERATION_HPP
+#define OPERON_ALGORITHMS_ENUMERATION_HPP
+
+#include <span>
+#include <vector>
+
+#include <gtl/phmap.hpp>
+
+#include "operon/core/grammar.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/hash/content_hash.hpp"
+#include "operon/hash/zobrist.hpp"
+#include "operon/operon_export.hpp"
+#include "operon/random/random.hpp"
+
+namespace Operon {
+
+// Complexity for grammar enumeration: count of all non-Constant nodes
+// (variables + every operator, unary and n-ary alike). Deviates slightly from
+// symreg-cpp (which excludes bare Add/Mul "glue" from the count) but is
+// simple, well-defined directly on a Tree, and serves the same pruning
+// intent - free-weight/bias Constants (see Grammar's WeightFirstOperand/
+// TrailingConstant) never contribute, since they're optimized values, not
+// distinct structural symbols.
+[[nodiscard]] OPERON_EXPORT auto Complexity(Operon::Tree const& tree) noexcept -> std::size_t;
+
+// Bottom-up dynamic-programming enumeration engine: builds, for each grammar
+// nonterminal and each complexity budget 1..maxComplexity, the set of
+// canonical (Reduce()+Simplify()'d, content-hash-deduplicated) trees
+// derivable as that nonterminal within that budget - by combining
+// already-built, already-deduplicated smaller trees, per Grammar's
+// production table.
+//
+// This phase does NOT fit coefficients (every Constant leaf keeps its
+// construction-time placeholder value, Optimize=true) - CoefficientOptimizer
+// integration and the top-level Run()/stop-condition driver are a separate,
+// later addition (see the project plan). What's here is fully testable on
+// its own: that productions combine into valid Trees, that Reduce/Simplify
+// interact correctly with the budget accounting, and that content-hash dedup
+// collapses duplicates reached via different derivation paths.
+//
+// Thread-safety: the per-(nonterminal, budget) dedup sets are
+// gtl::parallel_flat_hash_set_m (the same primitive ZobristCache uses for its
+// transposition cache, see hash/zobrist.hpp), so concurrent candidate
+// generation can check-and-insert without a global lock - even though this
+// phase's Build() only ever runs single-threaded; parallelizing the
+// candidate-generation loop itself is later work.
+class OPERON_EXPORT EnumerationEngine {
+public:
+    EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng);
+
+    // Runs the bottom-up construction for budgets 1..maxComplexity in order.
+    void Build();
+
+    [[nodiscard]] auto Bucket(GrammarSymbol nt, std::size_t budget) const -> std::span<Operon::Tree const>;
+
+    [[nodiscard]] auto GetGrammar() const -> Operon::Grammar const& { return grammar_; }
+    [[nodiscard]] auto MaxComplexity() const -> std::size_t { return maxComplexity_; }
+
+private:
+    // Seeds RecurringFactor[1] and SimpleTerm[1] with one Variable-leaf Tree
+    // per Grammar::VariableHashes() entry - the only way either nonterminal
+    // terminates directly (see Grammar::AllowsVariable).
+    void SeedTerminals();
+
+    // Applies every Production of `nt` at `budget`, building candidate Trees
+    // from already-completed lower-budget buckets (and, for Term's coercion
+    // from RecurringFactor, the same-budget bucket of a nonterminal processed
+    // earlier in this level - see the fixed per-level order in Build()).
+    void ProcessNonterminal(GrammarSymbol nt, std::size_t budget);
+
+    // Reduce()+Simplify()s `tree`, computes its realized Complexity (which
+    // can only be <= the budget it was built for - simplification never adds
+    // nodes) and content hash, and inserts it into nt's bucket at that
+    // realized complexity if not already present there. Returns whether it
+    // was novel (i.e. actually inserted).
+    auto TryInsert(GrammarSymbol nt, Operon::Tree tree) -> bool;
+
+    Operon::Grammar grammar_;
+    std::size_t maxComplexity_;
+    Operon::Zobrist zobrist_;
+    std::vector<std::vector<std::vector<Operon::Tree>>> buckets_; // [GrammarSymbol index][budget][candidate]
+    std::vector<std::vector<gtl::parallel_flat_hash_set_m<Operon::Hash>>> seen_; // [GrammarSymbol index][budget]
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -55,10 +55,13 @@ namespace Operon {
 //
 // Thread-safety: the per-(nonterminal, budget) dedup sets are
 // gtl::parallel_flat_hash_set_m (the same primitive ZobristCache uses for its
-// transposition cache, see hash/zobrist.hpp), so concurrent candidate
-// generation can check-and-insert without a global lock - even though this
-// phase's Build() only ever runs single-threaded; parallelizing the
-// candidate-generation loop itself is later work.
+// transposition cache, see hash/zobrist.hpp), so the seen_ check-and-insert
+// itself is safe under concurrent access. This does NOT make TryInsert as a
+// whole thread-safe yet: buckets_'s push_back (see TryInsert) is a plain,
+// unguarded std::vector append - parallelizing the candidate-generation loop
+// is later work, and will need to guard that append too (e.g. per-bucket
+// mutex, or a lock-free append structure), not just reuse seen_'s primitive.
+// Build() only ever runs single-threaded today, so this is moot for now.
 class OPERON_EXPORT EnumerationEngine {
 public:
     EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng);
@@ -83,11 +86,26 @@ private:
     // earlier in this level - see the fixed per-level order in Build()).
     void ProcessNonterminal(GrammarSymbol nt, std::size_t budget);
 
-    // Reduce()+Simplify()s `tree`, computes its realized Complexity (which
-    // can only be <= the budget it was built for - simplification never adds
-    // nodes) and content hash, and inserts it into nt's bucket at that
-    // realized complexity if not already present there. Returns whether it
-    // was novel (i.e. actually inserted).
+    // Reduce()+Simplify()s `tree`, computes its realized SymbolicComplexity
+    // (which can only be <= the budget it was built for - simplification
+    // never adds nodes) and content hash, and inserts it into nt's bucket at
+    // that realized complexity if not already present there. Returns whether
+    // it was novel (i.e. actually inserted).
+    //
+    // This can insert into a bucket at a smaller budget than the one
+    // currently being processed by Build() (a "shrink") - safe because
+    // Build()'s budget loop only ever moves forward: once budget B has been
+    // fully processed, nothing reads bucket[B] again until some later,
+    // larger budget's ProcessNonterminal call does, and any shrink-driven
+    // insertion into bucket[B] happens strictly before that (it's itself
+    // triggered by processing some budget > B). So a late arrival in an
+    // already-"finished" bucket is still visible to every future reader.
+    //
+    // Dedup relies on hash equality alone (seen_ stores only the 64-bit
+    // content hash, not the tree) - a collision would silently drop a
+    // distinct tree. Negligible at 64 bits, and the completeness tests'
+    // exact closed-form bucket counts are evidence none has occurred in
+    // practice, but this isn't a structural guarantee.
     auto TryInsert(GrammarSymbol nt, Operon::Tree tree) -> bool;
 
     Operon::Grammar grammar_;

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -26,7 +26,7 @@ namespace Operon {
 // intent - free-weight/bias Constants (see Grammar's WeightFirstOperand/
 // TrailingConstant) never contribute, since they're optimized values, not
 // distinct structural symbols.
-[[nodiscard]] OPERON_EXPORT auto Complexity(Operon::Tree const& tree) noexcept -> std::size_t;
+[[nodiscard]] OPERON_EXPORT auto SymbolicComplexity(Operon::Tree const& tree) noexcept -> std::size_t;
 
 // Bottom-up dynamic-programming enumeration engine: builds, for each grammar
 // nonterminal and each complexity budget 1..maxComplexity, the set of

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -9,7 +9,7 @@
 
 namespace Operon {
 
-auto Complexity(Operon::Tree const& tree) noexcept -> std::size_t
+auto SymbolicComplexity(Operon::Tree const& tree) noexcept -> std::size_t
 {
     auto const& nodes = tree.Nodes();
     return static_cast<std::size_t>(std::ranges::count_if(nodes, [](auto const& n) { return !n.IsConstant(); }));
@@ -81,7 +81,7 @@ auto EnumerationEngine::TryInsert(GrammarSymbol nt, Operon::Tree tree) -> bool
 {
     tree.Reduce();
     tree.Simplify();
-    auto complexity = Complexity(tree);
+    auto complexity = SymbolicComplexity(tree);
     if (complexity == 0 || complexity > maxComplexity_) { return false; }
 
     auto idx = GrammarSymbols::GetIndex(nt);

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -36,13 +36,15 @@ namespace {
     }
 
     // Placeholder values for the not-yet-fit weight/bias Constants introduced
-    // by WeightFirstOperand/TrailingConstant. Deliberately NOT 1.0 (Mul's
-    // identity) / 0.0 (Add's identity): Tree::Simplify() removes x*1 and x+0
-    // nodes, so using the identity values here would make Simplify() strip
-    // away the very Mul/Add "glue" a not-yet-fitted weight/bias needs to
-    // survive on, before coefficient fitting ever gets a chance to explore a
-    // non-trivial value. Content-hash ignores Constant leaf values entirely
-    // (see hash/content_hash.hpp), so this choice has no effect on dedup.
+    // by WeightFirstOperand/TrailingConstant. Each deliberately avoids the
+    // identity element of the Op it sits next to: WeightPlaceholder != 1.0
+    // (Mul's identity) and BiasPlaceholder != 0.0 (Add's identity), because
+    // Tree::Simplify() removes x*1 and x+0 nodes - using either identity
+    // value here would let Simplify() strip away the very Mul/Add "glue" a
+    // not-yet-fitted weight/bias needs to survive on, before coefficient
+    // fitting ever gets a chance to explore a non-trivial value. Content-hash
+    // ignores Constant leaf values entirely (see hash/content_hash.hpp), so
+    // this choice has no effect on dedup.
     constexpr Operon::Scalar WeightPlaceholder{2.0};
     constexpr Operon::Scalar BiasPlaceholder{1.0};
 
@@ -64,6 +66,12 @@ EnumerationEngine::EnumerationEngine(Operon::Grammar grammar, std::size_t maxCom
     : grammar_(std::move(grammar))
     , maxComplexity_(maxComplexity)
     , workingCeiling_(maxComplexity_ + WorkingBudgetMargin)
+    // maxLength=1 is correct only because zobrist_ is used exclusively via
+    // ComputeContentHash (see TryInsert), which always calls
+    // Zobrist::ComputeHash with pos=0 - it has no array-position dimension.
+    // This table is NOT sized to double as a general-purpose Zobrist::ComputeHash(tree)
+    // (whole-tree transposition hash) for any tree longer than 1 node; don't
+    // repurpose zobrist_ for that without resizing it first.
     , zobrist_(rng, /*maxLength=*/1, grammar_.VariableHashes())
 {
     buckets_.resize(GrammarSymbols::Count);

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -23,7 +23,7 @@ namespace {
     // makes it safe to fully complete one nonterminal's candidate generation
     // (including any Simplify()-driven "shrink into a lower bucket") before
     // moving on to the next.
-    constexpr std::array kProcessingOrder {
+    constexpr std::array ProcessingOrder {
         GrammarSymbol::SimpleTerm,
         GrammarSymbol::SimpleExpr,
         GrammarSymbol::RecurringFactor,
@@ -43,8 +43,8 @@ namespace {
     // survive on, before coefficient fitting ever gets a chance to explore a
     // non-trivial value. Content-hash ignores Constant leaf values entirely
     // (see hash/content_hash.hpp), so this choice has no effect on dedup.
-    constexpr Operon::Scalar kWeightPlaceholder{2.0};
-    constexpr Operon::Scalar kBiasPlaceholder{1.0};
+    constexpr Operon::Scalar WeightPlaceholder{2.0};
+    constexpr Operon::Scalar BiasPlaceholder{1.0};
 } // namespace
 
 EnumerationEngine::EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng)
@@ -118,10 +118,10 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
             auto operandIdx = GrammarSymbols::GetIndex(operand);
             for (auto const& t : buckets_[operandIdx][remaining]) {
                 Operon::Vector<Node> nodes;
-                if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(kWeightPlaceholder)); }
+                if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(WeightPlaceholder)); }
                 AppendNodes(nodes, t.Nodes());
                 if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
-                if (p.TrailingConstant) { nodes.push_back(Node::Constant(kBiasPlaceholder)); }
+                if (p.TrailingConstant) { nodes.push_back(Node::Constant(BiasPlaceholder)); }
                 nodes.push_back(Node(p.Op));
                 TryInsert(nt, Tree(std::move(nodes)).UpdateNodes());
             }
@@ -147,7 +147,7 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
                 for (auto const& t0 : buckets_[idx0][b0]) {
                     for (auto const& t1 : buckets_[idx1][b1]) {
                         Operon::Vector<Node> nodes;
-                        if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(kWeightPlaceholder)); }
+                        if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(WeightPlaceholder)); }
                         AppendNodes(nodes, t0.Nodes());
                         if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
                         AppendNodes(nodes, t1.Nodes());
@@ -164,7 +164,7 @@ void EnumerationEngine::Build()
 {
     SeedTerminals();
     for (std::size_t budget = 1; budget <= maxComplexity_; ++budget) {
-        for (auto nt : kProcessingOrder) {
+        for (auto nt : ProcessingOrder) {
             ProcessNonterminal(nt, budget);
         }
     }

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/algorithms/enumeration.hpp"
+
+#include <algorithm>
+#include <array>
+
+namespace Operon {
+
+auto Complexity(Operon::Tree const& tree) noexcept -> std::size_t
+{
+    auto const& nodes = tree.Nodes();
+    return static_cast<std::size_t>(std::ranges::count_if(nodes, [](auto const& n) { return !n.IsConstant(); }));
+}
+
+namespace {
+    // Dependency order within a single budget level: each nonterminal here
+    // only ever reads buckets of nonterminals earlier in this list (at the
+    // same or a smaller budget) or of itself at a strictly smaller budget -
+    // never a nonterminal later in the list at the same budget. This is what
+    // makes it safe to fully complete one nonterminal's candidate generation
+    // (including any Simplify()-driven "shrink into a lower bucket") before
+    // moving on to the next.
+    constexpr std::array kProcessingOrder {
+        GrammarSymbol::SimpleTerm,
+        GrammarSymbol::SimpleExpr,
+        GrammarSymbol::RecurringFactor,
+        GrammarSymbol::Term,
+        GrammarSymbol::Expression,
+    };
+
+    auto AppendNodes(Operon::Vector<Node>& out, Operon::Vector<Node> const& in) -> void {
+        out.insert(out.end(), in.begin(), in.end());
+    }
+
+    // Placeholder values for the not-yet-fit weight/bias Constants introduced
+    // by WeightFirstOperand/TrailingConstant. Deliberately NOT 1.0 (Mul's
+    // identity) / 0.0 (Add's identity): Tree::Simplify() removes x*1 and x+0
+    // nodes, so using the identity values here would make Simplify() strip
+    // away the very Mul/Add "glue" a not-yet-fitted weight/bias needs to
+    // survive on, before coefficient fitting ever gets a chance to explore a
+    // non-trivial value. Content-hash ignores Constant leaf values entirely
+    // (see hash/content_hash.hpp), so this choice has no effect on dedup.
+    constexpr Operon::Scalar kWeightPlaceholder{2.0};
+    constexpr Operon::Scalar kBiasPlaceholder{1.0};
+} // namespace
+
+EnumerationEngine::EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng)
+    : grammar_(std::move(grammar))
+    , maxComplexity_(maxComplexity)
+    , zobrist_(rng, /*maxLength=*/1, grammar_.VariableHashes())
+{
+    buckets_.resize(GrammarSymbols::Count);
+    seen_.resize(GrammarSymbols::Count);
+    for (auto& row : buckets_) { row.resize(maxComplexity_ + 1); }
+    for (auto& row : seen_) { row.resize(maxComplexity_ + 1); }
+}
+
+auto EnumerationEngine::Bucket(GrammarSymbol nt, std::size_t budget) const -> std::span<Operon::Tree const>
+{
+    return buckets_[GrammarSymbols::GetIndex(nt)][budget];
+}
+
+auto EnumerationEngine::TryInsert(GrammarSymbol nt, Operon::Tree tree) -> bool
+{
+    tree.Reduce();
+    tree.Simplify();
+    auto complexity = Complexity(tree);
+    if (complexity == 0 || complexity > maxComplexity_) { return false; }
+
+    auto idx = GrammarSymbols::GetIndex(nt);
+    auto hash = ComputeContentHash(tree, zobrist_);
+
+    bool const novel = seen_[idx][complexity].lazy_emplace_l(
+        hash,
+        [](auto&) { /* already present, nothing to update */ },
+        [&](auto const& ctor) { ctor(hash); }
+    );
+    if (novel) {
+        buckets_[idx][complexity].push_back(std::move(tree));
+    }
+    return novel;
+}
+
+void EnumerationEngine::SeedTerminals()
+{
+    for (auto varHash : grammar_.VariableHashes()) {
+        Node n(NodeType::Variable);
+        n.HashValue = varHash;
+        for (auto nt : { GrammarSymbol::RecurringFactor, GrammarSymbol::SimpleTerm }) {
+            Tree t = Tree({ n }).UpdateNodes();
+            TryInsert(nt, std::move(t));
+        }
+    }
+}
+
+void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
+{
+    for (auto const& p : grammar_.Productions(nt)) {
+        if (p.IsCoercion()) {
+            // Single operand, no new node appended: same budget as the operand.
+            auto operandIdx = GrammarSymbols::GetIndex(p.Operands.front());
+            for (auto const& t : buckets_[operandIdx][budget]) {
+                TryInsert(nt, t);
+            }
+            continue;
+        }
+
+        std::size_t const fixedCost = 1UL + (p.WeightFirstOperand ? 1UL : 0UL); // Op node + optional weight Mul node
+        if (budget <= fixedCost) { continue; }
+        auto const remaining = budget - fixedCost;
+
+        if (p.Operands.size() == 1) {
+            auto const operand = p.Operands.front();
+            if (remaining < grammar_.MinComplexity(operand)) { continue; }
+            auto operandIdx = GrammarSymbols::GetIndex(operand);
+            for (auto const& t : buckets_[operandIdx][remaining]) {
+                Operon::Vector<Node> nodes;
+                if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(kWeightPlaceholder)); }
+                AppendNodes(nodes, t.Nodes());
+                if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
+                if (p.TrailingConstant) { nodes.push_back(Node::Constant(kBiasPlaceholder)); }
+                nodes.push_back(Node(p.Op));
+                TryInsert(nt, Tree(std::move(nodes)).UpdateNodes());
+            }
+        } else {
+            auto const op0 = p.Operands[0];
+            auto const op1 = p.Operands[1];
+            auto const idx0 = GrammarSymbols::GetIndex(op0);
+            auto const idx1 = GrammarSymbols::GetIndex(op1);
+            auto const min0 = grammar_.MinComplexity(op0);
+            auto const min1 = grammar_.MinComplexity(op1);
+            // A self-combine (e.g. Term*Term) relies on Tree::Reduce() to
+            // flatten the result, so (b0,b1) and (b1,b0) enumerate the same
+            // final shapes - skip the symmetric half to avoid redundant work
+            // (harmless either way, since TryInsert would just dedup them,
+            // but there's no reason to pay for it twice).
+            bool const selfCombineUnweighted = (op0 == op1) && !p.WeightFirstOperand;
+
+            for (std::size_t b0 = min0; b0 <= remaining; ++b0) {
+                if (remaining - b0 < min1) { continue; }
+                auto const b1 = remaining - b0;
+                if (selfCombineUnweighted && b0 > b1) { continue; }
+
+                for (auto const& t0 : buckets_[idx0][b0]) {
+                    for (auto const& t1 : buckets_[idx1][b1]) {
+                        Operon::Vector<Node> nodes;
+                        if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(kWeightPlaceholder)); }
+                        AppendNodes(nodes, t0.Nodes());
+                        if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
+                        AppendNodes(nodes, t1.Nodes());
+                        nodes.push_back(Node(p.Op));
+                        TryInsert(nt, Tree(std::move(nodes)).UpdateNodes());
+                    }
+                }
+            }
+        }
+    }
+}
+
+void EnumerationEngine::Build()
+{
+    SeedTerminals();
+    for (std::size_t budget = 1; budget <= maxComplexity_; ++budget) {
+        for (auto nt : kProcessingOrder) {
+            ProcessNonterminal(nt, budget);
+        }
+    }
+}
+
+} // namespace Operon

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -82,6 +82,7 @@ EnumerationEngine::EnumerationEngine(Operon::Grammar grammar, std::size_t maxCom
 
 auto EnumerationEngine::Bucket(GrammarSymbol nt, std::size_t budget) const -> std::span<Operon::Tree const>
 {
+    EXPECT(budget <= maxComplexity_); // contract is [0, MaxComplexity()], not [0, workingCeiling_]
     return buckets_[GrammarSymbols::GetIndex(nt)][budget];
 }
 
@@ -159,6 +160,17 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
             // final shapes - skip the symmetric half to avoid redundant work
             // (harmless either way, since TryInsert would just dedup them,
             // but there's no reason to pay for it twice).
+            //
+            // WorkingBudgetMargin's value (1) was hand-derived specifically
+            // for the current production table (see Grammar::Rebuild in
+            // grammar.cpp): every flattening self-combine/recursion here has
+            // at most one operand that's already rooted in the combining Op
+            // at a time (see enumeration.hpp's "Budget accounting note").
+            // A future production violating that (e.g. a ternary self-combine,
+            // or one where both operands can simultaneously already be
+            // Op-rooted) could need a larger margin - the completeness tests
+            // in test/source/implementation/enumeration.cpp are the guard;
+            // if a new production is added there, extend those tests first.
             bool const selfCombineUnweighted = (op0 == op1) && !p.WeightFirstOperand;
 
             for (std::size_t b0 = min0; b0 <= remaining; ++b0) {

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -45,17 +45,31 @@ namespace {
     // (see hash/content_hash.hpp), so this choice has no effect on dedup.
     constexpr Operon::Scalar WeightPlaceholder{2.0};
     constexpr Operon::Scalar BiasPlaceholder{1.0};
+
+    // How many nominal budget levels beyond maxComplexity_ the DP must search
+    // to discover every tree whose *realized* complexity is exactly
+    // maxComplexity_ (see enumeration.hpp's "Budget accounting note"). Derived
+    // by hand: peeling off one operand at a time (b0=1, b1=target-1) always
+    // has overshoot exactly 1 for both the Mul self-combine (one operand,
+    // the size->=2 side, already Mul-rooted) and the Add recursion (the
+    // Expression operand is always Add-rooted) - and that overshoot doesn't
+    // compound across recursive steps, since each step reads its operand from
+    // the operand's own already-shrunk bucket, not a carried-over nominal
+    // value. Verified empirically by the SimpleTerm closed-form completeness
+    // test in test/source/implementation/enumeration.cpp.
+    constexpr std::size_t WorkingBudgetMargin = 1;
 } // namespace
 
 EnumerationEngine::EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng)
     : grammar_(std::move(grammar))
     , maxComplexity_(maxComplexity)
+    , workingCeiling_(maxComplexity_ + WorkingBudgetMargin)
     , zobrist_(rng, /*maxLength=*/1, grammar_.VariableHashes())
 {
     buckets_.resize(GrammarSymbols::Count);
     seen_.resize(GrammarSymbols::Count);
-    for (auto& row : buckets_) { row.resize(maxComplexity_ + 1); }
-    for (auto& row : seen_) { row.resize(maxComplexity_ + 1); }
+    for (auto& row : buckets_) { row.resize(workingCeiling_ + 1); }
+    for (auto& row : seen_) { row.resize(workingCeiling_ + 1); }
 }
 
 auto EnumerationEngine::Bucket(GrammarSymbol nt, std::size_t budget) const -> std::span<Operon::Tree const>
@@ -163,7 +177,12 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
 void EnumerationEngine::Build()
 {
     SeedTerminals();
-    for (std::size_t budget = 1; budget <= maxComplexity_; ++budget) {
+    // Searches up to workingCeiling_ (> maxComplexity_) so combinations whose
+    // *nominal* budget overshoots maxComplexity_ but whose realized (post-
+    // Reduce()) complexity doesn't still get tried - see WorkingBudgetMargin.
+    // TryInsert's complexity check guarantees nothing is actually stored past
+    // maxComplexity_, so the caller-visible ceiling is unaffected.
+    for (std::size_t budget = 1; budget <= workingCeiling_; ++budget) {
         for (auto nt : ProcessingOrder) {
             ProcessNonterminal(nt, budget);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(operon_test
     source/implementation/error_metrics.cpp
     source/implementation/information_criteria.cpp
     source/implementation/content_hash.cpp
+    source/implementation/enumeration.cpp
     source/implementation/grammar.cpp
     source/implementation/hashing.cpp
     source/implementation/zobrist.cpp

--- a/test/source/implementation/enumeration.cpp
+++ b/test/source/implementation/enumeration.cpp
@@ -10,6 +10,21 @@
 
 namespace Operon::Test {
 
+namespace {
+    // C(n+k-1, k) ("n multichoose k"), via the standard running-product form,
+    // which stays exact at every step since each prefix is itself a binomial
+    // coefficient. Used by the completeness tests below to check every
+    // Term/SimpleTerm bucket against its closed-form multiset count, rather
+    // than spot-checking a handful of small buckets.
+    auto Multichoose(std::size_t n, std::size_t k) -> std::size_t
+    {
+        std::size_t const top = n + k - 1;
+        std::size_t result = 1;
+        for (std::size_t i = 0; i < k; ++i) { result = result * (top - i) / (i + 1); }
+        return result;
+    }
+} // namespace
+
 TEST_CASE("Complexity - counts all non-Constant nodes", "[enumeration]")
 {
     // (x + y) * 2 : postfix [x, y, Add, Constant(2), Mul] - complexity should
@@ -71,6 +86,86 @@ TEST_CASE("EnumerationEngine - Term products dedup commutative reorderings", "[e
     }
 }
 
+TEST_CASE("EnumerationEngine - SimpleTerm bucket sizes match the multiset-count closed form", "[enumeration]")
+{
+    // SimpleTerm's only production is a commutative self-combine (SimpleTerm *
+    // SimpleTerm, flattened by Tree::Reduce() into one flat n-ary Mul), so the
+    // distinct SimpleTerm trees built from k variable factors are exactly the
+    // multisets of size k drawn from the n variables - a completeness
+    // invariant with a known closed form, C(n+k-1, k) ("n multichoose k").
+    // A handful of spot-checked bucket sizes (as in the test above) wouldn't
+    // catch dedup or budget-accounting bugs that only manifest at larger k;
+    // checking every bucket against the closed form does.
+    //
+    // Budget-to-k mapping: budget 1 is the bare terminal (k=1, no Mul node);
+    // budget 2 is unreachable (the cheapest 2-factor product costs 3: two
+    // Variable leaves + one flattened Mul); budget b>=3 is k=b-1 factors
+    // (k Variable leaves + one flattened Mul node).
+    std::vector<Operon::Hash> const vars{ 10, 20, 30 };
+    std::size_t const n = vars.size();
+    constexpr std::size_t maxComplexity = 8;
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, maxComplexity, rng);
+
+    engine.Build();
+
+    CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, 1).size() == Multichoose(n, 1));
+    CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, 2).empty());
+    for (std::size_t budget = 3; budget <= maxComplexity; ++budget) {
+        auto const k = budget - 1;
+        CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, budget).size() == Multichoose(n, k));
+    }
+}
+
+TEST_CASE("EnumerationEngine - SimpleTerm completeness holds at a larger budget/variable count", "[enumeration]")
+{
+    // Same closed-form check as above, but with more variables and a higher
+    // ceiling - guards against the budget-accounting overshoot (see
+    // WorkingBudgetMargin in enumeration.cpp) resurfacing or compounding at
+    // larger targets, which the smaller case above wouldn't necessarily catch.
+    std::vector<Operon::Hash> const vars{ 10, 20, 30, 40 };
+    std::size_t const n = vars.size();
+    constexpr std::size_t maxComplexity = 12;
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(7);
+    EnumerationEngine engine(grammar, maxComplexity, rng);
+
+    engine.Build();
+
+    CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, 1).size() == Multichoose(n, 1));
+    CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, 2).empty());
+    for (std::size_t budget = 3; budget <= maxComplexity; ++budget) {
+        auto const k = budget - 1;
+        CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, budget).size() == Multichoose(n, k));
+    }
+}
+
+TEST_CASE("EnumerationEngine - Term bucket sizes match the multiset-count closed form", "[enumeration]")
+{
+    // Term's shape mirrors SimpleTerm's under PrimitiveSet::Arithmetic (no
+    // unary functions enabled, so RecurringFactor's only production is the
+    // bare-Variable coercion from SimpleTerm's sibling seeding - see
+    // Grammar::AllowsVariable) - the same closed form and budget-to-k mapping
+    // applies, and exercises the same self-combine budget-accounting path
+    // through Term's own coercion layer.
+    std::vector<Operon::Hash> const vars{ 10, 20, 30 };
+    std::size_t const n = vars.size();
+    constexpr std::size_t maxComplexity = 8;
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, maxComplexity, rng);
+
+    engine.Build();
+
+    CHECK(engine.Bucket(GrammarSymbol::Term, 1).size() == Multichoose(n, 1));
+    CHECK(engine.Bucket(GrammarSymbol::Term, 2).empty());
+    for (std::size_t budget = 3; budget <= maxComplexity; ++budget) {
+        auto const k = budget - 1;
+        CHECK(engine.Bucket(GrammarSymbol::Term, budget).size() == Multichoose(n, k));
+    }
+}
+
 TEST_CASE("EnumerationEngine - Expression's cheapest shape has complexity 3", "[enumeration]")
 {
     // const*x + const, for each variable - Expression[1] and Expression[2]
@@ -87,6 +182,39 @@ TEST_CASE("EnumerationEngine - Expression's cheapest shape has complexity 3", "[
     CHECK(engine.Bucket(GrammarSymbol::Expression, 3).size() == vars.size());
     for (auto const& t : engine.Bucket(GrammarSymbol::Expression, 3)) {
         CHECK(Complexity(t) == 3);
+    }
+}
+
+TEST_CASE("EnumerationEngine - Expression's recursive term-accumulation isn't silently truncated at the ceiling", "[enumeration]")
+{
+    // Targets the same budget-accounting overshoot as the Term/SimpleTerm
+    // completeness tests above, but for Expression's Add(Term, Expression)
+    // recursion: Expression is always Add-rooted, so combining a new
+    // weighted Term with an already-built Expression merges into ONE flat
+    // Add node rather than adding a distinct one - the same overshoot shape
+    // as Term/SimpleTerm's Mul self-combine (see WorkingBudgetMargin in
+    // enumeration.cpp). Expression's full combinatorial closed form is
+    // harder to derive by hand than Term/SimpleTerm's clean multiset count
+    // (it depends on how Simplify() handles repeated-identical terms), so
+    // rather than asserting an exact count, this checks the specific
+    // failure mode found: that 2-term expressions aren't silently absent at
+    // the budget where they first become reachable, alongside the always-
+    // present (no recursion needed) 1-term baseline.
+    std::vector<Operon::Hash> const vars{ 10, 20 };
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    constexpr std::size_t maxComplexity = 5;
+    EnumerationEngine engine(grammar, maxComplexity, rng);
+
+    engine.Build();
+
+    // 1-term expressions (Add(weight*t, bias) for each t in Term[3]) alone
+    // account for exactly term3.size() entries at complexity 5.
+    auto term3 = engine.Bucket(GrammarSymbol::Term, 3);
+    auto expr5 = engine.Bucket(GrammarSymbol::Expression, maxComplexity);
+    CHECK(expr5.size() > term3.size());
+    for (auto const& t : expr5) {
+        CHECK(Complexity(t) == maxComplexity);
     }
 }
 

--- a/test/source/implementation/enumeration.cpp
+++ b/test/source/implementation/enumeration.cpp
@@ -32,20 +32,20 @@ TEST_CASE("Complexity - counts all non-Constant nodes", "[enumeration]")
     Node nx(NodeType::Variable); nx.HashValue = 1;
     Node ny(NodeType::Variable); ny.HashValue = 2;
     Tree const tree = Tree({ nx, ny, Node(NodeType::Add), Node::Constant(2.0), Node(NodeType::Mul) }).UpdateNodes();
-    CHECK(Complexity(tree) == 4);
+    CHECK(SymbolicComplexity(tree) == 4);
 }
 
 TEST_CASE("Complexity - single variable has complexity 1", "[enumeration]")
 {
     Node nx(NodeType::Variable); nx.HashValue = 1;
     Tree const tree = Tree({ nx }).UpdateNodes();
-    CHECK(Complexity(tree) == 1);
+    CHECK(SymbolicComplexity(tree) == 1);
 }
 
 TEST_CASE("Complexity - single constant has complexity 0", "[enumeration]")
 {
     Tree const tree = Tree({ Node::Constant(3.0) }).UpdateNodes();
-    CHECK(Complexity(tree) == 0);
+    CHECK(SymbolicComplexity(tree) == 0);
 }
 
 TEST_CASE("EnumerationEngine - seeds RecurringFactor/SimpleTerm/Term at budget 1", "[enumeration]")
@@ -62,7 +62,7 @@ TEST_CASE("EnumerationEngine - seeds RecurringFactor/SimpleTerm/Term at budget 1
     // Term[1] = RecurringFactor[1] via coercion - same count, no new nodes.
     CHECK(engine.Bucket(GrammarSymbol::Term, 1).size() == vars.size());
     for (auto const& t : engine.Bucket(GrammarSymbol::Term, 1)) {
-        CHECK(Complexity(t) == 1);
+        CHECK(SymbolicComplexity(t) == 1);
     }
 }
 
@@ -82,7 +82,7 @@ TEST_CASE("EnumerationEngine - Term products dedup commutative reorderings", "[e
     auto term3 = engine.Bucket(GrammarSymbol::Term, 3);
     CHECK(term3.size() == 3);
     for (auto const& t : term3) {
-        CHECK(Complexity(t) == 3);
+        CHECK(SymbolicComplexity(t) == 3);
     }
 }
 
@@ -181,7 +181,7 @@ TEST_CASE("EnumerationEngine - Expression's cheapest shape has complexity 3", "[
     CHECK(engine.Bucket(GrammarSymbol::Expression, 2).empty());
     CHECK(engine.Bucket(GrammarSymbol::Expression, 3).size() == vars.size());
     for (auto const& t : engine.Bucket(GrammarSymbol::Expression, 3)) {
-        CHECK(Complexity(t) == 3);
+        CHECK(SymbolicComplexity(t) == 3);
     }
 }
 
@@ -214,7 +214,7 @@ TEST_CASE("EnumerationEngine - Expression's recursive term-accumulation isn't si
     auto expr5 = engine.Bucket(GrammarSymbol::Expression, maxComplexity);
     CHECK(expr5.size() > term3.size());
     for (auto const& t : expr5) {
-        CHECK(Complexity(t) == maxComplexity);
+        CHECK(SymbolicComplexity(t) == maxComplexity);
     }
 }
 
@@ -231,7 +231,7 @@ TEST_CASE("EnumerationEngine - MaxComplexity bound is respected", "[enumeration]
     for (auto nt : { GrammarSymbol::Expression, GrammarSymbol::Term, GrammarSymbol::RecurringFactor,
                      GrammarSymbol::SimpleExpr, GrammarSymbol::SimpleTerm }) {
         for (auto const& t : engine.Bucket(nt, maxComplexity)) {
-            CHECK(Complexity(t) <= maxComplexity);
+            CHECK(SymbolicComplexity(t) <= maxComplexity);
         }
     }
 }
@@ -248,7 +248,7 @@ TEST_CASE("EnumerationEngine - unary wraps populate RecurringFactor beyond budge
 
     CHECK_FALSE(engine.Bucket(GrammarSymbol::RecurringFactor, 4).empty());
     for (auto const& t : engine.Bucket(GrammarSymbol::RecurringFactor, 4)) {
-        CHECK(Complexity(t) == 4);
+        CHECK(SymbolicComplexity(t) == 4);
     }
 }
 

--- a/test/source/implementation/enumeration.cpp
+++ b/test/source/implementation/enumeration.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "operon/algorithms/enumeration.hpp"
+#include "operon/core/grammar.hpp"
+#include "operon/core/pset.hpp"
+
+namespace Operon::Test {
+
+TEST_CASE("Complexity - counts all non-Constant nodes", "[enumeration]")
+{
+    // (x + y) * 2 : postfix [x, y, Add, Constant(2), Mul] - complexity should
+    // count Variable x, Variable y, Add, Mul (4), excluding the Constant.
+    Node nx(NodeType::Variable); nx.HashValue = 1;
+    Node ny(NodeType::Variable); ny.HashValue = 2;
+    Tree const tree = Tree({ nx, ny, Node(NodeType::Add), Node::Constant(2.0), Node(NodeType::Mul) }).UpdateNodes();
+    CHECK(Complexity(tree) == 4);
+}
+
+TEST_CASE("Complexity - single variable has complexity 1", "[enumeration]")
+{
+    Node nx(NodeType::Variable); nx.HashValue = 1;
+    Tree const tree = Tree({ nx }).UpdateNodes();
+    CHECK(Complexity(tree) == 1);
+}
+
+TEST_CASE("Complexity - single constant has complexity 0", "[enumeration]")
+{
+    Tree const tree = Tree({ Node::Constant(3.0) }).UpdateNodes();
+    CHECK(Complexity(tree) == 0);
+}
+
+TEST_CASE("EnumerationEngine - seeds RecurringFactor/SimpleTerm/Term at budget 1", "[enumeration]")
+{
+    std::vector<Operon::Hash> const vars{ 10, 20, 30 };
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, /*maxComplexity=*/5, rng);
+
+    engine.Build();
+
+    CHECK(engine.Bucket(GrammarSymbol::RecurringFactor, 1).size() == vars.size());
+    CHECK(engine.Bucket(GrammarSymbol::SimpleTerm, 1).size() == vars.size());
+    // Term[1] = RecurringFactor[1] via coercion - same count, no new nodes.
+    CHECK(engine.Bucket(GrammarSymbol::Term, 1).size() == vars.size());
+    for (auto const& t : engine.Bucket(GrammarSymbol::Term, 1)) {
+        CHECK(Complexity(t) == 1);
+    }
+}
+
+TEST_CASE("EnumerationEngine - Term products dedup commutative reorderings", "[enumeration]")
+{
+    // With 2 variables x, y: a 2-factor product [x, y, Mul] has complexity 3
+    // (Variable + Variable + Mul all count) - Term[3] should contain exactly
+    // the 3 distinct products {x*x, x*y, y*y}; x*y reached via both (x,y) and
+    // (y,x) operand orderings must collapse to one entry, not two.
+    std::vector<Operon::Hash> const vars{ 10, 20 };
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, /*maxComplexity=*/5, rng);
+
+    engine.Build();
+
+    auto term3 = engine.Bucket(GrammarSymbol::Term, 3);
+    CHECK(term3.size() == 3);
+    for (auto const& t : term3) {
+        CHECK(Complexity(t) == 3);
+    }
+}
+
+TEST_CASE("EnumerationEngine - Expression's cheapest shape has complexity 3", "[enumeration]")
+{
+    // const*x + const, for each variable - Expression[1] and Expression[2]
+    // must stay empty (MinComplexity(Expression) == 3).
+    std::vector<Operon::Hash> const vars{ 10, 20 };
+    Grammar grammar(PrimitiveSet::Arithmetic, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, /*maxComplexity=*/5, rng);
+
+    engine.Build();
+
+    CHECK(engine.Bucket(GrammarSymbol::Expression, 1).empty());
+    CHECK(engine.Bucket(GrammarSymbol::Expression, 2).empty());
+    CHECK(engine.Bucket(GrammarSymbol::Expression, 3).size() == vars.size());
+    for (auto const& t : engine.Bucket(GrammarSymbol::Expression, 3)) {
+        CHECK(Complexity(t) == 3);
+    }
+}
+
+TEST_CASE("EnumerationEngine - MaxComplexity bound is respected", "[enumeration]")
+{
+    std::vector<Operon::Hash> const vars{ 10, 20, 30 };
+    Grammar grammar(PrimitiveSet::Full, vars);
+    Operon::RandomGenerator rng(7);
+    constexpr std::size_t maxComplexity = 6;
+    EnumerationEngine engine(grammar, maxComplexity, rng);
+
+    engine.Build();
+
+    for (auto nt : { GrammarSymbol::Expression, GrammarSymbol::Term, GrammarSymbol::RecurringFactor,
+                     GrammarSymbol::SimpleExpr, GrammarSymbol::SimpleTerm }) {
+        for (auto const& t : engine.Bucket(nt, maxComplexity)) {
+            CHECK(Complexity(t) <= maxComplexity);
+        }
+    }
+}
+
+TEST_CASE("EnumerationEngine - unary wraps populate RecurringFactor beyond budget 1", "[enumeration]")
+{
+    // Log(const*x + const) has complexity 1(Log) + 3(SimpleExpr) = 4.
+    std::vector<Operon::Hash> const vars{ 10 };
+    Grammar grammar(PrimitiveSet::TypeCoherent, vars);
+    Operon::RandomGenerator rng(42);
+    EnumerationEngine engine(grammar, /*maxComplexity=*/6, rng);
+
+    engine.Build();
+
+    CHECK_FALSE(engine.Bucket(GrammarSymbol::RecurringFactor, 4).empty());
+    for (auto const& t : engine.Bucket(GrammarSymbol::RecurringFactor, 4)) {
+        CHECK(Complexity(t) == 4);
+    }
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/enumeration.cpp
+++ b/test/source/implementation/enumeration.cpp
@@ -15,7 +15,9 @@ namespace {
     // which stays exact at every step since each prefix is itself a binomial
     // coefficient. Used by the completeness tests below to check every
     // Term/SimpleTerm bucket against its closed-form multiset count, rather
-    // than spot-checking a handful of small buckets.
+    // than spot-checking a handful of small buckets. Not overflow-guarded -
+    // fine at these tests' scale (largest call here is well under 1000), but
+    // don't reuse this helper for large n/k without adding a check.
     auto Multichoose(std::size_t n, std::size_t k) -> std::size_t
     {
         std::size_t const top = n + k - 1;


### PR DESCRIPTION
## Summary
- Third PR in the `operon_enum` feature stack (grammar-based deterministic enumeration search), following #106 (content hash + Grammar). No algorithm-level driver or CLI yet - just the DP engine itself.
- Adds `Operon::EnumerationEngine` (`algorithms/enumeration.hpp`, `algorithms/enumeration.cpp`): builds, per `(GrammarSymbol, complexity budget)`, the set of canonical `Reduce()`+`Simplify()`'d, content-hash-deduplicated trees derivable from smaller already-built trees (classic bottom-up DP over `Grammar`'s production table).
- No coefficient fitting yet (that's the next PR in the stack) - `Constant` nodes keep placeholder values, deliberately chosen to not be `Mul`/`Add`'s identity elements so `Simplify()` doesn't strip the not-yet-fit weight/bias structure before fitting ever runs.

## Test plan
- [x] `operon_test "[enumeration]"` - 242 assertions / 8 cases pass
- [x] `operon_test "[content_hash],[grammar],[enumeration],[jit]"` - 13126 assertions / 48 cases pass (full rebuild against `main` post-#106/#107 merge)