### PR TITLE
refactor(operators): factor shared ProfileSigma helper

### DIFF
--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -422,12 +422,21 @@ public:
 
         auto const trainingRange = problem->TrainingRange();
         ENSURE(buf.size() >= trainingRange.Size());
+        // EvaluatorBase::Evaluate's contract permits buf.size() >
+        // trainingRange.Size() (a caller-owned scratch buffer sized for
+        // reuse across calls), but everything below - the interpreter's
+        // fixed-size write, the Jacobian's row count, ComputeFisherMatrix's
+        // row-count inference from estimatedValues.size() - is built
+        // around exactly trainingRange.Size() rows. Slice once, up front,
+        // so every downstream use (including Interpreter::Evaluate's own
+        // result buffer, which it silently leaves untouched if given a
+        // mismatched size) sees a span sized to match.
+        auto estimatedValues = buf.subspan(0, trainingRange.Size());
 
         ++Base::ResidualEvaluations;
-        interpreter.Evaluate(parameters, trainingRange, buf);
+        interpreter.Evaluate(parameters, trainingRange, estimatedValues);
 
-        auto estimatedValues = buf;
-        auto targetValues    = problem->TargetValues(trainingRange);
+        auto targetValues = problem->TargetValues(trainingRange);
         Operon::Scalar profiledSigma{};
         if (sigma_.empty() && Lik::UsesSigma) {
             profiledSigma = detail::ProfileSigma(estimatedValues, targetValues);
@@ -484,12 +493,15 @@ public:
         auto const trainingRange = problem->TrainingRange();
         auto const n { static_cast<double>(trainingRange.Size()) };
         ENSURE(buf.size() >= trainingRange.Size());
+        // See MinimumDescriptionLengthEvaluator's operator() for why this
+        // slice is needed: everything downstream assumes exactly
+        // trainingRange.Size() rows, but buf may legitimately be larger.
+        auto estimatedValues = buf.subspan(0, trainingRange.Size());
 
         ++Base::ResidualEvaluations;
-        interpreter.Evaluate(parameters, trainingRange, buf);
+        interpreter.Evaluate(parameters, trainingRange, estimatedValues);
 
-        auto estimatedValues = buf;
-        auto targetValues    = problem->TargetValues(trainingRange);
+        auto targetValues = problem->TargetValues(trainingRange);
         double mlNLL{};
         Operon::Scalar profiledSigma{};
         if (sigma_.empty() && Lik::UsesSigma) { // NLL = 0.5*n*(log(2*pi*sigma^2)+1), clamped to avoid log(0)
@@ -570,11 +582,14 @@ class OPERON_EXPORT LikelihoodEvaluator final : public Evaluator<DTable> {
 
         auto const trainingRange = problem->TrainingRange();
         ENSURE(buf.size() >= trainingRange.Size());
+        // See MinimumDescriptionLengthEvaluator's operator() for why this
+        // slice is needed: everything downstream assumes exactly
+        // trainingRange.Size() rows, but buf may legitimately be larger.
+        auto estimatedValues = buf.subspan(0, trainingRange.Size());
         ++Base::ResidualEvaluations;
-        interpreter.Evaluate(parameters, trainingRange, buf);
+        interpreter.Evaluate(parameters, trainingRange, estimatedValues);
 
-        auto estimatedValues = buf;
-        auto targetValues    = problem->TargetValues(trainingRange);
+        auto targetValues = problem->TargetValues(trainingRange);
 
         auto lik = Likelihood::ComputeLikelihood(estimatedValues, targetValues, sigma_);
         return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(lik) };

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -370,9 +370,16 @@ namespace detail {
     // `sigma_.empty() && Lik::UsesSigma` gating at each call site).
     inline auto ProfileSigma(Operon::Span<Operon::Scalar const> estimated, Operon::Span<Operon::Scalar const> target) -> Operon::Scalar
     {
-        auto const n = static_cast<double>(estimated.size());
+        // Bounded by the shorter of the two spans, not just estimated's -
+        // callers only guarantee estimated.size() >= target.size() (e.g. a
+        // reused scratch buffer sized to a training range but possibly
+        // larger; see EvaluatorBase::Evaluate's ENSURE), not equality, so
+        // indexing target[i] up to estimated.size() alone would read past
+        // target's end whenever the buffer is oversized.
+        auto const count = std::min(estimated.size(), target.size());
+        auto const n = static_cast<double>(count);
         auto ssr = 0.0;
-        for (std::size_t i = 0; i < estimated.size(); ++i) {
+        for (std::size_t i = 0; i < count; ++i) {
             auto const e = static_cast<double>(estimated[i]) - static_cast<double>(target[i]);
             ssr += e * e;
         }

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -362,6 +362,25 @@ private:
     std::size_t sampleSize_ {};
 };
 
+namespace detail {
+    // Profile MLE sigma-hat = sqrt(SSR/n) from residuals (estimated - target),
+    // clamped away from zero so a downstream log(sigma^2) or division by
+    // sigma can't hit zero. Shared by evaluators that fall back to this
+    // estimate when the caller hasn't supplied a sigma of their own (see the
+    // `sigma_.empty() && Lik::UsesSigma` gating at each call site).
+    inline auto ProfileSigma(Operon::Span<Operon::Scalar const> estimated, Operon::Span<Operon::Scalar const> target) -> Operon::Scalar
+    {
+        auto const n = static_cast<double>(estimated.size());
+        auto ssr = 0.0;
+        for (std::size_t i = 0; i < estimated.size(); ++i) {
+            auto const e = static_cast<double>(estimated[i]) - static_cast<double>(target[i]);
+            ssr += e * e;
+        }
+        return std::max(static_cast<Operon::Scalar>(std::sqrt(ssr / n)),
+                         std::numeric_limits<Operon::Scalar>::epsilon());
+    }
+} // namespace detail
+
 template <typename DTable, Concepts::Likelihood Lik>
 requires Concepts::HasFisherMatrix<Lik>
 class OPERON_EXPORT MinimumDescriptionLengthEvaluator final : public Evaluator<DTable> {
@@ -403,15 +422,8 @@ public:
         auto estimatedValues = buf;
         auto targetValues    = problem->TargetValues(trainingRange);
         Operon::Scalar profiledSigma{};
-        if (sigma_.empty() && Lik::UsesSigma) { // profile MLE σ̂ = sqrt(SSR/n) from residuals
-            auto const nObs = static_cast<double>(trainingRange.Size());
-            auto ssr = 0.0;
-            for (auto i = 0; i < static_cast<std::ptrdiff_t>(trainingRange.Size()); ++i) {
-                auto const e = static_cast<double>(estimatedValues[i]) - static_cast<double>(targetValues[i]);
-                ssr += e * e;
-            }
-            profiledSigma = std::max(static_cast<Operon::Scalar>(std::sqrt(ssr / nObs)),
-                                     std::numeric_limits<Operon::Scalar>::epsilon());
+        if (sigma_.empty() && Lik::UsesSigma) {
+            profiledSigma = detail::ProfileSigma(estimatedValues, targetValues);
         }
         auto const effectiveSigma = (sigma_.empty() && Lik::UsesSigma)
             ? std::span<Operon::Scalar const>{&profiledSigma, 1}  // profiled
@@ -473,14 +485,8 @@ public:
         auto targetValues    = problem->TargetValues(trainingRange);
         double mlNLL{};
         Operon::Scalar profiledSigma{};
-        if (sigma_.empty() && Lik::UsesSigma) { // profile MLE σ̂ = sqrt(SSR/n); NLL = 0.5·n·(log(2π·σ̂²)+1), clamped to avoid log(0)
-            auto ssr = 0.0;
-            for (auto i = 0; i < static_cast<std::ptrdiff_t>(trainingRange.Size()); ++i) {
-                auto const e = static_cast<double>(estimatedValues[i]) - static_cast<double>(targetValues[i]);
-                ssr += e * e;
-            }
-            profiledSigma = std::max(static_cast<Operon::Scalar>(std::sqrt(ssr / n)),
-                                     std::numeric_limits<Operon::Scalar>::epsilon());
+        if (sigma_.empty() && Lik::UsesSigma) { // NLL = 0.5*n*(log(2*pi*sigma^2)+1), clamped to avoid log(0)
+            profiledSigma = detail::ProfileSigma(estimatedValues, targetValues);
             auto const s = static_cast<double>(profiledSigma);
             mlNLL = 0.5 * n * (std::log(Operon::Math::Tau * s * s) + 1.0);
         }

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -319,6 +319,46 @@ TEST_CASE("FBF evaluator", "[evaluator]")
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// LikelihoodEvaluator
+// ──────────────────────────────────────────────────────────────────────────────
+TEST_CASE("LikelihoodEvaluator", "[evaluator]")
+{
+    EvaluatorFixture fix;
+    using DTable = EvaluatorFixture::DTable;
+
+    SECTION("Gaussian: finite result") {
+        // LikelihoodEvaluator only overrides the 3-arg operator() (unlike
+        // MDL/FBF, which also provide their own 2-arg override), so this
+        // always calls the buffered form directly rather than through
+        // EvaluatorBase::Evaluate.
+        GaussianLikelihoodEvaluator<DTable> const ev{&fix.problem, &fix.dtable};
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        std::vector<Operon::Scalar> buf(EvaluatorFixture::Nrow);
+        auto const result = ev(fix.rng, ind, buf);
+        REQUIRE(result.size() == 1);
+        CHECK(std::isfinite(result[0]));
+    }
+
+    // Same regression guard as MDL/FBF's - see MinimumDescriptionLengthEvaluator's
+    // operator() for why the slice fix is needed.
+    SECTION("Gaussian: oversized buffer matches exact-size buffer") {
+        GaussianLikelihoodEvaluator<DTable> const ev{&fix.problem, &fix.dtable};
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        std::vector<Operon::Scalar> oversizedBuf(EvaluatorFixture::Nrow + 50);
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // detail::ProfileSigma
 // ──────────────────────────────────────────────────────────────────────────────
 TEST_CASE("ProfileSigma", "[evaluator]")

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -221,6 +221,7 @@ TEST_CASE("MDL evaluator", "[evaluator]")
         REQUIRE(result.size() == 1);
         CHECK(std::isfinite(result[0]));
     }
+
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -275,6 +276,39 @@ TEST_CASE("FBF evaluator", "[evaluator]")
         auto const result = ev(fix.rng, ind);
         REQUIRE(result.size() == 1);
         CHECK(std::isfinite(result[0]));
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// detail::ProfileSigma
+// ──────────────────────────────────────────────────────────────────────────────
+TEST_CASE("ProfileSigma", "[evaluator]")
+{
+    SECTION("estimated longer than target: bounded by the shorter span, no out-of-bounds read") {
+        // Regression guard: EvaluatorBase::Evaluate's contract only requires
+        // buf.size() >= TrainingRange().Size(), not equality, so a caller
+        // may legitimately hand ProfileSigma an oversized `estimated` span.
+        // It must not index `target` past its own (shorter) length.
+        std::vector<Operon::Scalar> const target{1.0F, 2.0F, 3.0F};
+        std::vector<Operon::Scalar> estimated{1.1F, 2.1F, 3.1F, 999.F, 999.F}; // 2 extra, unrelated entries
+        auto const sigma = Operon::detail::ProfileSigma(estimated, target);
+        CHECK(std::isfinite(sigma));
+        // sqrt(SSR/n) over exactly the 3 overlapping entries (residual 0.1 each): sqrt(3*0.01/3) = 0.1
+        CHECK_THAT(static_cast<double>(sigma), Catch::Matchers::WithinRel(0.1, 1e-3));
+    }
+
+    SECTION("exact-size spans: matches the straightforward SSR/n computation") {
+        std::vector<Operon::Scalar> const estimated{1.0F, 2.0F, 3.0F, 4.0F};
+        std::vector<Operon::Scalar> const target{0.0F, 0.0F, 0.0F, 0.0F};
+        auto const sigma = Operon::detail::ProfileSigma(estimated, target);
+        // SSR = 1+4+9+16 = 30, n = 4, sigma = sqrt(30/4)
+        CHECK_THAT(static_cast<double>(sigma), Catch::Matchers::WithinRel(std::sqrt(30.0 / 4.0), 1e-3));
+    }
+
+    SECTION("SSR=0 clamps to epsilon rather than returning exactly zero") {
+        std::vector<Operon::Scalar> const v{1.0F, 2.0F, 3.0F};
+        auto const sigma = Operon::detail::ProfileSigma(v, v);
+        CHECK(sigma == std::numeric_limits<Operon::Scalar>::epsilon());
     }
 }
 

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -222,6 +222,28 @@ TEST_CASE("MDL evaluator", "[evaluator]")
         CHECK(std::isfinite(result[0]));
     }
 
+    // End-to-end regression test (through the real evaluator path, not just
+    // detail::ProfileSigma in isolation): EvaluatorBase::Evaluate's contract
+    // permits buf.size() > TrainingRange().Size(), and the operator() body
+    // now slices down to exactly TrainingRange().Size() before using it
+    // anywhere (interpreter output, ComputeFisherMatrix's row-count
+    // inference) - so an oversized buffer must produce the same result as
+    // an exactly-sized one, not crash or silently diverge.
+    SECTION("Gaussian / profiled sigma: oversized buffer matches exact-size buffer") {
+        MinimumDescriptionLengthEvaluator<DTable, GaussianLikelihood<Operon::Scalar>> const ev{&fix.problem, &fix.dtable};
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        std::vector<Operon::Scalar> oversizedBuf(EvaluatorFixture::Nrow + 50);
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -268,6 +290,23 @@ TEST_CASE("FBF evaluator", "[evaluator]")
         auto const rG = evG(fix.rng, ind);
         auto const rP = evP(fix.rng, ind);
         CHECK(rG[0] != rP[0]);
+    }
+
+    // Same regression guard as MDL's - see the comment there.
+    SECTION("Gaussian / profiled sigma: oversized buffer matches exact-size buffer") {
+        FractionalBayesFactorEvaluator<DTable, GaussianLikelihood<Operon::Scalar>> const ev{&fix.problem, &fix.dtable};
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        std::vector<Operon::Scalar> oversizedBuf(EvaluatorFixture::Nrow + 50);
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
     }
 
     SECTION("Gaussian / profiled sigma: SSR=0 does not produce NaN (epsilon clamp)") {


### PR DESCRIPTION
## Summary
- Phase 1 item A2 of the architecture remediation plan.
- `MinimumDescriptionLengthEvaluator` and `FractionalBayesFactorEvaluator` each carried a near-identical "profile MLE sigma-hat = sqrt(SSR/n) from residuals, clamped away from zero" block. Extracted into one `detail::ProfileSigma(estimated, target)` helper in `operators/evaluator.hpp`.
- FBF's own NLL derivation from the profiled sigma (`0.5*n*(log(2*pi*sigma^2)+1)`) stays in its caller, unchanged — only the sigma-profiling computation itself is shared.
- The epsilon clamp (`std::numeric_limits<Operon::Scalar>::epsilon()`) is preserved exactly.

**Update 1 (review round 1):** `ProfileSigma`'s residual loop originally bounded on `estimated.size()` while indexing `target[i]` — safe today only because every current caller sizes its buffer exactly to `TrainingRange().Size()`, but `EvaluatorBase::Evaluate`'s contract only requires `>=`. Fixed by bounding on `std::min(estimated.size(), target.size())`. Added direct unit tests for `detail::ProfileSigma`.

**Update 2 (review round 2 — this was flagged as not sufficient end-to-end, correctly):** the round-1 fix only stopped `ProfileSigma` itself from reading out of bounds — it didn't fix the surrounding evaluator body, which still passed the *full* (possibly oversized) buffer into `interpreter.Evaluate`/`ComputeFisherMatrix`/`ComputeLikelihood`. Two real, separate problems there:
  1. `Interpreter::Evaluate(coeff, range, result)` only writes into `result` when `result.size() == range.Size()` *exactly* — given an oversized buffer, it silently leaves it untouched, so `estimatedValues` held **stale data from a previous call**, not the current candidate's predictions.
  2. `ComputeFisherMatrix` infers the Jacobian's column count as `jac.size() / estimated.size()` — an oversized `estimated` span makes this silently wrong, which surfaced as a real crash (`ASSERT(fisherDiag.size() == p)`) when I drove a regression test through the actual evaluator with an oversized buffer.

  Fixed by slicing `buf` down to exactly `trainingRange.Size()` **once, up front**, in `MinimumDescriptionLengthEvaluator`, `FractionalBayesFactorEvaluator`, and `LikelihoodEvaluator` (same pattern, same file) — every downstream use now sees a correctly-sized span. Added end-to-end regression tests (through the real evaluator, not just `ProfileSigma` in isolation) confirming an oversized buffer now produces the *same result* as an exactly-sized one instead of crashing or silently drifting.

  **Not fixed here, filed as [#114](https://github.com/heal-research/operon/issues/114):** the base `Evaluator<DTable>::operator()` (`source/operators/evaluator.cpp`, used by every default R2/MSE/NMSE/etc. evaluator and inherited by BIC/AIC) has the identical bug pattern. Bigger, more foundational fix than this PR's ProfileSigma-dedup scope warrants.

**Update 3 (review round 3):** added the requested `LikelihoodEvaluator` end-to-end oversized-buffer test, mirroring MDL/FBF's. Incidentally discovered (not fixed, out of scope) that `LikelihoodEvaluator` has no 2-arg `operator()` override of its own — unlike MDL/FBF, it relies entirely on the inherited `Evaluator<DTable>` 2-arg path, which isn't generically defined for arbitrary `DTable` (only explicitly specialized for `ScalarDispatch`). The new test calls the 3-arg buffered form directly to sidestep this pre-existing gap.

## Test plan
- [x] Full build (`cmake --build build`).
- [x] Full test suite green: `./build/test/operon_test '~[performance]'` — 23293 assertions / 188 cases, matching baseline otherwise.
- [x] New `detail::ProfileSigma` unit tests (oversized span, exact-size SSR/n, epsilon clamp).
- [x] New end-to-end MDL/FBF/LikelihoodEvaluator tests: oversized buffer produces the same result as an exact-size buffer (previously crashed for MDL/FBF).