### PR TITLE
chore(operators): static_assert concrete operators against core/concepts.hpp

### DIFF
--- a/docs/research/architecture-remediation-plan.md
+++ b/docs/research/architecture-remediation-plan.md
@@ -263,7 +263,7 @@ and acceptance criteria.
 
 ### Phase 3 — Contract clarity (pick a lane)
 
-#### C1. Resolve the concepts-vs-vtable duplication — direction resolved, implementation pending PR
+#### C1. Resolve the concepts-vs-vtable duplication — DONE
 
 - **Effort:** medium · **needs a direction call first**
 - **What:** Decide the role of `core/concepts.hpp`. Recommended: keep
@@ -286,7 +286,7 @@ and acceptance criteria.
   (`Mutator`/`Crossover`: `Tree -> Tree`) vs. population (`Selector`/
   `Reinserter`: `Span<Individual> -> ...`). That broader axis is scoped as a
   separate follow-up, not part of C1 itself.
-- **Planned implementation:** A survey found zero existing templated
+- **What actually landed:** A survey found zero existing templated
   adapter/wrapper sites for Creator/Mutator/Crossover/Selector/Reinserter/
   EvaluatorCallable — every one of them is a concrete subclass behind pure
   virtual `OperatorBase` dispatch, nothing generic to constrain (only
@@ -302,11 +302,6 @@ and acceptance criteria.
   type's signature drifts from its concept, with zero runtime change.
   Introducing lego-block-style templated adapters is left to the
   individual/population-level follow-up.
-- **Status note:** this implementation was drafted and briefly pushed
-  directly to `main`, then reverted (2026-07-13) because it should have gone
-  through the same branch → PR → review flow as A1–A3 instead of a direct
-  push. The plan above still reflects the intended shape; redo via a feature
-  branch and PR before landing again.
 - **Acceptance:** Exactly one contract mechanism remains authoritative;
   concept names either constrain real templates or are removed entirely.
 
@@ -385,7 +380,7 @@ parallel; Phase 3–4 items want a decision or careful staging first.
 | A3  | `StoppableAlgorithm` mixin              |   1   | Small  |    No    | Done   | —              |
 | B1  | `NodeType` order asserts                |   2   | Small  |    No    | Done   | —              |
 | B2  | Interpreter thread-affinity contract    |   2   | Medium |    No    | Done*  | —              |
-| C1  | Concepts vs vtable                      |   3   | Medium |    No    | Pending PR | Direction resolved |
+| C1  | Concepts vs vtable                      |   3   | Medium |    No    | Done   | —              |
 | C2  | `move_only_function` callbacks          |   3   | Small  |   Yes    |        | —              |
 | D1  | `std::expected` lookups                 |   4   | Medium |  Maybe   |        | —              |
 | D2  | Optimizer result type                   |   4   | Large  |   Yes    |        | Stage last     |

--- a/include/operon/core/concepts.hpp
+++ b/include/operon/core/concepts.hpp
@@ -17,6 +17,13 @@ class Tree;
 struct Individual;
 } // namespace Operon
 
+// Runtime dispatch for Creator/Mutator/Crossover/Selector/Reinserter/
+// EvaluatorCallable stays on the OperatorBase virtual hierarchy (pyoperon and
+// the CLI factories need dynamic wiring), so these concepts don't constrain a
+// template anywhere. Instead, each concrete operator type gets
+// `static_assert(Concepts::X<ConcreteType>)` immediately after its
+// definition, pinning "this type satisfies its concept" as a compile-time
+// fact so signature drift is a build error rather than a silent mismatch.
 namespace Operon::Concepts {
 
 template<typename T>

--- a/include/operon/operators/crossover.hpp
+++ b/include/operon/operators/crossover.hpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "operon/operon_export.hpp"
+#include "operon/core/concepts.hpp"
 #include "operon/core/operator.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/node.hpp"
@@ -46,6 +47,11 @@ private:
     size_t maxDepth_;
     size_t maxLength_;
 };
+
+// SubtreeCrossover satisfies Concepts::Crossover; CrossoverBase itself stays
+// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
+// this assert here catches signature drift against the concept at compile time.
+static_assert(Concepts::Crossover<SubtreeCrossover>);
 
 } // namespace Operon
 #endif

--- a/include/operon/operators/crossover.hpp
+++ b/include/operon/operators/crossover.hpp
@@ -48,9 +48,7 @@ private:
     size_t maxLength_;
 };
 
