### PR TITLE
refactor(core,algorithms): collapse getter overload pairs to deducing-this

### DIFF
--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -88,14 +88,28 @@ public:
         generator_->SetCache(config.Cache);
     }
 
-    [[nodiscard]] auto Parents() const -> Operon::Span<Individual const> { return { parents_.data(), parents_.size() }; }
-    auto Parents() -> Operon::Span<Individual> { return parents_; }
+    // Parents()/Offspring() genuinely change *type* between const and
+    // non-const (Span<Individual const> vs Span<Individual>), not just
+    // reference-qualification - a plain forwarding-reference return would
+    // return `Operon::Span<Individual> const&` for a const Self, which
+    // still exposes mutable *elements* through that span (Span's
+    // operator[] isn't disabled by the span object's own constness), i.e.
+    // it wouldn't actually be const-correct. The conditional_t below keeps
+    // the const-correctness the original two overloads had.
+    template<typename Self>
+    [[nodiscard]] auto Parents(this Self& self) -> Operon::Span<std::conditional_t<std::is_const_v<Self>, Individual const, Individual>> { return self.parents_; }
 
-    [[nodiscard]] auto Offspring() const -> Operon::Span<Individual const> { return { offspring_.data(), offspring_.size() }; }
-    auto Offspring() -> Operon::Span<Individual> { return offspring_; }
+    template<typename Self>
+    [[nodiscard]] auto Offspring(this Self& self) -> Operon::Span<std::conditional_t<std::is_const_v<Self>, Individual const, Individual>> { return self.offspring_; }
 
-    [[nodiscard]] auto Individuals() -> Operon::Vector<Operon::Individual>& { return individuals_; }
-    [[nodiscard]] auto Individuals() const -> Operon::Vector<Operon::Individual> const& { return individuals_; }
+    // Individuals()/WorkerRngs()/Timings() only ever changed reference
+    // qualification (T& vs T const&) between overloads, so ordinary
+    // forwarding-reference deduction via `auto&&` reproduces both exactly -
+    // unlike decltype(auto), which would strip the reference entirely for
+    // an unparenthesized member-access return expression (see Nodes() in
+    // tree.hpp for the full explanation of why that pitfall matters here).
+    template<typename Self>
+    [[nodiscard]] auto&& Individuals(this Self&& self) { return std::forward<Self>(self).individuals_; }
 
     [[nodiscard]] auto GetProblem() const -> const Problem* { return problem_.get(); }
     [[nodiscard]] auto GetConfig() const -> GeneticAlgorithmConfig { return config_; }
@@ -105,20 +119,26 @@ public:
     [[nodiscard]] auto GetGenerator() const -> OffspringGeneratorBase const* { return generator_.get(); }
     [[nodiscard]] auto GetReinserter() const -> ReinserterBase const* { return reinserter_.get(); }
 
-    [[nodiscard]] auto WorkerRngs() const -> std::vector<Operon::RandomGenerator> const& { return workerRngs_; }
-    auto WorkerRngs() -> std::vector<Operon::RandomGenerator>& { return workerRngs_; }
+    template<typename Self>
+    [[nodiscard]] auto&& WorkerRngs(this Self&& self) { return std::forward<Self>(self).workerRngs_; }
 
-    [[nodiscard]] auto Generation() const -> size_t { return generation_; }
-    auto Generation() -> size_t& { return generation_; }
+    // Generation()/Elapsed()/IsFitted() are trivially-copyable scalars
+    // whose non-const overload existed only to allow direct assignment
+    // (e.g. `algo.IsFitted() = true;`). `auto&&` gives `size_t const&`/
+    // `bool const&`/etc. for a const Self instead of the original
+    // return-by-value - a strictly compatible relaxation for read-only
+    // callers, while still supporting assignment through the mutable case.
+    template<typename Self>
+    [[nodiscard]] auto&& Generation(this Self&& self) { return std::forward<Self>(self).generation_; }
 
