### PR TITLE
refactor(algorithms): std::move_only_function for ReportCallback and onNovelExpression_

### DIFF
--- a/docs/research/architecture-remediation-plan.md
+++ b/docs/research/architecture-remediation-plan.md
@@ -305,7 +305,7 @@ and acceptance criteria.
 - **Acceptance:** Exactly one contract mechanism remains authoritative;
   concept names either constrain real templates or are removed entirely.
 
-#### C2. `std::move_only_function` for callbacks
+#### C2. `std::move_only_function` for callbacks — DONE
 
 - **Effort:** small · **pyoperon-facing:** yes
 - **What:** Swap `std::function` for `std::move_only_function` on
@@ -314,13 +314,40 @@ and acceptance criteria.
 - **Why:** These are only ever called and moved; dropping the copyability
   requirement permits move-only captures (e.g. a captured `unique_ptr`
   progress sink) and is marginally cheaper to construct.
-- **Files:** `algorithms/ga_base.hpp` (the `ReportCallback` alias),
-  `algorithms/enumeration.hpp`.
+- **Files:** `algorithms/stoppable.hpp` (the `ReportCallback` alias — moved
+  here from `ga_base.hpp` by A3), `algorithms/enumeration.hpp`.
 - **Watch:** `ReportCallback` is passed by value into several `Run()`
   signatures and used from Python — confirm pybind11 can still bind it, or
   keep a `std::function`-typed shim at the binding boundary if not.