-// SubtreeCrossover satisfies Concepts::Crossover; CrossoverBase itself stays
-// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
-// this assert here catches signature drift against the concept at compile time.
+// See core/concepts.hpp for why this is asserted here rather than constraining a template.
 static_assert(Concepts::Crossover<SubtreeCrossover>);
 
 } // namespace Operon

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -551,6 +551,13 @@ class OPERON_EXPORT BayesianInformationCriterionEvaluator final : public Evaluat
     using Base = Evaluator<DTable>;
 
 public:
+    // Un-hide Base's 2-arg operator(): declaring only the 3-arg override
+    // below would otherwise hide the inherited 2-arg overload from
+    // unqualified lookup, so a bare `t(rng, ind)` call - and
+    // Concepts::EvaluatorCallable, which relies on that exact call form -
+    // would fail to find it.
+    using Base::operator();
+
     explicit BayesianInformationCriterionEvaluator(Operon::Problem const* problem, DTable const* dtable)
         : Base(problem, dtable, MSE{})
     {
@@ -565,6 +572,9 @@ class OPERON_EXPORT AkaikeInformationCriterionEvaluator final : public Evaluator
     using Base = Evaluator<DTable>;
 
 public:
+    // See BayesianInformationCriterionEvaluator's using-declaration above for why this is needed.
+    using Base::operator();
+
     explicit AkaikeInformationCriterionEvaluator(Operon::Problem const* problem, DTable const* dtable)
         : Base(problem, dtable, MSE{})
     {
@@ -580,6 +590,9 @@ class OPERON_EXPORT LikelihoodEvaluator final : public Evaluator<DTable> {
     using Base = Evaluator<DTable>;
 
     public:
+    // See BayesianInformationCriterionEvaluator's using-declaration above for why this is needed.
+    using Base::operator();
+
     explicit LikelihoodEvaluator(Operon::Problem const* problem, DTable const* dtable)
         : Base(problem, dtable), sigma_(1, 0.001)
     {
@@ -625,6 +638,15 @@ using GaussianLikelihoodEvaluator = LikelihoodEvaluator<DTable, GaussianLikeliho
 
 template<typename DTable>
 using PoissonLikelihoodEvaluator = LikelihoodEvaluator<DTable, PoissonLikelihood<Operon::Scalar>>;
+
+// These three previously did not satisfy Concepts::EvaluatorCallable: each
+// declared only the 3-arg buffered operator(), which hides Evaluator<DTable>'s
+// 2-arg override from unqualified lookup (see the `using Base::operator();`
+// declarations added to each class above). Asserted here, after their
+// definitions, since they're templates.
+static_assert(Concepts::EvaluatorCallable<BayesianInformationCriterionEvaluator<ScalarDispatch>>);
+static_assert(Concepts::EvaluatorCallable<AkaikeInformationCriterionEvaluator<ScalarDispatch>>);
+static_assert(Concepts::EvaluatorCallable<LikelihoodEvaluator<ScalarDispatch>>);
 
 } // namespace Operon
 #endif

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "operon/collections/projection.hpp"
+#include "operon/core/concepts.hpp"
 #include "operon/core/individual.hpp"
 #include "operon/core/operator.hpp"
 #include "operon/core/problem.hpp"
@@ -368,6 +369,16 @@ private:
     Operon::HashMode hashmode_ { Operon::HashMode::Strict };
     std::size_t sampleSize_ {};
 };
+
+// The concrete evaluators satisfy Concepts::EvaluatorCallable; EvaluatorBase
+// itself stays virtual-dispatch (pyoperon/CLI factories need dynamic wiring),
+// but pinning these asserts here catches signature drift against the concept
+// at compile time.
+static_assert(Concepts::EvaluatorCallable<UserDefinedEvaluator>);
+static_assert(Concepts::EvaluatorCallable<Evaluator<ScalarDispatch>>);
+static_assert(Concepts::EvaluatorCallable<MultiEvaluator>);
+static_assert(Concepts::EvaluatorCallable<AggregateEvaluator>);
+static_assert(Concepts::EvaluatorCallable<DiversityEvaluator>);
 
 namespace detail {
     // Profile MLE sigma-hat = sqrt(SSR/n) from residuals (estimated - target),

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -370,10 +370,10 @@ private:
     std::size_t sampleSize_ {};
 };
 
-// The concrete evaluators satisfy Concepts::EvaluatorCallable; EvaluatorBase
-// itself stays virtual-dispatch (pyoperon/CLI factories need dynamic wiring),
-// but pinning these asserts here catches signature drift against the concept
-// at compile time.
+// See core/concepts.hpp for why these are asserted here rather than constraining a template.
+// LengthEvaluator/ShapeEvaluator aren't asserted separately: they inherit
+// UserDefinedEvaluator's operator() overloads without overriding either one,
+// so UserDefinedEvaluator's assert below already covers them.
 static_assert(Concepts::EvaluatorCallable<UserDefinedEvaluator>);
 static_assert(Concepts::EvaluatorCallable<Evaluator<ScalarDispatch>>);
 static_assert(Concepts::EvaluatorCallable<MultiEvaluator>);

--- a/include/operon/operators/mutation.hpp
+++ b/include/operon/operators/mutation.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "operon/operon_export.hpp"
+#include "operon/core/concepts.hpp"
 #include "operon/core/operator.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/core/tree.hpp"
@@ -174,6 +175,21 @@ private:
 struct OPERON_EXPORT ShuffleSubtreesMutation : public MutatorBase {
     auto operator()(Operon::RandomGenerator& /*random*/, Tree /*args*/) const -> Tree override;
 };
+
+// The concrete mutators satisfy Concepts::Mutator; MutatorBase itself stays
+// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
+// these asserts here catches signature drift against the concept at compile time.
+static_assert(Concepts::Mutator<OnePointMutation<std::normal_distribution<Operon::Scalar>>>);
+static_assert(Concepts::Mutator<MultiPointMutation<std::normal_distribution<Operon::Scalar>>>);
+static_assert(Concepts::Mutator<DiscretePointMutation>);
+static_assert(Concepts::Mutator<MultiMutation>);
+static_assert(Concepts::Mutator<ChangeVariableMutation>);
+static_assert(Concepts::Mutator<ChangeFunctionMutation>);
+static_assert(Concepts::Mutator<RemoveSubtreeMutation>);
+static_assert(Concepts::Mutator<InsertSubtreeMutation>);
+static_assert(Concepts::Mutator<ReplaceSubtreeMutation>);
+static_assert(Concepts::Mutator<ShuffleSubtreesMutation>);
+
 } // namespace Operon
 
 #endif

--- a/include/operon/operators/mutation.hpp
+++ b/include/operon/operators/mutation.hpp
@@ -176,9 +176,10 @@ struct OPERON_EXPORT ShuffleSubtreesMutation : public MutatorBase {
     auto operator()(Operon::RandomGenerator& /*random*/, Tree /*args*/) const -> Tree override;
 };
 
-// The concrete mutators satisfy Concepts::Mutator; MutatorBase itself stays
-// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
-// these asserts here catches signature drift against the concept at compile time.
+// See core/concepts.hpp for why these are asserted here rather than constraining a template.
+// OnePointMutation/MultiPointMutation are templated on Dist, but satisfying
+// Mutator doesn't depend on which Dist is plugged in (only on the fixed
+// operator() signature), so asserting one canonical instantiation suffices.
 static_assert(Concepts::Mutator<OnePointMutation<std::normal_distribution<Operon::Scalar>>>);
 static_assert(Concepts::Mutator<MultiPointMutation<std::normal_distribution<Operon::Scalar>>>);
 static_assert(Concepts::Mutator<DiscretePointMutation>);

--- a/include/operon/operators/reinserter.hpp
+++ b/include/operon/operators/reinserter.hpp
@@ -75,10 +75,7 @@ public:
     }
 };
 
