### PR TITLE
refactor(operators): EvaluatorBase::Evaluate via deducing-this

### DIFF
--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -100,16 +100,23 @@ struct EvaluatorBase : public E1, E2
     {
     }
 
-    template<typename Derived>
-    static auto Evaluate(Derived const* self, Operon::RandomGenerator& rng, Operon::Individual const& ind, std::span<Operon::Scalar> buf) {
-        ENSURE(buf.size() >= self->GetProblem()->TrainingRange().Size());
-        return std::invoke(*self, rng, ind, buf);
+    // Deducing-this in place of the old `static Evaluate(Derived const*
+    // self, ...)` CRTP helper: Self deduces to the most-derived type at each
+    // call site (a derived operator()'s own `this`), so std::invoke(self,
+    // ...) below still calls that concrete override directly rather than
+    // going through this base's virtual operator(). Not virtual - can't be,
+    // per the language rule on explicit-object member functions - which
+    // matches the original static member's own non-virtual-ness.
+    template<typename Self>
+    auto Evaluate(this Self const& self, Operon::RandomGenerator& rng, Operon::Individual const& ind, std::span<Operon::Scalar> buf) {
+        ENSURE(buf.size() >= self.GetProblem()->TrainingRange().Size());
+        return std::invoke(self, rng, ind, buf);
     }
 
-    template<typename Derived>
-    static auto Evaluate(Derived const* self, Operon::RandomGenerator& rng, Operon::Individual const& ind) {
-        std::vector<Operon::Scalar> buf(self->GetProblem()->TrainingRange().Size());
-        return std::invoke(*self, rng, ind, buf);
+    template<typename Self>
+    auto Evaluate(this Self const& self, Operon::RandomGenerator& rng, Operon::Individual const& ind) {
+        std::vector<Operon::Scalar> buf(self.GetProblem()->TrainingRange().Size());
+        return std::invoke(self, rng, ind, buf);
     }
 
     virtual void Prepare(Operon::Span<Individual const> /*pop*/) const
@@ -177,7 +184,7 @@ public:
     }
 
     auto operator()(Operon::RandomGenerator& rng, Individual const& ind) const -> typename EvaluatorBase::ReturnType override {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return Evaluate(rng, ind);
     }
 
 private:
@@ -240,7 +247,7 @@ public:
     auto
     operator()(Operon::RandomGenerator& rng, Individual const& ind) const -> typename EvaluatorBase::ReturnType override
     {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return Evaluate(rng, ind);
     }
 
     auto
@@ -377,7 +384,7 @@ public:
     auto SetSigma(std::vector<Operon::Scalar> sigma) const -> void { sigma_ = std::move(sigma); }
 
     auto operator()(Operon::RandomGenerator& rng, Operon::Individual const& ind) const -> typename EvaluatorBase::ReturnType override {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return this->Evaluate(rng, ind);
     }
 
     auto operator()(Operon::RandomGenerator& /*random*/, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override {
@@ -448,7 +455,7 @@ public:
     auto SetSigma(std::vector<Operon::Scalar> sigma) const -> void { sigma_ = std::move(sigma); }
 
     auto operator()(Operon::RandomGenerator& rng, Operon::Individual const& ind) const -> typename EvaluatorBase::ReturnType override {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return this->Evaluate(rng, ind);
     }
 
     auto operator()(Operon::RandomGenerator& /*random*/, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override {

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -184,7 +184,7 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
 
 auto JitEvaluator::operator()(RandomGenerator& rng, Individual const& ind) const -> ReturnType
 {
-    return EvaluatorBase::Evaluate(this, rng, ind);
+    return Evaluate(rng, ind);
 }
 
 auto JitEvaluator::CacheSize() const -> std::size_t

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -81,7 +81,7 @@ namespace {
     template<> auto OPERON_EXPORT
     Evaluator<ScalarDispatch>::operator()(Operon::RandomGenerator& rng, Individual const& ind) const -> typename EvaluatorBase::ReturnType
     {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return Evaluate(rng, ind);
     }
 
     auto DiversityEvaluator::Prepare(Operon::Span<Operon::Individual const> pop) const -> void {
@@ -99,7 +99,7 @@ namespace {
 
     auto
     DiversityEvaluator::operator()(Operon::RandomGenerator& rng, Individual const& ind) const -> typename EvaluatorBase::ReturnType {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return Evaluate(rng, ind);
     }
 
     auto
@@ -124,7 +124,7 @@ namespace {
     auto
     AggregateEvaluator::operator()(Operon::RandomGenerator& rng, Individual const& ind) const -> typename EvaluatorBase::ReturnType
     {
-        return EvaluatorBase::Evaluate(this, rng, ind);
+        return Evaluate(rng, ind);
     }
 
     auto

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -422,4 +422,93 @@ TEST_CASE("Weighted evaluator", "[evaluator]")
     }
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// EvaluatorBase::Evaluate (deducing-this) dispatch
+//
+// Regression coverage for the CRTP-to-deducing-this rewrite: the unbuffered
+// 2-arg operator() overload must reach the *concrete derived* 3-arg
+// override via std::invoke(self, ...) - not the base's own pure-virtual
+// operator(), and not some other evaluator's override. Verified per class by
+// checking the 2-arg result matches an independently-computed expectation
+// (either a direct 3-arg call, or - for the one evaluator whose 3-arg body
+// consumes RNG state - a separately-seeded but identical RNG sequence).
+// ──────────────────────────────────────────────────────────────────────────────
+TEST_CASE("EvaluatorBase::Evaluate dispatch reaches the concrete derived override", "[evaluator]")
+{
+    EvaluatorFixture fix;
+    using DTable = EvaluatorFixture::DTable;
+
+    SECTION("UserDefinedEvaluator") {
+        int calls = 0;
+        Operon::UserDefinedEvaluator ev{&fix.problem, [&](Operon::RandomGenerator&, Operon::Individual const&) -> Operon::EvaluatorBase::ReturnType {
+            ++calls;
+            return { Operon::Scalar{42} };
+        }};
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        auto const result = ev(fix.rng, ind); // 2-arg
+        REQUIRE(result.size() == 1);
+        CHECK(result[0] == Operon::Scalar{42});
+        CHECK(calls == 1); // the 3-arg override's lambda ran exactly once, not zero or twice
+    }
+
+    SECTION("MultiEvaluator") {
+        Operon::Evaluator<DTable> r2{&fix.problem, &fix.dtable, Operon::R2{}};
+        Operon::Evaluator<DTable> mse{&fix.problem, &fix.dtable, Operon::MSE{}};
+        Operon::MultiEvaluator me{&fix.problem};
+        me.Add(&r2);
+        me.Add(&mse);
+
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        auto const combined = me(fix.rng, ind); // 2-arg
+        auto const expectedR2  = r2(fix.rng, ind);
+        auto const expectedMse = mse(fix.rng, ind);
+
+        REQUIRE(combined.size() == 2);
+        CHECK(combined[0] == expectedR2[0]);
+        CHECK(combined[1] == expectedMse[0]);
+    }
+
+    SECTION("AggregateEvaluator") {
+        // Aggregating a single-objective evaluator is a no-op regardless of
+        // AggregateType (min/max/median/mean of one element is that
+        // element), so the 2-arg result must equal the wrapped evaluator's
+        // own 2-arg result exactly.
+        Operon::Evaluator<DTable> inner{&fix.problem, &fix.dtable, Operon::MSE{}};
+        Operon::AggregateEvaluator ae{&inner};
+
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        auto const aggregated = ae(fix.rng, ind); // 2-arg
+        auto const expected   = inner(fix.rng, ind);
+
+        REQUIRE(aggregated.size() == 1);
+        CHECK(aggregated[0] == expected[0]);
+    }
+
+    SECTION("DiversityEvaluator") {
+        // The 3-arg override consumes RNG state (Operon::Random::Sample per
+        // sample), so two independently-seeded-but-identical RandomGenerator
+        // instances must produce bit-identical results if the 2-arg path
+        // reaches the same code as a direct 3-arg call.
+        Operon::DiversityEvaluator dv{&fix.problem};
+        std::vector<Operon::Individual> pop{
+            EvaluatorFixture::MakeIndividual(fix.tree),
+            EvaluatorFixture::MakeIndividual(fix.perfectTree),
+        };
+        dv.Prepare(pop);
+
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        Operon::RandomGenerator rngA{123};
+        Operon::RandomGenerator rngB{123};
+
+        auto const via2Arg = dv(rngA, ind); // 2-arg
+        std::vector<Operon::Scalar> buf(fix.problem.TrainingRange().Size());
+        auto const via3Arg = dv(rngB, ind, buf); // 3-arg, direct
+
+        REQUIRE(via2Arg.size() == 1);
+        REQUIRE(via3Arg.size() == 1);
+        CHECK(std::isfinite(via2Arg[0]));
+        CHECK(via2Arg[0] == via3Arg[0]);
+    }
+}
+
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Scoped-down Phase 1 item A1 of the architecture remediation plan.
- Replaces `EvaluatorBase`'s `static Evaluate(Derived const* self, ...)` CRTP helper (the codebase's one hand-rolled CRTP pattern) with a deducing-this member. Same behavior: `std::invoke` on the concrete derived type directly (not through the virtual `operator()`), just without threading `Derived*`/`this` through by hand at each of the 7 call sites.
- **Deferred from the original plan**: the getter-pair collapse (`Tree::Nodes`, `ga_base.hpp`'s `Parents`/`Offspring`/`Individuals`/`Generation`/`IsFitted`/etc.). I inspected pyoperon's binding code directly and found it disambiguates const vs. non-const overloads via `nb::overload_cast<>(&Class::Method, nb::const_)` — e.g. `IsFitted` is bound read-only via the const overload while a separate lambda calls the non-const overload for the setter (`self.IsFitted() = value;`). That disambiguation mechanism needs two genuinely distinct overloaded symbols and doesn't work against a single deducing-this template member. Collapsing those getters would require a coordinated pyoperon binding change (via a local flake path override, per this repo's cross-repo dev convention) — out of scope for this PR. `EvaluatorBase::Evaluate` itself isn't bound by pyoperon at all, so this narrower change is safe standalone.

**Update (review):** added targeted regression tests locking in that the deducing-this `Evaluate()` reaches each evaluator's own concrete 3-arg override — not the base's virtual `operator()`, not another evaluator's override — for the four `EvaluatorBase` subclasses that previously had no test coverage at all: `UserDefinedEvaluator`, `MultiEvaluator`, `AggregateEvaluator`, `DiversityEvaluator`. `DiversityEvaluator`'s check is done via two identically-seeded-but-independent RNGs (its 3-arg body consumes RNG state), confirming the 2-arg and 3-arg paths produce bit-identical results.

## Test plan
- [x] Full build (`cmake --build build`) including all CLIs, JIT backend, and examples.
- [x] Full test suite green: `./build/test/operon_test '~[performance]'` — 23287 assertions / 187 cases, matching baseline otherwise.
- [x] New dispatch regression tests for `UserDefinedEvaluator`, `MultiEvaluator`, `AggregateEvaluator`, `DiversityEvaluator`.