+- **What actually happened:** pyoperon uses nanobind, not pybind11, and
+  nanobind has no built-in caster for `std::move_only_function` (only
+  `nanobind/stl/function.h`, i.e. `std::function`). `GeneticProgrammingAlgorithm::Run`/
+  `NSGA2::Run`'s pyoperon bindings were changed from
+  `nb::overload_cast<...>(&Run)` to explicit lambdas taking
+  `std::function<bool()>` and converting to `Operon::ReportCallback` at the
+  call site — verified end-to-end via a local flake `path:` override
+  (co-developed per this doc's cross-repo guardrail, reverted before
+  merging): built, then ran a real GP fit from Python with a report
+  callback, confirming it fires correctly across the full run. The
+  enumeration engine's `onNovelExpression_` hook isn't exposed to Python at
+  all, so it had zero binding risk. Only one call site in
+  `GrammarEnumerationAlgorithm::Run` needed a fix: `engine_.Build(shouldStop)`
+  became `engine_.Build(std::move(shouldStop))` since the local
+  `ReportCallback` there is no longer copyable.
+- **Also found (unrelated to C2, fixed alongside it in the same pyoperon
+  PR):** pyoperon's bindings for `GeneticAlgorithmBase::Generation/
+  Individuals/Parents/Offspring` and `GeneticProgrammingAlgorithm/NSGA2::
+  IsFitted` were still written against the pre-A1 getter-pair style
+  (`nb::overload_cast<...>(&Generation)` etc.) and no longer compiled
+  against A1's deducing-this getters (PR #115) — exactly the risk A1's own
+  entry flagged ("Verify pybind11 signatures still resolve") but which
+  wasn't caught at the time, since pyoperon's pin never advanced past A1
+  until this work needed to build against current `main`. Fixed with
+  lambda wrappers calling the deducing-this getters directly.
 - **Acceptance:** GP/NSGA2/enumeration report callbacks work from both C++
-  and pyoperon; a move-only-captured callback compiles and runs.
+  and pyoperon; a move-only-captured callback compiles and runs — both
+  verified (a new `ga_base.cpp` test case for the C++ side, a live Python
+  GP run for the pyoperon side).
 
 ### Phase 4 — Error-handling modernization (largest blast radius, do last)
 
@@ -381,7 +408,7 @@ parallel; Phase 3–4 items want a decision or careful staging first.
 | B1  | `NodeType` order asserts                |   2   | Small  |    No    | Done   | —              |
 | B2  | Interpreter thread-affinity contract    |   2   | Medium |    No    | Done*  | —              |
 | C1  | Concepts vs vtable                      |   3   | Medium |    No    | Done   | —              |
-| C2  | `move_only_function` callbacks          |   3   | Small  |   Yes    |        | —              |
+| C2  | `move_only_function` callbacks          |   3   | Small  |   Yes    | Done   | —              |
 | D1  | `std::expected` lookups                 |   4   | Medium |  Maybe   |        | —              |
 | D2  | Optimizer result type                   |   4   | Large  |   Yes    |        | Stage last     |
 

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -68,6 +68,11 @@ namespace Operon {
 // is later work, and will need to guard that append too (e.g. per-bucket
 // mutex, or a lock-free append structure), not just reuse seen_'s primitive.
 // Build() only ever runs single-threaded today, so this is moot for now.
+// Move-only: onNovelExpression_ is a std::move_only_function member, which
+// implicitly deletes this class's copy constructor/assignment. Nothing in
+// the codebase copies an EnumerationEngine today, but this is a real API
+// surface change worth flagging explicitly rather than leaving the next
+// caller to discover it as a compile error.
 class OPERON_EXPORT EnumerationEngine {
 public:
     EnumerationEngine(Operon::Grammar grammar, std::size_t maxComplexity, Operon::RandomGenerator& rng);

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -87,7 +87,7 @@ public:
     // compositional intermediates. The hook receives a mutable reference so a
     // caller (GrammarEnumerationAlgorithm) can fit coefficients in place
     // before the tree is stored.
-    void SetOnNovelExpression(std::function<void(Operon::Tree&)> hook) { onNovelExpression_ = std::move(hook); }
+    void SetOnNovelExpression(std::move_only_function<void(Operon::Tree&)> hook) { onNovelExpression_ = std::move(hook); }
 
     [[nodiscard]] auto Bucket(GrammarSymbol nt, std::size_t budget) const -> std::span<Operon::Tree const>;
 
@@ -139,7 +139,7 @@ private:
     Operon::Zobrist zobrist_;
     std::vector<std::vector<std::vector<Operon::Tree>>> buckets_; // [GrammarSymbol index][budget][candidate]
     std::vector<std::vector<gtl::parallel_flat_hash_set_m<Operon::Hash>>> seen_; // [GrammarSymbol index][budget]
-    std::function<void(Operon::Tree&)> onNovelExpression_;
+    std::move_only_function<void(Operon::Tree&)> onNovelExpression_;
 };
 
 struct EnumerationConfig {

--- a/include/operon/algorithms/stoppable.hpp
+++ b/include/operon/algorithms/stoppable.hpp
@@ -15,7 +15,13 @@ namespace Operon {
 // Run() to report progress. Returning true requests early termination; each
 // algorithm's own stop condition ORs StopRequested() in alongside its own
 // generation-count/budget, evaluator-budget, and time-limit checks.
-using ReportCallback = std::function<bool()>;
+// move_only_function, not function: this is only ever called and moved
+// (passed by value into Run(), never copied), so it permits move-only
+// captures (e.g. a captured unique_ptr progress sink) that std::function
+// couldn't hold. pyoperon binds this via an explicit std::function-taking
+// lambda shim rather than nb::overload_cast directly, since nanobind has no
+// built-in caster for move_only_function - see pyoperon's source/algorithm.cpp.
+using ReportCallback = std::move_only_function<bool()>;
 
 // Shared stopRequested_ + StopRequested()/RequestStop() idiom for search
 // drivers, whether population-based (GeneticAlgorithmBase) or not

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -318,7 +318,7 @@ void GrammarEnumerationAlgorithm::Run(Operon::RandomGenerator& rng, Operon::Repo
         return false;
     };
 
-    engine_.Build(shouldStop);
+    engine_.Build(std::move(shouldStop));
 
     // onNovelExpression_ captures coeffOptimizer (and rng) by reference, both
     // function-locals about to go out of scope - clear the hook so a stale

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -191,13 +191,21 @@ TEST_CASE("ReportCallback accepts a move-only capture (unique_ptr progress sink)
     GaBaseFixture f; // Config.Generations == 1
     Operon::RandomGenerator rng{42};
 
-    auto calls = std::make_unique<std::size_t>(0);
-    Operon::ReportCallback report = [sink = std::move(calls)]() mutable -> bool {
+    // `calls` is a plain local counter, alive on this TEST_CASE's own stack
+    // frame independent of the callback's lifetime, so reading it after
+    // Run() returns is safe. `sink` is the move-only capture under test -
+    // Run() consumes it (and destroys it, freeing its heap allocation) as
+    // part of tearing down the callback, so nothing below reads through it.
+    std::size_t calls = 0;
+    auto sink = std::make_unique<std::size_t>(0);
+    Operon::ReportCallback report = [&calls, sink = std::move(sink)]() mutable -> bool {
+        ++calls;
         ++*sink;
         return true;
     };
     f.Gp.Run(rng, std::move(report), /*threads=*/1);
 
+    CHECK(calls == 1); // the moved-in sink was actually reached, not just moved and dropped
     CHECK(f.Gp.Generation() == 0);
 }
 

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -183,6 +183,24 @@ TEST_CASE("ReportCallback returning true stops the run before the next generatio
     CHECK(f.Gp.Generation() == 0);
 }
 
+TEST_CASE("ReportCallback accepts a move-only capture (unique_ptr progress sink)", "[algorithms]")
+{
+    // ReportCallback is std::move_only_function<bool()>; this exercises the
+    // one property std::function couldn't have offered - a lambda that
+    // captures a move-only type by value, moved (not copied) into Run().
+    GaBaseFixture f; // Config.Generations == 1
+    Operon::RandomGenerator rng{42};
+
+    auto calls = std::make_unique<std::size_t>(0);
+    Operon::ReportCallback report = [sink = std::move(calls)]() mutable -> bool {
+        ++*sink;
+        return true;
+    };
+    f.Gp.Run(rng, std::move(report), /*threads=*/1);
+
+    CHECK(f.Gp.Generation() == 0);
+}
+
 TEST_CASE("ReportCallback returning false lets the run reach the configured generations", "[algorithms]")
 {
     GaBaseFixture f; // Config.Generations == 1


### PR DESCRIPTION
## Summary
- C2 from `docs/research/architecture-remediation-plan.md`: swaps `std::function` for `std::move_only_function` on `ReportCallback` (`algorithms/stoppable.hpp`) and the enumeration engine's `onNovelExpression_`/`SetOnNovelExpression` hook (`algorithms/enumeration.hpp`). Both are invoke-and-move-only — never copied — so this permits move-only captures (e.g. a `unique_ptr` progress sink) that `std::function` couldn't hold.
- One call site needed a fix: `GrammarEnumerationAlgorithm::Run`'s local `shouldStop` callback is now passed with `std::move` into `engine_.Build(...)`, since it's no longer copyable.
- pyoperon uses nanobind, which has no built-in caster for `move_only_function` (only `std::function`, via `nanobind/stl/function.h`). Verified via a local flake `path:` override (reverted before this PR) that a `std::function`-taking lambda shim at the binding boundary works correctly end-to-end from Python — companion fix going into pyoperon separately.
- `onNovelExpression_` isn't exposed to Python at all, so it had zero binding risk.

## Test plan
- [x] `cmake --build build` (full: lib, tests, CLI, examples) — clean
- [x] `./build/test/operon_test '~[performance]'` — all 194 test cases / 23349 assertions pass
- [x] New test: `ReportCallback accepts a move-only capture (unique_ptr progress sink)` — a lambda capturing a `unique_ptr` by value, moved into `Run()`, compiles and runs correctly
- [x] Verified end-to-end against a local pyoperon build: ran a real GP fit from Python with a report callback, confirmed it fires across the full run