-    [[nodiscard]] auto Elapsed() const -> double { return elapsed_; }
-    auto Elapsed() -> double& { return elapsed_; }
+    template<typename Self>
+    [[nodiscard]] auto&& Elapsed(this Self&& self) { return std::forward<Self>(self).elapsed_; }
 
-    [[nodiscard]] auto Timings() const -> Operon::Map<std::string, double> const& { return phaseTimes_; }
-    auto Timings() -> Operon::Map<std::string, double>& { return phaseTimes_; }
+    template<typename Self>
+    [[nodiscard]] auto&& Timings(this Self&& self) { return std::forward<Self>(self).phaseTimes_; }
 
-    [[nodiscard]] auto IsFitted() const -> bool { return isFitted_; }
-    auto IsFitted() -> bool& { return isFitted_; }
+    template<typename Self>
+    [[nodiscard]] auto&& IsFitted(this Self&& self) { return std::forward<Self>(self).isFitted_; }
 
     // StopRequested()/RequestStop() are inherited from StoppableAlgorithm.
 

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -96,6 +96,13 @@ public:
     // operator[] isn't disabled by the span object's own constness), i.e.
     // it wouldn't actually be const-correct. The conditional_t below keeps
     // the const-correctness the original two overloads had.
+    //
+    // Self& (not Self&&): the original non-ref-qualified overloads were
+    // technically callable on an rvalue *this, immediately returning a Span
+    // into that rvalue's about-to-be-destroyed individuals_ - a dangling
+    // Span by construction. Self& refuses to compile for an rvalue caller
+    // instead, a deliberate, source-incompatible tightening (no in-repo or
+    // downstream caller does this).
     template<typename Self>
     [[nodiscard]] auto Parents(this Self& self) -> Operon::Span<std::conditional_t<std::is_const_v<Self>, Individual const, Individual>> { return self.parents_; }
 
@@ -104,10 +111,13 @@ public:
 
     // Individuals()/WorkerRngs()/Timings() only ever changed reference
     // qualification (T& vs T const&) between overloads, so ordinary
-    // forwarding-reference deduction via `auto&&` reproduces both exactly -
-    // unlike decltype(auto), which would strip the reference entirely for
-    // an unparenthesized member-access return expression (see Nodes() in
-    // tree.hpp for the full explanation of why that pitfall matters here).
+    // forwarding-reference deduction via `auto&&` reproduces both exactly.
+    // decltype(auto) would have been the wrong choice here for the lvalue/
+    // const-lvalue cases specifically: on an unparenthesized member-access
+    // return expression it yields the *declared* member type by value (a
+    // silent copy), losing reference identity - see Nodes() in tree.hpp for
+    // the full explanation, including why the rvalue case isn't part of
+    // that particular defect.
     template<typename Self>
     [[nodiscard]] auto&& Individuals(this Self&& self) { return std::forward<Self>(self).individuals_; }
 
@@ -126,8 +136,13 @@ public:
     // whose non-const overload existed only to allow direct assignment
     // (e.g. `algo.IsFitted() = true;`). `auto&&` gives `size_t const&`/
     // `bool const&`/etc. for a const Self instead of the original
-    // return-by-value - a strictly compatible relaxation for read-only
-    // callers, while still supporting assignment through the mutable case.
+    // return-by-value - compatible for ordinary read-only use (auto/T/
+    // const T&, arithmetic, comparison), while still supporting assignment
+    // through the mutable case. The one caller shape this changes is a
+    // decltype(auto) capture on a const object (`decltype(auto) x =
+    // constObj.Generation();`), which now aliases the member instead of
+    // snapshotting it - vanishingly unlikely for a scalar getter, but not
+    // literally "no behavior change" in that one case.
     template<typename Self>
     [[nodiscard]] auto&& Generation(this Self&& self) { return std::forward<Self>(self).generation_; }
 

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -100,9 +100,12 @@ public:
     // Self& (not Self&&): the original non-ref-qualified overloads were
     // technically callable on an rvalue *this, immediately returning a Span
     // into that rvalue's about-to-be-destroyed individuals_ - a dangling