-// The concrete reinserters satisfy Concepts::Reinserter; ReinserterBase itself
-// stays virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but
-// pinning these asserts here catches signature drift against the concept at
-// compile time.
+// See core/concepts.hpp for why these are asserted here rather than constraining a template.
 static_assert(Concepts::Reinserter<KeepBestReinserter>);
 static_assert(Concepts::Reinserter<ReplaceWorstReinserter>);
 

--- a/include/operon/operators/reinserter.hpp
+++ b/include/operon/operators/reinserter.hpp
@@ -6,6 +6,7 @@
 #define OPERON_REINSERTER_HPP
 
 #include <algorithm>
+#include "operon/core/concepts.hpp"
 #include "operon/core/operator.hpp"
 #include "operon/core/individual.hpp"
 
@@ -73,6 +74,13 @@ public:
         std::swap_ranges(pool.begin(), pool.begin() + offset, pop.end() - offset);
     }
 };
+
+// The concrete reinserters satisfy Concepts::Reinserter; ReinserterBase itself
+// stays virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but
+// pinning these asserts here catches signature drift against the concept at
+// compile time.
+static_assert(Concepts::Reinserter<KeepBestReinserter>);
+static_assert(Concepts::Reinserter<ReplaceWorstReinserter>);
 
 } // namespace Operon
 

--- a/include/operon/operators/selector.hpp
+++ b/include/operon/operators/selector.hpp
@@ -98,9 +98,7 @@ public:
     }
 };
 
