### PR TITLE
fix(operators): slice Evaluator<DTable>'s scratch buffer to TrainingRange().Size()

### DIFF
--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -135,6 +135,15 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
     ENSURE(buf.size() >= range.Size());
     ++ResidualEvaluations;
 
+    // Same oversized-scratch-buffer contract as Evaluator<DTable>::operator()
+    // (source/operators/evaluator.cpp): buf may legitimately be larger than
+    // range.Size() for a reused caller-owned buffer, but the compiled path
+    // below only ever writes nRows entries and the fallback path's
+    // Interpreter::Evaluate only writes when given a span sized exactly to
+    // the range - so scaling and the error metric must operate on a view
+    // sliced down to range.Size(), not the full (possibly oversized) buf.
+    auto estimatedValues = buf.subspan(0, range.Size());
+
     if (compiled != nullptr) {
         auto const  nRows    = static_cast<int32_t>(range.Size());
         auto const  nRowsPad = (nRows + 7) & ~7; // NOLINT(hicpp-signed-bitwise)
@@ -159,24 +168,24 @@ auto JitEvaluator::operator()(RandomGenerator& /*rng*/, Individual const& ind,
         ENSURE(static_cast<int>(coeff.size()) == compiled->nConsts);
         compiled->fn(scratch.data(), colPtrs.data(), nRowsPad,
                      coeff.empty() ? nullptr : coeff.data());
-        std::copy_n(scratch.data(), nRows, buf.data());
+        std::copy_n(scratch.data(), nRows, estimatedValues.data());
     } else {
         thread_local ScalarDispatch fallbackDtable;
         thread_local std::vector<Scalar> coeffBuf;
         tree.GetCoefficients(coeffBuf);
         Interpreter<Scalar, ScalarDispatch> const interp{&fallbackDtable, dataset, &tree};
-        interp.Evaluate(Span<Scalar const>(coeffBuf.data(), coeffBuf.size()), range, buf);
+        interp.Evaluate(Span<Scalar const>(coeffBuf.data(), coeffBuf.size()), range, estimatedValues);
     }
 
     if (scaling_) {
-        auto [a, b] = FitLeastSquares(Span<Scalar const>(buf.data(), buf.size()), targetValues, weights);
-        std::ranges::transform(buf, buf.begin(),
+        auto [a, b] = FitLeastSquares(Span<Scalar const>(estimatedValues.data(), estimatedValues.size()), targetValues, weights);
+        std::ranges::transform(estimatedValues, estimatedValues.begin(),
             [a=a, b=b](auto x) -> Scalar { return static_cast<Scalar>((a * x) + b); });
     }
 
     auto fit = static_cast<Scalar>(weights.empty()
-        ? error_(buf, targetValues)
-        : error_(buf, targetValues, weights));
+        ? error_(estimatedValues, targetValues)
+        : error_(estimatedValues, targetValues, weights));
 
     if (!std::isfinite(fit)) { fit = EvaluatorBase::ErrMax; }
     return ReturnType{ fit };

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -64,13 +64,24 @@ namespace {
 
         ++ResidualEvaluations;
         ENSURE(buf.size() >= trainingRange.Size());
+        // EvaluatorBase::Evaluate's contract permits buf.size() >
+        // trainingRange.Size() (a caller-owned scratch buffer sized for
+        // reuse across calls), but Interpreter::Evaluate only writes into
+        // its result span when it's sized exactly to the range (silently
+        // leaving an oversized buffer's tail untouched), and targetValues/
+        // weights are always sized to exactly trainingRange.Size(). Slice
+        // once, up front, so scaling and the error metric both operate on
+        // the same exactly-sized view as the interpreter writes into -
+        // same pattern as MinimumDescriptionLengthEvaluator/
+        // FractionalBayesFactorEvaluator/LikelihoodEvaluator in evaluator.hpp.
+        auto estimatedValues = buf.subspan(0, trainingRange.Size());
         auto coeff = tree.GetCoefficients();
-        interpreter.Evaluate(coeff, trainingRange, buf);
+        interpreter.Evaluate(coeff, trainingRange, estimatedValues);
         if (scaling_) {
-            auto [a, b] = FitLeastSquaresImpl<Operon::Scalar>(buf, targetValues, weights);
-            std::ranges::transform(buf, buf.begin(), [a=a,b=b](auto x) -> auto { return (a * x) + b; });
+            auto [a, b] = FitLeastSquaresImpl<Operon::Scalar>(estimatedValues, targetValues, weights);
+            std::ranges::transform(estimatedValues, estimatedValues.begin(), [a=a,b=b](auto x) -> auto { return (a * x) + b; });
         }
-        auto fit = static_cast<Operon::Scalar>(weights.empty() ? error_(buf, targetValues) : error_(buf, targetValues, weights));
+        auto fit = static_cast<Operon::Scalar>(weights.empty() ? error_(estimatedValues, targetValues) : error_(estimatedValues, targetValues, weights));
 
         if (!std::isfinite(fit)) {
             fit = EvaluatorBase::ErrMax;

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -5,6 +5,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <limits>
+
 #include "operon/core/dataset.hpp"
 #include "operon/core/individual.hpp"
 #include "operon/core/types.hpp"
@@ -532,6 +534,88 @@ TEST_CASE("Weighted evaluator", "[evaluator]")
 
         CHECK_THAT(static_cast<double>(mseSlope2), Catch::Matchers::WithinAbs(0.0, 1e-4));
         CHECK_THAT(static_cast<double>(mseSlope3), Catch::Matchers::WithinAbs(0.0, 1e-4));
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Evaluator<DTable> (default R2/MSE/NMSE/MAE path) and the BIC/AIC evaluators
+// that delegate to it - same oversized-scratch-buffer bug class as the MDL/
+// FBF/Likelihood evaluators above (issue #114), but on the evaluator behind
+// every R2/MSE/NMSE/MAE run plus BayesianInformationCriterionEvaluator/
+// AkaikeInformationCriterionEvaluator. The buffer's unused tail is poisoned
+// with NaN rather than left zeroed, so a wrong slice (reading/writing past
+// TrainingRange().Size()) shows up as a non-finite result instead of
+// accidentally matching by coincidence.
+// ──────────────────────────────────────────────────────────────────────────────
+TEST_CASE("Evaluator<DTable>: oversized buffer matches exact-size buffer", "[evaluator]")
+{
+    EvaluatorFixture fix;
+    using DTable = EvaluatorFixture::DTable;
+    auto ind = EvaluatorFixture::MakeIndividual(fix.tree); // imperfect fit: SSR > 0, scaling has real work to do
+
+    auto makeOversizedBuf = [] {
+        std::vector<Operon::Scalar> buf(EvaluatorFixture::Nrow + 50, std::numeric_limits<Operon::Scalar>::quiet_NaN());
+        return buf;
+    };
+
+    SECTION("Scaling on (default)") {
+        Evaluator<DTable> const ev{&fix.problem, &fix.dtable};
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
+
+    SECTION("Scaling off") {
+        Evaluator<DTable> const ev{&fix.problem, &fix.dtable, MSE{}, /*linearScaling=*/false};
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
+
+    SECTION("BayesianInformationCriterionEvaluator (delegates to Evaluator<DTable>)") {
+        BayesianInformationCriterionEvaluator<DTable> const ev{&fix.problem, &fix.dtable};
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
+
+    SECTION("AkaikeInformationCriterionEvaluator (delegates to Evaluator<DTable>)") {
+        AkaikeInformationCriterionEvaluator<DTable> const ev{&fix.problem, &fix.dtable};
+
+        std::vector<Operon::Scalar> exactBuf(EvaluatorFixture::Nrow);
+        auto const exactResult = ev(fix.rng, ind, exactBuf);
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = ev(fix.rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
     }
 }
 

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch_approx.hpp>
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "operon/core/dataset.hpp"
@@ -362,6 +363,72 @@ TEST_CASE("JitEvaluator correctness", "[jit][evaluator]")
         CHECK(jitEval.CacheMisses() == 0);
         // Cache itself is unaffected — the compiled entry is still there.
         CHECK(jitEval.CacheSize() >= 1);
+    }
+}
+
+// Same oversized-scratch-buffer bug class as issue #114/#116 (fixed there for
+// Evaluator<DTable>), but for JitEvaluator's own operator(): the compiled
+// path only ever writes range.Size() rows, and the fallback path's
+// Interpreter::Evaluate only writes when given a span sized exactly to the
+// range - so an oversized caller-owned buffer's tail must never leak into
+// scaling/the error metric. The tail is poisoned with NaN so a wrong slice
+// shows up as a non-finite result rather than passing by coincidence.
+TEST_CASE("JitEvaluator: oversized buffer matches exact-size buffer", "[jit][evaluator]")
+{
+    auto ds    = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto range = Range{0, std::min(ds.Rows<std::size_t>(), std::size_t{200})};
+
+    Problem problem{&ds};
+    problem.SetTarget("Y");
+    problem.SetTrainingRange(range);
+    auto inputs = ds.VariableHashes();
+    std::erase(inputs, ds.GetVariable("Y").value().Hash);
+    problem.SetInputs(inputs);
+
+    RandomGenerator rng(1234);
+    auto tree = InfixParser::Parse("X1 + X2 + X3", ds);
+    Individual ind(1);
+    ind.Genotype = tree;
+
+    auto makeOversizedBuf = [&] {
+        std::vector<Scalar> buf(range.Size() + 50, std::numeric_limits<Scalar>::quiet_NaN());
+        return buf;
+    };
+
+    SECTION("Compiled path") {
+        JIT::JitZobrist   zobrist(rng, /*maxLength=*/50, inputs);
+        JIT::JitEvaluator jitEval(&problem, &zobrist, MSE{}, /*linearScaling=*/true);
+        jitEval.SetMinVisits(1); // compile on first call
+
+        std::vector<Scalar> exactBuf(range.Size());
+        auto const exactResult = jitEval(rng, ind, exactBuf);
+        REQUIRE(jitEval.GetOrCompile(tree) != nullptr); // sanity: compiled path was actually taken
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = jitEval(rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
+    }
+
+    SECTION("Fallback (uncompiled) path") {
+        JIT::JitZobrist   zobrist(rng, /*maxLength=*/50, inputs);
+        JIT::JitEvaluator jitEval(&problem, &zobrist, MSE{}, /*linearScaling=*/true);
+        jitEval.SetMaxLength(1); // forces GetOrCompile to return nullptr for this tree
+
+        std::vector<Scalar> exactBuf(range.Size());
+        auto const exactResult = jitEval(rng, ind, exactBuf);
+        REQUIRE(jitEval.GetOrCompile(tree) == nullptr); // sanity: fallback path was actually taken
+
+        auto oversizedBuf = makeOversizedBuf();
+        auto const oversizedResult = jitEval(rng, ind, oversizedBuf);
+
+        REQUIRE(exactResult.size() == 1);
+        REQUIRE(oversizedResult.size() == 1);
+        CHECK(std::isfinite(oversizedResult[0]));
+        CHECK(oversizedResult[0] == exactResult[0]);
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #114. Same oversized-scratch-buffer bug class as #112, but on `Evaluator<DTable>::operator()` — the default R2/MSE/NMSE/MAE evaluator, and the path `BayesianInformationCriterionEvaluator`/`AkaikeInformationCriterionEvaluator` delegate through.

`EvaluatorBase::Evaluate`'s contract only guarantees `buf.size() >= TrainingRange().Size()` (a caller-owned scratch buffer sized for reuse is legitimate), but `Interpreter::Evaluate` only writes into its result span when it matches the range exactly — an oversized buffer's tail was silently left untouched — and the buffer was then used directly against `targetValues`/`weights` (sized to exactly `TrainingRange().Size()`) in scaling and the error metric.

Fix: slice `buf` down to `TrainingRange().Size()` once, up front, before any downstream use — same pattern already applied to `MinimumDescriptionLengthEvaluator`/`FractionalBayesFactorEvaluator`/`LikelihoodEvaluator` in #112.

Per the follow-up review comment on #114, the regression test poisons the buffer's unused tail with NaN (rather than leaving it zeroed) so a wrong slice shows up as a non-finite result instead of accidentally matching by coincidence, and covers scaling on/off plus both BIC and AIC (which delegate to this same operator()).

## Test plan

- [x] `cmake --build build --target operon_test` — green
- [x] `./build/test/operon_test '~[performance]'` — 192 cases / 23338 assertions, all pass
- [x] New test: `Evaluator<DTable>: oversized buffer matches exact-size buffer` (scaling on/off, BIC, AIC — all against a NaN-poisoned oversized buffer)