### PR TITLE
refactor(algorithms): extract StoppableAlgorithm mixin

### DIFF
--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -5,7 +5,6 @@
 #ifndef OPERON_ALGORITHMS_ENUMERATION_HPP
 #define OPERON_ALGORITHMS_ENUMERATION_HPP
 
-#include <atomic>
 #include <functional>
 #include <span>
 #include <utility>
@@ -14,7 +13,7 @@
 #include <gsl/pointers>
 #include <gtl/phmap.hpp>
 
-#include "operon/algorithms/ga_base.hpp" // for Operon::ReportCallback
+#include "operon/algorithms/stoppable.hpp" // for Operon::ReportCallback, StoppableAlgorithm
 #include "operon/core/grammar.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/hash/content_hash.hpp"
@@ -150,11 +149,12 @@ struct EnumerationConfig {
 
 // Top-level driver: wraps EnumerationEngine with coefficient fitting (via the
 // existing CoefficientOptimizer - this fully replaces symreg-cpp's Ceres
-// dependency with operon's own optimizer stack, no new fitting code needed)
-// and a stop-condition/reporting surface mirroring GeneticAlgorithmBase's
-// ReportCallback/StopRequested()/RequestStop() idiom (ga_base.hpp), even
-// though this doesn't inherit from GeneticAlgorithmBase - there's no
-// population/generation model here, just a level-by-level DP construction.
+// dependency with operon's own optimizer stack, no new fitting code needed).
+// Shares its stop-condition/reporting surface (ReportCallback/
+// StopRequested()/RequestStop()) with GeneticAlgorithmBase-derived
+// algorithms via StoppableAlgorithm, even though this doesn't inherit
+// GeneticAlgorithmBase itself - there's no population/generation model
+// here, just a level-by-level DP construction.
 //
 // Coefficient fitting and fitness scoring are deliberately separate
 // concerns, mirroring BasicOffspringGenerator's evaluate step
@@ -167,7 +167,7 @@ struct EnumerationConfig {
 // evaluator - rather than trusting OptimizerSummary's own cost fields -
 // keeps this consistent with the rest of the codebase and avoids coupling
 // ranking to whichever internal loss a given OptimizerBase happens to use.
-class OPERON_EXPORT GrammarEnumerationAlgorithm {
+class OPERON_EXPORT GrammarEnumerationAlgorithm : public StoppableAlgorithm {
 public:
     // `rng` is used once here to build the engine's Zobrist salt table (see
     // EnumerationEngine); Run()'s own `rng` argument is independent and used
@@ -190,16 +190,15 @@ public:
     // way operon_enum does, rather than let it reach here.
     //
     // Single-shot: Run() is not meant to be called more than once on the
-    // same instance - RequestStop() is one-way (nothing clears
-    // stopRequested_) and the underlying EnumerationEngine::Build() is not
-    // re-runnable (its buckets/dedup sets are already populated after the
-    // first call). Construct a new GrammarEnumerationAlgorithm for another
-    // run, mirroring the one-shot (not warm-restartable) contract already
-    // implied by EnumerationEngine.
+    // same instance - unlike GeneticAlgorithmBase, this class has no
+    // Reset() to clear StopRequested() between runs, and the underlying
+    // EnumerationEngine::Build() is not re-runnable (its buckets/dedup sets
+    // are already populated after the first call). Construct a new
+    // GrammarEnumerationAlgorithm for another run, mirroring the one-shot
+    // (not warm-restartable) contract already implied by EnumerationEngine.
     void Run(Operon::RandomGenerator& rng, Operon::ReportCallback report = {});
 
-    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(std::memory_order_acquire); }
-    void RequestStop() { stopRequested_.store(true, std::memory_order_release); }
+    // StopRequested()/RequestStop() are inherited from StoppableAlgorithm.
 
     // Best-fitness Expression trees found so far, sorted ascending by
     // evaluator score (lower = better), capped at EnumerationConfig::TopK.
@@ -214,7 +213,6 @@ private:
     EnumerationEngine engine_;
     gsl::not_null<Operon::OptimizerBase const*> optimizer_;
     gsl::not_null<Operon::EvaluatorBase const*> evaluator_;
-    std::atomic<bool> stopRequested_{false};
     std::vector<std::pair<Operon::Scalar, Operon::Tree>> best_; // sorted ascending by .first, size() <= config_.TopK
 };
 

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -5,13 +5,12 @@
 #ifndef GA_BASE_HPP
 #define GA_BASE_HPP
 
-#include <atomic>
-#include <functional>
 #include <string>
 #include <operon/operon_export.hpp>
 #include "operon/core/types.hpp"
 #include "operon/operators/generator.hpp"
 #include "config.hpp"
+#include "stoppable.hpp"
 
 namespace Operon {
 
@@ -20,57 +19,18 @@ class ReinserterBase;
 struct CoefficientInitializerBase;
 struct TreeInitializerBase;
 
-// Invoked once per generation by every algorithm's Run() to report progress.
-// Returning true requests early termination; each algorithm's own stop
-// condition ORs StopRequested() in alongside its evaluator-budget,
-// generation-count, and time-limit checks.
-using ReportCallback = std::function<bool()>;
-
-class GeneticAlgorithmBase {
+class GeneticAlgorithmBase : public StoppableAlgorithm {
 public:
-    virtual ~GeneticAlgorithmBase() = default;
-    // std::atomic<bool> isn't copyable, so stopRequested_ needs manual
-    // handling; every other member is copied exactly as the defaulted
-    // versions would have done.
-    GeneticAlgorithmBase(GeneticAlgorithmBase const& other)
-        : config_(other.config_)
-        , problem_(other.problem_)
-        , treeInit_(other.treeInit_)
-        , coeffInit_(other.coeffInit_)
-        , generator_(other.generator_)
-        , reinserter_(other.reinserter_)
-        , individuals_(other.individuals_)
-        , parents_(other.parents_)
-        , offspring_(other.offspring_)
-        , workerRngs_(other.workerRngs_)
-        , generation_(other.generation_)
-        , elapsed_(other.elapsed_)
-        , phaseTimes_(other.phaseTimes_)
-        , isFitted_(other.isFitted_)
-        , stopRequested_(other.stopRequested_.load())
-    {
-    }
+    ~GeneticAlgorithmBase() override = default;
+    // The atomic stopRequested_ that used to force a hand-written copy
+    // ctor/assign here now lives in StoppableAlgorithm, which provides its
+    // own copy handling for it - so copying *this* class is back to plain
+    // memberwise copy, and `= default` is correct (not just convenient).
+    // Move stays deleted: there's no use case for moving a live search
+    // driver.
+    GeneticAlgorithmBase(GeneticAlgorithmBase const&) = default;
     GeneticAlgorithmBase(GeneticAlgorithmBase&&) = delete;
-    auto operator=(GeneticAlgorithmBase const& other) -> GeneticAlgorithmBase&
-    {
-        if (this == &other) { return *this; }
-        config_ = other.config_;
-        problem_ = other.problem_;
-        treeInit_ = other.treeInit_;
-        coeffInit_ = other.coeffInit_;
-        generator_ = other.generator_;
-        reinserter_ = other.reinserter_;
-        individuals_ = other.individuals_;
-        parents_ = other.parents_;
-        offspring_ = other.offspring_;
-        workerRngs_ = other.workerRngs_;
-        generation_ = other.generation_;
-        elapsed_ = other.elapsed_;
-        phaseTimes_ = other.phaseTimes_;
-        isFitted_ = other.isFitted_;
-        stopRequested_.store(other.stopRequested_.load());
-        return *this;
-    }
+    auto operator=(GeneticAlgorithmBase const&) -> GeneticAlgorithmBase& = default;
     auto operator=(GeneticAlgorithmBase&&) -> GeneticAlgorithmBase& = delete;
 
     GeneticAlgorithmBase(GeneticAlgorithmConfig config, gsl::not_null<Problem const*> problem, gsl::not_null<TreeInitializerBase const*> treeInit, gsl::not_null<CoefficientInitializerBase const*> coeffInit, gsl::not_null<OffspringGeneratorBase const*> generator, gsl::not_null<ReinserterBase const*> reinserter)
@@ -119,12 +79,7 @@ public:
     [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
     auto IsFitted() -> bool& { return isFitted_; }
 
-    // Set by an algorithm's Run() when its ReportCallback returns true; each
-    // algorithm's own stop condition ORs this in. Atomic so it's also safe to
-    // call RequestStop() from outside the callback (e.g. another thread, a
-    // signal handler) while Run() is in progress.
-    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(std::memory_order_acquire); }
-    auto RequestStop() -> void { stopRequested_.store(true, std::memory_order_release); }
+    // StopRequested()/RequestStop() are inherited from StoppableAlgorithm.
 
     // Valid to call between runs only. The PhaseTimer observer owns its own
     // totals and is recreated each Run(), so Reset() mid-run would cause the
@@ -133,7 +88,7 @@ public:
     {
         generation_ = 0;
         elapsed_ = 0;
-        stopRequested_.store(false, std::memory_order_release);
+        ClearStopRequested();
         phaseTimes_.clear();
         GetGenerator()->Evaluator()->Reset();
     }
@@ -165,7 +120,6 @@ private:
     double elapsed_{0};
     Operon::Map<std::string, double> phaseTimes_;
     bool isFitted_{false};
-    std::atomic<bool> stopRequested_{false};
 };
 
 } // namespace Operon

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -22,15 +22,56 @@ struct TreeInitializerBase;
 class GeneticAlgorithmBase : public StoppableAlgorithm {
 public:
     ~GeneticAlgorithmBase() override = default;
-    // The atomic stopRequested_ that used to force a hand-written copy
-    // ctor/assign here now lives in StoppableAlgorithm, which provides its
-    // own copy handling for it - so copying *this* class is back to plain
-    // memberwise copy, and `= default` is correct (not just convenient).
-    // Move stays deleted: there's no use case for moving a live search
-    // driver.
-    GeneticAlgorithmBase(GeneticAlgorithmBase const&) = default;
+    // Not `= default`: parents_/offspring_ are non-owning spans into
+    // individuals_'s storage, so a plain memberwise copy would leave the
+    // copy's spans pointing at the *source* object's individuals_ buffer
+    // (dangling once the source is destroyed, and aliasing it while both
+    // are alive). They're rebound here to the copy's own individuals_,
+    // exactly like the primary constructor and RestoreIndividuals() do -
+    // both derive them from config_.PopulationSize/PoolSize rather than
+    // copying the span objects themselves. The atomic stopRequested_ still
+    // gets its own handling via StoppableAlgorithm's copy ctor/assign
+    // (invoked explicitly here since every other member is memberwise-safe
+    // to copy or, like the spans, needs deriving instead).
+    GeneticAlgorithmBase(GeneticAlgorithmBase const& other)
+        : StoppableAlgorithm(other)
+        , config_(other.config_)
+        , problem_(other.problem_)
+        , treeInit_(other.treeInit_)
+        , coeffInit_(other.coeffInit_)
+        , generator_(other.generator_)
+        , reinserter_(other.reinserter_)
+        , individuals_(other.individuals_)
+        , parents_(individuals_.data(), config_.PopulationSize)
+        , offspring_(individuals_.data() + config_.PopulationSize, config_.PoolSize)
+        , workerRngs_(other.workerRngs_)
+        , generation_(other.generation_)
+        , elapsed_(other.elapsed_)
+        , phaseTimes_(other.phaseTimes_)
+        , isFitted_(other.isFitted_)
+    {
+    }
     GeneticAlgorithmBase(GeneticAlgorithmBase&&) = delete;
-    auto operator=(GeneticAlgorithmBase const&) -> GeneticAlgorithmBase& = default;
+    auto operator=(GeneticAlgorithmBase const& other) -> GeneticAlgorithmBase&
+    {
+        if (this == &other) { return *this; }
+        StoppableAlgorithm::operator=(other);
+        config_ = other.config_;
+        problem_ = other.problem_;
+        treeInit_ = other.treeInit_;
+        coeffInit_ = other.coeffInit_;
+        generator_ = other.generator_;
+        reinserter_ = other.reinserter_;
+        individuals_ = other.individuals_;
+        parents_ = Operon::Span<Individual>(individuals_.data(), config_.PopulationSize);
+        offspring_ = Operon::Span<Individual>(individuals_.data() + config_.PopulationSize, config_.PoolSize);
+        workerRngs_ = other.workerRngs_;
+        generation_ = other.generation_;
+        elapsed_ = other.elapsed_;
+        phaseTimes_ = other.phaseTimes_;
+        isFitted_ = other.isFitted_;
+        return *this;
+    }
     auto operator=(GeneticAlgorithmBase&&) -> GeneticAlgorithmBase& = delete;
 
     GeneticAlgorithmBase(GeneticAlgorithmConfig config, gsl::not_null<Problem const*> problem, gsl::not_null<TreeInitializerBase const*> treeInit, gsl::not_null<CoefficientInitializerBase const*> coeffInit, gsl::not_null<OffspringGeneratorBase const*> generator, gsl::not_null<ReinserterBase const*> reinserter)

--- a/include/operon/algorithms/stoppable.hpp
+++ b/include/operon/algorithms/stoppable.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_STOPPABLE_HPP
+#define OPERON_ALGORITHMS_STOPPABLE_HPP
+
+#include <atomic>
+#include <functional>
+
+namespace Operon {
+
+// Invoked once per generation (GeneticAlgorithmBase-derived algorithms) or
+// once per budget level (GrammarEnumerationAlgorithm) by an algorithm's
+// Run() to report progress. Returning true requests early termination; each
+// algorithm's own stop condition ORs StopRequested() in alongside its own
+// generation-count/budget, evaluator-budget, and time-limit checks.
+using ReportCallback = std::function<bool()>;
+
+// Shared stopRequested_ + StopRequested()/RequestStop() idiom for search
+// drivers, whether population-based (GeneticAlgorithmBase) or not
+// (GrammarEnumerationAlgorithm). Factored out because both independently
+// need it and neither can inherit the other (one has a population/
+// generation model, the other a bottom-up DP construction with none).
+//
+// std::atomic<bool> isn't copyable, so copy/assign are hand-written here
+// once instead of being duplicated (and risking drift) in every derived
+// class. Move is deleted for the same reason GeneticAlgorithmBase deletes
+// it: there's no use case for moving a live search driver, and skipping it
+// avoids having to define a moved-from state for the atomic.
+class StoppableAlgorithm {
+public:
+    StoppableAlgorithm() = default;
+    virtual ~StoppableAlgorithm() = default;
+
+    StoppableAlgorithm(StoppableAlgorithm const& other)
+        : stopRequested_(other.stopRequested_.load(std::memory_order_acquire))
+    {
+    }
+    StoppableAlgorithm(StoppableAlgorithm&&) = delete;
+
+    auto operator=(StoppableAlgorithm const& other) -> StoppableAlgorithm&
+    {
+        if (this == &other) { return *this; }
+        stopRequested_.store(other.stopRequested_.load(std::memory_order_acquire), std::memory_order_release);
+        return *this;
+    }
+    auto operator=(StoppableAlgorithm&&) -> StoppableAlgorithm& = delete;
+
+    // Set by an algorithm's Run() when its ReportCallback returns true; each
+    // algorithm's own stop condition ORs this in. Atomic so it's also safe
+    // to call RequestStop() from outside the callback (e.g. another thread,
+    // a signal handler) while Run() is in progress.
+    [[nodiscard]] auto StopRequested() const -> bool { return stopRequested_.load(std::memory_order_acquire); }
+    auto RequestStop() -> void { stopRequested_.store(true, std::memory_order_release); }
+
+protected:
+    // Not public: only a derived class's own Reset() (if it has one) should
+    // decide when clearing this is safe - e.g. GeneticAlgorithmBase::Reset()
+    // documents that it's only valid to call between runs.
+    auto ClearStopRequested() -> void { stopRequested_.store(false, std::memory_order_release); }
+
+private:
+    std::atomic<bool> stopRequested_{false};
+};
+
+} // namespace Operon
+
+#endif

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <vector>
@@ -126,6 +127,44 @@ TEST_CASE("RestoreIndividuals maps parents and offspring spans correctly", "[alg
     for (std::size_t i = 0; i < poolSize; ++i) {
         CHECK(offspring[i].Fitness[0] == static_cast<Operon::Scalar>(popSize + i));
     }
+}
+
+TEST_CASE("Copying a GeneticAlgorithmBase-derived object rebinds Parents()/Offspring() to its own storage", "[algorithms]")
+{
+    GaBaseFixture f;
+    constexpr auto popSize  = GaBaseFixture::PopSize;
+    constexpr auto poolSize = GaBaseFixture::PoolSize;
+    constexpr auto total    = popSize + poolSize;
+
+    std::vector<Operon::Individual> inds(total);
+    for (std::size_t i = 0; i < total; ++i) {
+        inds[i].Fitness.resize(1);
+        inds[i].Fitness[0] = static_cast<Operon::Scalar>(i);
+    }
+    f.Gp.RestoreIndividuals(inds);
+    f.Gp.RequestStop(); // exercise StopRequested() being copied too
+
+    Operon::GeneticProgrammingAlgorithm copy{f.Gp}; // NOLINT(performance-unnecessary-copy-initialization)
+
+    // Parents()/Offspring() must point into the *copy*'s own Individuals(),
+    // not the original's - otherwise they dangle once the original that
+    // still owns that storage goes out of scope, or alias it while both are
+    // alive. std::addressof on the first element is the simplest way to
+    // check "same underlying storage" without relying on span internals.
+    CHECK(std::addressof(copy.Parents()[0]) == std::addressof(copy.Individuals()[0]));
+    CHECK(std::addressof(copy.Offspring()[0]) == std::addressof(copy.Individuals()[popSize]));
+    CHECK(std::addressof(copy.Parents()[0]) != std::addressof(f.Gp.Parents()[0]));
+
+    // Content and stop-flag state are still copied correctly.
+    REQUIRE(copy.Parents().size()   == popSize);
+    REQUIRE(copy.Offspring().size() == poolSize);
+    for (std::size_t i = 0; i < popSize; ++i) {
+        CHECK(copy.Parents()[i].Fitness[0] == static_cast<Operon::Scalar>(i));
+    }
+    for (std::size_t i = 0; i < poolSize; ++i) {
+        CHECK(copy.Offspring()[i].Fitness[0] == static_cast<Operon::Scalar>(popSize + i));
+    }
+    CHECK(copy.StopRequested());
 }
 
 TEST_CASE("ReportCallback returning true stops the run before the next generation", "[algorithms]")


### PR DESCRIPTION
## Summary
- Phase 1 item A3 of the architecture remediation plan.
- `GrammarEnumerationAlgorithm` reimplemented `GeneticAlgorithmBase`'s `stopRequested_`/`StopRequested()`/`RequestStop()`/`ReportCallback` idiom verbatim, since it can't inherit the population-based base (no population/generation model). Both now derive from a new shared `StoppableAlgorithm` (`algorithms/stoppable.hpp`) instead.

**Update (review fix):** the `= default` collapse I initially made surfaced (but did not introduce - confirmed by diffing against the pre-PR code) a real bug: `parents_`/`offspring_` are non-owning spans into `individuals_`'s storage, and a plain memberwise copy leaves the copy's spans pointing at the *source* object's `individuals_` buffer rather than its own - dangling once the source is destroyed, or aliasing it while both are alive. Went back to an explicit (not defaulted) copy ctor/assign that rebinds `parents_`/`offspring_` from `config_.PopulationSize`/`PoolSize`, exactly like the primary constructor and `RestoreIndividuals()` already do, while still delegating the atomic's copy handling to `StoppableAlgorithm`. Added a regression test covering both the storage-rebinding and stop-flag-copying behavior.

## Test plan
- [x] Full build (`cmake --build build`) including all CLIs (`operon_gp`, `operon_nsgp`, `operon_parse_model`, `operon_enum`) and examples.
- [x] Full test suite green: `./build/test/operon_test '~[performance]'` — 23291 assertions / 187 cases (+12 assertions / +1 case from the new copy-correctness regression test), matching baseline otherwise.
- [x] No new clang-tidy/clangd findings introduced by the refactor.