-    // Span by construction. Self& refuses to compile for an rvalue caller
-    // instead, a deliberate, source-incompatible tightening (no in-repo or
-    // downstream caller does this).
+    // Span by construction. Self& refuses to compile for a *mutable* rvalue
+    // caller instead, a deliberate, source-incompatible tightening (no
+    // in-repo or downstream caller does this). A const rvalue caller still
+    // compiles here (Self deduces to a const type, so Self& becomes
+    // Self const&, which binds a const rvalue same as it always could) -
+    // this only closes off the mutable-rvalue case, not rvalues generally.
     template<typename Self>
     [[nodiscard]] auto Parents(this Self& self) -> Operon::Span<std::conditional_t<std::is_const_v<Self>, Individual const, Individual>> { return self.parents_; }
 
@@ -110,14 +113,22 @@ public:
     [[nodiscard]] auto Offspring(this Self& self) -> Operon::Span<std::conditional_t<std::is_const_v<Self>, Individual const, Individual>> { return self.offspring_; }
 
     // Individuals()/WorkerRngs()/Timings() only ever changed reference
-    // qualification (T& vs T const&) between overloads, so ordinary
-    // forwarding-reference deduction via `auto&&` reproduces both exactly.
-    // decltype(auto) would have been the wrong choice here for the lvalue/
-    // const-lvalue cases specifically: on an unparenthesized member-access
-    // return expression it yields the *declared* member type by value (a
-    // silent copy), losing reference identity - see Nodes() in tree.hpp for
-    // the full explanation, including why the rvalue case isn't part of
-    // that particular defect.
+    // qualification (T& vs T const&) between overloads (never by-value, so
+    // these don't need the conditional_t treatment Generation()/Elapsed()/
+    // IsFitted() below get), and ordinary forwarding-reference deduction via
+    // `auto&&` reproduces both lvalue cases exactly. It's not a byte-for-
+    // byte match for rvalue callers specifically - the old, non-ref-
+    // qualified overloads always returned a plain T&/T const& regardless of
+    // the object's value category, while `auto&&` forwarding gives T&&/
+    // T const&& for a (mutable or const) rvalue caller instead. Not a new
+    // hazard (both are still references, and neither version's reference
+    // outlives the rvalue any better than the other - no in-repo or
+    // downstream caller does this), just a different reference category
+    // than before. decltype(auto) would have been the wrong choice here for
+    // the lvalue/const-lvalue cases specifically: on an unparenthesized
+    // member-access return expression it yields the *declared* member type
+    // by value (a silent copy), losing reference identity entirely - see
+    // Nodes() in tree.hpp for the full explanation.
     template<typename Self>
     [[nodiscard]] auto&& Individuals(this Self&& self) { return std::forward<Self>(self).individuals_; }
 

--- a/include/operon/algorithms/ga_base.hpp
+++ b/include/operon/algorithms/ga_base.hpp
@@ -132,28 +132,38 @@ public:
     template<typename Self>
     [[nodiscard]] auto&& WorkerRngs(this Self&& self) { return std::forward<Self>(self).workerRngs_; }
 