-// The concrete selectors satisfy Concepts::Selector; SelectorBase itself stays
-// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
-// these asserts here catches signature drift against the concept at compile time.
+// See core/concepts.hpp for why these are asserted here rather than constraining a template.
 static_assert(Concepts::Selector<TournamentSelector>);
 static_assert(Concepts::Selector<ProportionalSelector>);
 static_assert(Concepts::Selector<RandomSelector>);

--- a/include/operon/operators/selector.hpp
+++ b/include/operon/operators/selector.hpp
@@ -5,6 +5,7 @@
 #ifndef OPERON_SELECTOR_HPP
 #define OPERON_SELECTOR_HPP
 
+#include "operon/core/concepts.hpp"
 #include "operon/core/individual.hpp"
 #include "operon/core/operator.hpp"
 
@@ -96,6 +97,13 @@ public:
         return std::uniform_int_distribution<size_t>(0, Population().size() - 1)(random);
     }
 };
+
+// The concrete selectors satisfy Concepts::Selector; SelectorBase itself stays
+// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
+// these asserts here catches signature drift against the concept at compile time.
+static_assert(Concepts::Selector<TournamentSelector>);
+static_assert(Concepts::Selector<ProportionalSelector>);
+static_assert(Concepts::Selector<RandomSelector>);
 
 } //namespace Operon
 

--- a/source/operators/creator/creator.cpp
+++ b/source/operators/creator/creator.cpp
@@ -12,9 +12,12 @@
 
 namespace Operon {
 
-// The concrete creators satisfy Concepts::Creator; CreatorBase itself stays
-// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
-// these asserts here catches signature drift against the concept at compile time.
+// See core/concepts.hpp for why these are asserted here rather than
+// constraining a template. Asserted from this .cpp rather than creator.hpp:
+// Concepts::Creator's return-type check needs Tree complete, and
+// creator.hpp only forward-declares it. If BalancedTreeCreator/
+// GrowTreeCreator/ProbabilisticTreeCreator's definitions ever move out of
+// this translation unit, move these asserts (and the tree.hpp include) with them.
 static_assert(Concepts::Creator<BalancedTreeCreator>);
 static_assert(Concepts::Creator<GrowTreeCreator>);
 static_assert(Concepts::Creator<ProbabilisticTreeCreator>);

--- a/source/operators/creator/creator.cpp
+++ b/source/operators/creator/creator.cpp
@@ -5,10 +5,19 @@
 #include <ranges>
 #include <vector>
 
+#include "operon/core/concepts.hpp"
 #include "operon/core/pset.hpp"
+#include "operon/core/tree.hpp"
 #include "operon/operators/creator.hpp"
 
 namespace Operon {
+
+// The concrete creators satisfy Concepts::Creator; CreatorBase itself stays
+// virtual-dispatch (pyoperon/CLI factories need dynamic wiring), but pinning
+// these asserts here catches signature drift against the concept at compile time.
+static_assert(Concepts::Creator<BalancedTreeCreator>);
+static_assert(Concepts::Creator<GrowTreeCreator>);
+static_assert(Concepts::Creator<ProbabilisticTreeCreator>);
 
 CreatorBase::CreatorBase(gsl::not_null<PrimitiveSet const*> pset, std::vector<Operon::Hash> variables, size_t maxLength)
     : pset_(pset)


### PR DESCRIPTION
## Summary
- C1 from `docs/research/architecture-remediation-plan.md`: resolves the concepts-vs-vtable duplication by keeping `core/concepts.hpp`'s `Creator`/`Mutator`/`Crossover`/`Selector`/`Reinserter`/`EvaluatorCallable` concepts and putting them to real use, rather than deleting them or leaving them decorative.
- A survey found no existing templated adapter/wrapper sites for these six concepts (every concrete operator is a subclass behind pure virtual `OperatorBase` dispatch — only `Concepts::Likelihood` had real constrained templates already, at MDL/FBF/LikelihoodEvaluator). So each concrete operator type (BalancedTreeCreator, OnePointMutation, SubtreeCrossover, TournamentSelector, KeepBestReinserter, Evaluator<DTable>, etc.) gets a `static_assert(Concepts::X<ConcreteType>)` right after its definition instead.
- Zero runtime change: virtual dispatch through `OperatorBase` is untouched. This just turns "the concept describes this type" from an implicit assumption into a compile-time-checked fact, so future signature drift on a concrete operator is a build error.

## Test plan
- [x] `cmake --build build` (full: lib, tests, CLI, examples) — clean
- [x] `./build/test/operon_test '~[performance]'` — all 193 test cases / 23348 assertions pass
- [x] Verified a deliberate signature break on `RandomSelector::operator()` fails to compile