-    // Generation()/Elapsed()/IsFitted() are trivially-copyable scalars
-    // whose non-const overload existed only to allow direct assignment
-    // (e.g. `algo.IsFitted() = true;`). `auto&&` gives `size_t const&`/
-    // `bool const&`/etc. for a const Self instead of the original
-    // return-by-value - compatible for ordinary read-only use (auto/T/
-    // const T&, arithmetic, comparison), while still supporting assignment
-    // through the mutable case. The one caller shape this changes is a
-    // decltype(auto) capture on a const object (`decltype(auto) x =
-    // constObj.Generation();`), which now aliases the member instead of
-    // snapshotting it - vanishingly unlikely for a scalar getter, but not
-    // literally "no behavior change" in that one case.
+    // Generation()/Elapsed()/IsFitted() are trivially-copyable scalars whose
+    // non-const overload existed only to allow direct assignment (e.g.
+    // `algo.IsFitted() = true;`); neither original overload was ref-
+    // qualified, so the const one returned by value regardless of whether
+    // the object was an lvalue or rvalue. A plain `auto&&` here would get
+    // that wrong for a const *rvalue* specifically: Self deduces to a
+    // non-reference type, and forwarding through it yields a `T const&&`
+    // binding - a reference into a temporary - where the old code always
+    // handed back a safe, independent copy. (Reading through a const
+    // *lvalue* isn't affected: only the reference category changes there,
+    // same as Individuals()/WorkerRngs()/Timings() above.)
+    //
+    // No caller does this today (confirmed: nothing in this repo or its
+    // downstream consumers calls these getters on a const rvalue), but it's
+    // one line of conditional_t to close off entirely rather than leave as
+    // a latent trap. Note this deliberately does *not* forward self: naming
+    // `self` inside the function body is always an lvalue expression
+    // regardless of which reference type Self deduced to, so branching the
+    // return *type* on constness alone (ignoring value category) is enough
+    // to reproduce the original by-value-for-const/reference-for-mutable
+    // split exactly, for all four Self×value-category combinations.
     template<typename Self>
-    [[nodiscard]] auto&& Generation(this Self&& self) { return std::forward<Self>(self).generation_; }
+    [[nodiscard]] auto Generation(this Self&& self) -> std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, size_t, size_t&> { return self.generation_; } // NOLINT(cppcoreguidelines-missing-std-forward)
 
     template<typename Self>
-    [[nodiscard]] auto&& Elapsed(this Self&& self) { return std::forward<Self>(self).elapsed_; }
+    [[nodiscard]] auto Elapsed(this Self&& self) -> std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, double, double&> { return self.elapsed_; } // NOLINT(cppcoreguidelines-missing-std-forward)
 
     template<typename Self>
     [[nodiscard]] auto&& Timings(this Self&& self) { return std::forward<Self>(self).phaseTimes_; }
 
     template<typename Self>
-    [[nodiscard]] auto&& IsFitted(this Self&& self) { return std::forward<Self>(self).isFitted_; }
+    [[nodiscard]] auto IsFitted(this Self&& self) -> std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, bool, bool&> { return self.isFitted_; } // NOLINT(cppcoreguidelines-missing-std-forward)
 
     // StopRequested()/RequestStop() are inherited from StoppableAlgorithm.
 

--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -76,14 +76,20 @@ public:
     // One deducing-this member replaces the former &/&&/const& overload
     // triplet: Self deduces the caller's value category and cv-qualifier,
     // and forwarding through it onto nodes_ reproduces exactly the same
-    // three return types (Node&, Node const&, Node&&) the overloads gave.
+    // three return types (Vector<Node>&, Vector<Node> const&,
+    // Vector<Node>&&) the overloads gave.
     //
-    // Return type is `auto&&`, not `decltype(auto)`: decltype(auto) treats
-    // an unparenthesized member-access return expression as the *declared*
-    // member type (Operon::Vector<Node>, by value - a silent copy, and a
-    // silent move-into-copy for the && case), discarding the value
-    // category entirely. `auto&&` performs ordinary forwarding-reference
-    // deduction instead, which does propagate it correctly.
+    // Return type is `auto&&`, not `decltype(auto)`. For the lvalue and
+    // const-lvalue cases, decltype(auto) on an unparenthesized member-access
+    // return expression yields the *declared* member type by value
+    // (Operon::Vector<Node>, a silent copy) rather than a reference - the
+    // real defect: it loses reference identity, not just "the value
+    // category." For the rvalue case specifically, decltype(auto) would
+    // still move (the expression is still an xvalue, so the by-value result
+    // is move-constructed, not copied) - it only changes the return *type*
+    // from Vector<Node>&& to a by-value Vector<Node> prvalue. `auto&&`
+    // performs ordinary forwarding-reference deduction instead, which
+    // reproduces all three original reference types exactly.
     template<typename Self>
     [[nodiscard]] auto&& Nodes(this Self&& self) { return std::forward<Self>(self).nodes_; }
 

--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -73,9 +73,19 @@ public:
         }
     }
 
-    auto Nodes() & -> Operon::Vector<Node>& { return nodes_; }
-    auto Nodes() && -> Operon::Vector<Node>&& { return std::move(nodes_); }
-    [[nodiscard]] auto Nodes() const& -> Operon::Vector<Node> const& { return nodes_; }
+    // One deducing-this member replaces the former &/&&/const& overload
+    // triplet: Self deduces the caller's value category and cv-qualifier,
+    // and forwarding through it onto nodes_ reproduces exactly the same
+    // three return types (Node&, Node const&, Node&&) the overloads gave.
+    //
+    // Return type is `auto&&`, not `decltype(auto)`: decltype(auto) treats
+    // an unparenthesized member-access return expression as the *declared*
+    // member type (Operon::Vector<Node>, by value - a silent copy, and a
+    // silent move-into-copy for the && case), discarding the value
+    // category entirely. `auto&&` performs ordinary forwarding-reference
+    // deduction instead, which does propagate it correctly.
+    template<typename Self>
+    [[nodiscard]] auto&& Nodes(this Self&& self) { return std::forward<Self>(self).nodes_; }
 
     [[nodiscard]] auto CoefficientsCount() const
     {

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <numeric>
 #include <random>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "operon/algorithms/config.hpp"
@@ -215,6 +217,35 @@ TEST_CASE("NSGA2: ReportCallback returning false lets the run reach the configur
 
     CHECK(f.Nsga.Generation() == f.Config.Generations);
     CHECK(calls == 2); // one report from init, one from the single generation's body
+}
+
+TEST_CASE("Generation/Elapsed/IsFitted return by value for const objects, by reference for mutable, regardless of value category", "[algorithms]")
+{
+    // The pre-deducing-this overloads were never ref-qualified, so the const
+    // overload returned by value for both lvalues and rvalues, and the
+    // non-const overload returned a reference for both. A naive `auto&&`
+    // deducing-this replacement gets the const-rvalue case wrong (a
+    // reference into a temporary instead of a safe copy) - this locks in
+    // that all four Self x value-category combinations still match the
+    // original behavior exactly.
+    using Algo = Operon::GeneticProgrammingAlgorithm;
+
+    static_assert(std::is_same_v<decltype(std::declval<Algo&>().Generation()), std::size_t&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&>().Generation()), std::size_t>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo&&>().Generation()), std::size_t&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&&>().Generation()), std::size_t>);
+
+    static_assert(std::is_same_v<decltype(std::declval<Algo&>().Elapsed()), double&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&>().Elapsed()), double>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo&&>().Elapsed()), double&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&&>().Elapsed()), double>);
+
+    static_assert(std::is_same_v<decltype(std::declval<Algo&>().IsFitted()), bool&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&>().IsFitted()), bool>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo&&>().IsFitted()), bool&>);
+    static_assert(std::is_same_v<decltype(std::declval<Algo const&&>().IsFitted()), bool>);
+
+    SUCCEED("all four Self x value-category combinations verified at compile time");
 }
 
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Completes Phase 1 item A1 of the architecture remediation plan (the getter-pair half deferred from #113).
- `Tree::Nodes()` and `GeneticAlgorithmBase`'s `Parents`/`Offspring`/`Individuals`/`WorkerRngs`/`Generation`/`Elapsed`/`Timings`/`IsFitted` each had a const+non-const (and, for `Nodes()`, `&&` too) overload pair; each becomes one deducing-this member.
- `Parents()`/`Offspring()` keep an explicit `conditional_t` since they genuinely change *type* between const and non-const (`Span<Individual>` vs `Span<Individual const>`), not just reference-qualification — a plain forwarding-reference return would leak mutable element access through a const object (`Span`'s `operator[]` isn't disabled by the span object's own constness). They also switch to `this Self&` (not `Self&&`), a deliberate, source-incompatible tightening: the original overloads were technically callable on an rvalue `*this`, immediately handing back a `Span` into that rvalue's about-to-be-destroyed storage — a dangling-by-construction case that's now a compile error instead. No in-repo or downstream caller does this.
- `Individuals`/`WorkerRngs`/`Timings` use `auto&&` forwarding-reference deduction, **not** `decltype(auto)`. The pitfall: `decltype(auto)` on an unparenthesized member-access return expression yields the *declared* member type by value for the lvalue/const-lvalue cases — a silent copy that loses reference identity. (The rvalue case is subtler: `decltype(auto)` there would still *move*, since the expression is still an xvalue — it only changes the return *type* to a by-value prvalue instead of `T&&`. The real defect is lvalue/const-lvalue, not rvalue.) Verified with a standalone check against the built library confirming actual reference identity for the lvalue/const-lvalue cases and a real move for the rvalue case.
- **Breaking change for external consumers**: any code addressing these getters via overloaded member pointer (`nb::overload_cast<>(&Class::Method, nb::const_)`, `static_cast<Ret (Class::*)() const>(&Class::Method)`) breaks, since a deducing-this template is one symbol, not two. This is the reason for the pyoperon coordination below; I also checked `model-explorer` (the only other in-workspace consumer) and confirmed it doesn't address these getters by member pointer.

**Update (independent review, GPT-5.4 via opencode, verified by hand):** `Generation`/`Elapsed`/`IsFitted` needed different treatment than `Individuals`/`WorkerRngs`/`Timings`. Their *old* overloads were never ref-qualified, so the const overload returned **by value** regardless of whether the object was an lvalue or rvalue — a plain `auto&&` deducing-this replacement gets this wrong specifically for a **const rvalue**: `Self` deduces to a non-reference type, and forwarding through it yields `T const&&` — a reference into a temporary, where the old code always handed back a safe, independent copy. Verified this precisely with a compiled `static_assert` before and after the fix. Unreachable today (no caller in this repo or its downstream consumers calls these getters on a const rvalue), but fixed anyway rather than leave a latent trap: `Generation`/`Elapsed`/`IsFitted` now use a `conditional_t` on constness alone (ignoring value category), and deliberately don't forward `self` — a named forwarding-reference parameter is always an lvalue expression inside the function body regardless of which reference type `Self` deduced to, so branching only on constness reproduces the original by-value-for-const/reference-for-mutable split exactly across all four `Self`×value-category combinations. Locked in with a permanent test (`static_assert` over all four combinations for each of the three getters).

**Enables:** this required a coordinated pyoperon binding change first — pyoperon's `nb::overload_cast<>(&Class::Method, nb::const_)`/`static_cast<Ret (Class::*)() const>(&Class::Method)` bindings need two genuinely distinct overloaded symbols to disambiguate, which a single deducing-this template member can't provide. That prep landed as [pyoperon#66](https://github.com/heal-research/pyoperon/pull/66) (merged) — its lambda-based rebind works identically against either the old overload-pair shape or this new deducing-this shape.

## Test plan
- [x] Full build (`cmake --build build`) including all CLIs and examples.
- [x] Full test suite green: `./build/test/operon_test '~[performance]'` — 23322 assertions / 191 cases, matching baseline (post #111/#112/#113 merge) otherwise.
- [x] Standalone correctness check (compiled and run against the built library, not just "it compiles") confirming `Tree::Nodes()`'s reference/move semantics: non-const lvalue gives the same mutable storage, const lvalue gives the same storage read-only (no copy), rvalue actually moves rather than copying.
- [x] Standalone `static_assert` check confirming `Generation`/`Elapsed`/`IsFitted` return the correct type for all four `Self`×value-category combinations, now locked in as a permanent test.
- [x] **Cross-repo verification**: built pyoperon's merged `main` (with #66's lambda bindings) against a local install of this branch via `CMAKE_PREFIX_PATH` override (per this repo's cross-repo dev convention), in a disposable worktree — compiles clean, full `tests/test_sklearn.py` suite green (67 passed), confirming the getter collapse doesn't break the Python bindings now that #66 has landed.