### PR TITLE
refactor(optimizer): OptimizerSummary -> tl::expected<FitResult, FitFailure>

### DIFF
--- a/cli/source/operon_parse_model.cpp
+++ b/cli/source/operon_parse_model.cpp
@@ -156,10 +156,11 @@ namespace {
         Operon::Reporter<void>::PrintStats(stats, /*printHeader=*/true);
 
         if (opt->Iterations() > 0) {
+            auto const& diag = Operon::Diagnostics(summary);
             fmt::print("optimization summary:\n");
-            fmt::print("status: {}\n", summary.Success);
-            fmt::print("initial cost: {}\n", summary.InitialCost);
-            fmt::print("final cost: {}\n", summary.FinalCost);
+            fmt::print("status: {}\n", summary.has_value());
+            fmt::print("initial cost: {}\n", diag.InitialCost);
+            fmt::print("final cost: {}\n", diag.FinalCost);
         }
     }
 } // namespace

--- a/include/operon/algorithms/enumeration.hpp
+++ b/include/operon/algorithms/enumeration.hpp
@@ -19,7 +19,7 @@
 #include "operon/hash/content_hash.hpp"
 #include "operon/hash/zobrist.hpp"
 #include "operon/operators/evaluator.hpp" // for EvaluatorBase, Individual
-#include "operon/operators/local_search.hpp" // for CoefficientOptimizer, OptimizerBase/OptimizerSummary fwd decls
+#include "operon/operators/local_search.hpp" // for CoefficientOptimizer, OptimizerBase/FitResult/FitFailure fwd decls
 #include "operon/operon_export.hpp"
 #include "operon/random/random.hpp"
 
@@ -168,8 +168,9 @@ struct EnumerationConfig {
 // never itself surfaced as a score; `evaluator` is the user-selectable
 // ErrorMetric (R2/NMSE/MSE/MAE/...) that actually ranks candidates in
 // BestTrees(), same as GP/NSGA2. Always taking the optimizer's resulting
-// tree (regardless of OptimizerSummary::Success) and re-scoring it via
-// evaluator - rather than trusting OptimizerSummary's own cost fields -
+// tree (regardless of whether the fit outcome was FitResult or FitFailure)
+// and re-scoring it via evaluator - rather than trusting the outcome's own
+// cost fields -
 // keeps this consistent with the rest of the codebase and avoids coupling
 // ranking to whichever internal loss a given OptimizerBase happens to use.
 class OPERON_EXPORT GrammarEnumerationAlgorithm : public StoppableAlgorithm {

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -76,10 +76,11 @@ public:
             if (coeffOptimizer_ != nullptr && BernoulliTrial{pLocal}(random)) {
                 auto c = res.Child->Genotype.GetCoefficients(); // save original coefficients
                 auto t0 = std::chrono::steady_clock::now();
-                auto [optimizedTree, summary] = (*Optimizer())(random, std::move(res.Child->Genotype));
+                auto [optimizedTree, outcome] = (*Optimizer())(random, std::move(res.Child->Genotype));
                 auto t1 = std::chrono::steady_clock::now();
-                Evaluator()->ResidualEvaluations += summary.FunctionEvaluations;
-                Evaluator()->JacobianEvaluations += summary.JacobianEvaluations;
+                auto const& diag = Diagnostics(outcome);
+                Evaluator()->ResidualEvaluations += diag.FunctionEvaluations;
+                Evaluator()->JacobianEvaluations += diag.JacobianEvaluations;
                 Evaluator()->CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
                 res.Child->Genotype = std::move(optimizedTree);
                 res.Child->Fitness = (*Evaluator())(random, *res.Child, buf);

--- a/include/operon/operators/local_search.hpp
+++ b/include/operon/operators/local_search.hpp
@@ -6,6 +6,7 @@
 #define OPERON_LOCAL_SEARCH_HPP
 
 #include <gsl/pointers>
+#include <tl/expected.hpp>
 #include "operon/core/operator.hpp"
 #include "operon/operon_export.hpp"
 
@@ -15,15 +16,16 @@ namespace Operon {
 // forward declarations
 class Tree;
 class OptimizerBase;
-struct OptimizerSummary;
+struct FitResult;
+struct FitFailure;
 
-class OPERON_EXPORT CoefficientOptimizer : public OperatorBase<std::tuple<Operon::Tree, OptimizerSummary>, Operon::Tree> {
+class OPERON_EXPORT CoefficientOptimizer : public OperatorBase<std::tuple<Operon::Tree, tl::expected<FitResult, FitFailure>>, Operon::Tree> {
 public:
     explicit CoefficientOptimizer(gsl::not_null<OptimizerBase const*> optimizer)
         : optimizer_(optimizer)
     { }
 
-    auto operator()(Operon::RandomGenerator& rng, Operon::Tree tree) const -> std::tuple<Operon::Tree, OptimizerSummary> override;
+    auto operator()(Operon::RandomGenerator& rng, Operon::Tree tree) const -> std::tuple<Operon::Tree, tl::expected<FitResult, FitFailure>> override;
 
 private:
     gsl::not_null<Operon::OptimizerBase const*> optimizer_;

--- a/include/operon/optimizer/optimizer.hpp
+++ b/include/operon/optimizer/optimizer.hpp
@@ -7,6 +7,7 @@
 
 #include <gsl/pointers>
 #include <lbfgs/solver.hpp>
+#include <tl/expected.hpp>
 #include <functional>
 
 #include "operon/error_metrics/sum_of_squared_errors.hpp"
@@ -32,7 +33,11 @@ namespace Operon {
 
 enum class OptimizerType : int { Tiny, Eigen };
 
-struct OptimizerSummary {
+// Fields every Optimize() call always produces, whether or not the fit
+// improved on the initial coefficients (FitResult/FitFailure below both
+// carry these - callers that need e.g. FunctionEvaluations regardless of
+// outcome go through Diagnostics(), not a has_value() branch of their own).
+struct FitDiagnostics {
     std::vector<Operon::Scalar> InitialParameters;
     std::vector<Operon::Scalar> FinalParameters;
     Operon::Scalar InitialCost{};
@@ -40,8 +45,17 @@ struct OptimizerSummary {
     int Iterations{};
     int FunctionEvaluations{};
     int JacobianEvaluations{};
-    bool Success{};
 };
+
+struct FitResult : FitDiagnostics {};   // FinalCost improved on InitialCost
+struct FitFailure : FitDiagnostics {};  // did not improve (incl. non-finite cost)
+
+using FitOutcome = tl::expected<FitResult, FitFailure>;
+
+[[nodiscard]] inline auto Diagnostics(FitOutcome const& outcome) -> FitDiagnostics const& {
+    return outcome.has_value() ? static_cast<FitDiagnostics const&>(*outcome)
+                                : static_cast<FitDiagnostics const&>(outcome.error());
+}
 
 class OptimizerBase {
 gsl::not_null<Problem const*> problem_;
@@ -69,7 +83,7 @@ public:
     auto SetBatchSize(std::size_t batchSize) const { batchSize_ = batchSize; }
     auto SetIterations(std::size_t iterations) const { iterations_ = iterations; }
 
-    [[nodiscard]] virtual auto Optimize(Operon::RandomGenerator& rng, Tree const& tree) const -> OptimizerSummary = 0;
+    [[nodiscard]] virtual auto Optimize(Operon::RandomGenerator& rng, Tree const& tree) const -> FitOutcome = 0;
     [[nodiscard]] virtual auto ComputeLikelihood(Operon::Span<Operon::Scalar const> x, Operon::Span<Operon::Scalar const> y, Operon::Span<Operon::Scalar const> w) const -> Operon::Scalar = 0;
     [[nodiscard]] virtual auto ComputeFisherMatrix(Operon::Span<Operon::Scalar const> pred, Operon::Span<Operon::Scalar const> jac, Operon::Span<Operon::Scalar const> sigma) const -> Eigen::Matrix<Operon::Scalar, -1, -1> = 0;
 };
@@ -78,6 +92,17 @@ namespace detail {
     inline auto CheckSuccess(double initialCost, double finalCost) {
         constexpr auto CHECK_NAN{true};
         return Operon::Less<CHECK_NAN>{}(finalCost, initialCost);
+    }
+
+    // Replaces the near-identical summary-assembly tail block that used to
+    // be repeated at the end of every Optimize() override: each override
+    // builds one FitDiagnostics via aggregate init, then returns
+    // MakeFitOutcome(std::move(diag)) as its last line.
+    inline auto MakeFitOutcome(FitDiagnostics diag) -> FitOutcome {
+        if (CheckSuccess(diag.InitialCost, diag.FinalCost)) {
+            return FitResult{std::move(diag)};
+        }
+        return tl::unexpected(FitFailure{std::move(diag)});
     }
 } // namespace detail
 
@@ -88,7 +113,7 @@ struct LevenbergMarquardtOptimizer : public OptimizerBase {
     {
     }
 
-    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*unused*/, Operon::Tree const& tree) const -> OptimizerSummary final
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*unused*/, Operon::Tree const& tree) const -> FitOutcome final
     {
         auto const* dtable = this->GetDispatchTable();
         auto const* problem = this->GetProblem();
@@ -105,22 +130,21 @@ struct LevenbergMarquardtOptimizer : public OptimizerBase {
         solver.options.max_num_iterations = static_cast<int>(iterations+1);
 
         auto x0 = tree.GetCoefficients();
-        OptimizerSummary summary;
-        summary.InitialParameters = x0;
+        FitDiagnostics diag;
+        diag.InitialParameters = x0;
         auto m0 = Eigen::Map<Eigen::Matrix<Operon::Scalar, Eigen::Dynamic, 1>>(x0.data(), x0.size());
         if (!x0.empty()) {
             typename decltype(solver)::Parameters p = m0.cast<typename decltype(cf)::Scalar>();
             solver.Solve(cf, &p);
             m0 = p.template cast<Operon::Scalar>();
         }
-        summary.FinalParameters = x0;
-        summary.InitialCost = solver.summary.initial_cost;
-        summary.FinalCost = solver.summary.final_cost;
-        summary.Iterations = solver.summary.iterations;
-        summary.FunctionEvaluations = cf.ResidualCalls();
-        summary.JacobianEvaluations = cf.JacobianCalls();
-        summary.Success = detail::CheckSuccess(summary.InitialCost, summary.FinalCost);
-        return summary;
+        diag.FinalParameters = x0;
+        diag.InitialCost = solver.summary.initial_cost;
+        diag.FinalCost = solver.summary.final_cost;
+        diag.Iterations = solver.summary.iterations;
+        diag.FunctionEvaluations = cf.ResidualCalls();
+        diag.JacobianEvaluations = cf.JacobianCalls();
+        return detail::MakeFitOutcome(std::move(diag));
     }
 
     auto GetDispatchTable() const -> DTable const* { return dtable_.get(); }
@@ -145,7 +169,7 @@ struct LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> final : public 
     {
     }
 
-    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*unused*/, Operon::Tree const& tree) const -> OptimizerSummary final
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*unused*/, Operon::Tree const& tree) const -> FitOutcome final
     {
         auto const* dtable = this->GetDispatchTable();
         auto const* problem = this->GetProblem();
@@ -162,15 +186,15 @@ struct LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> final : public 
         lm.setMaxfev(static_cast<int>(iterations+2));
 
         auto x0 = tree.GetCoefficients();
-        OptimizerSummary summary;
-        summary.InitialParameters = x0;
+        FitDiagnostics diag;
+        diag.InitialParameters = x0;
         if (!x0.empty()) {
             Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1>> m0(x0.data(), std::ssize(x0));
             Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
 
             // do the minimization loop manually because we want to extract the initial cost
             Eigen::LevenbergMarquardtSpace::Status status = lm.minimizeInit(m);
-            summary.InitialCost = summary.FinalCost = lm.fnorm() * lm.fnorm() * 0.5; // get the initial cost after calling minimizeInit()
+            diag.InitialCost = diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5; // get the initial cost after calling minimizeInit()
             if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
                 do {
                     status = lm.minimizeOneStep(m);
@@ -178,14 +202,13 @@ struct LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> final : public 
             }
             m0 = m;
         }
-        summary.FinalParameters = x0;
-        summary.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
-        summary.Iterations = static_cast<int>(lm.iterations());
-        summary.FunctionEvaluations = static_cast<int>(cf.ResidualCalls());
-        summary.JacobianEvaluations = static_cast<int>(cf.JacobianCalls());
+        diag.FinalParameters = x0;
+        diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
+        diag.Iterations = static_cast<int>(lm.iterations());
+        diag.FunctionEvaluations = static_cast<int>(cf.ResidualCalls());
+        diag.JacobianEvaluations = static_cast<int>(cf.JacobianCalls());
 
-        summary.Success = detail::CheckSuccess(summary.InitialCost, summary.FinalCost);
-        return summary;
+        return detail::MakeFitOutcome(std::move(diag));
     }
 
     auto GetDispatchTable() const -> DTable const* { return dtable_.get(); }
@@ -210,7 +233,7 @@ struct LBFGSOptimizer final : public OptimizerBase {
     {
     }
 
-    [[nodiscard]] auto Optimize(Operon::RandomGenerator& rng, Operon::Tree const& tree) const -> OptimizerSummary final
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& rng, Operon::Tree const& tree) const -> FitOutcome final
     {
         auto const* dtable = this->GetDispatchTable();
         auto const* problem = this->GetProblem();
@@ -237,9 +260,9 @@ struct LBFGSOptimizer final : public OptimizerBase {
             // optimizes. Do NOT assume this line is weighted just because
             // `weights` is passed in - each LossFunction decides for itself
             // whether to apply it (GaussianLoss::Cost: yes; PoissonLoss::Cost:
-            // no, see its comment) - otherwise Success could be judged against
-            // the wrong objective and CoefficientOptimizer (local_search.cpp)
-            // would drop valid weighted gains.
+            // no, see its comment) - otherwise the outcome could be judged
+            // against the wrong objective and CoefficientOptimizer
+            // (local_search.cpp) would drop valid weighted gains.
             //
             // TODO: Cost is an SSE surrogate for every LossFunction, not each
             // one's true objective (Poisson::operator() actually optimizes
@@ -255,25 +278,24 @@ struct LBFGSOptimizer final : public OptimizerBase {
         solver.max_iterations = iterations;
         solver.max_line_search_iterations = iterations;
         auto const f0 = cost(coeff);
-        OptimizerSummary summary;
-        summary.InitialParameters = coeff;
-        summary.InitialCost = f0;
+        FitDiagnostics diag;
+        diag.InitialParameters = coeff;
+        diag.InitialCost = f0;
 
         if (auto res = solver.optimize(x0)) {
             auto xf = res.value();
             std::copy(xf.begin(), xf.end(), coeff.begin());
         }
 
-        summary.FinalParameters = coeff;
+        diag.FinalParameters = coeff;
         auto const f1 = cost(coeff);
-        summary.FinalCost = f1;
-        summary.Success = detail::CheckSuccess(f0, f1);
+        diag.FinalCost = f1;
         auto const funEvals = loss.FunctionEvaluations();
         auto const jacEvals = loss.JacobianEvaluations();
         auto const rangeSize = range.Size();
-        summary.FunctionEvaluations = static_cast<std::size_t>(static_cast<double>(funEvals + jacEvals) * batchSize / rangeSize);
-        summary.JacobianEvaluations = summary.FunctionEvaluations;
-        return summary;
+        diag.FunctionEvaluations = static_cast<std::size_t>(static_cast<double>(funEvals + jacEvals) * batchSize / rangeSize);
+        diag.JacobianEvaluations = diag.FunctionEvaluations;
+        return detail::MakeFitOutcome(std::move(diag));
     }
 
     auto GetDispatchTable() const -> DTable const* { return dtable_.get(); }
@@ -307,7 +329,7 @@ struct SGDOptimizer final : public OptimizerBase {
 
     auto GetDispatchTable() const -> DTable const* { return dtable_.get(); }
 
-    [[nodiscard]] auto Optimize(Operon::RandomGenerator& rng, Operon::Tree const& tree) const -> OptimizerSummary final
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& rng, Operon::Tree const& tree) const -> FitOutcome final
     {
         auto const* dtable = this->GetDispatchTable();
         auto const* problem = this->GetProblem();
@@ -334,9 +356,9 @@ struct SGDOptimizer final : public OptimizerBase {
             // optimizes. Do NOT assume this line is weighted just because
             // `weights` is passed in - each LossFunction decides for itself
             // whether to apply it (GaussianLoss::Cost: yes; PoissonLoss::Cost:
-            // no, see its comment) - otherwise Success could be judged against
-            // the wrong objective and CoefficientOptimizer (local_search.cpp)
-            // would drop valid weighted gains.
+            // no, see its comment) - otherwise the outcome could be judged
+            // against the wrong objective and CoefficientOptimizer
+            // (local_search.cpp) would drop valid weighted gains.
             //
             // TODO: Cost is an SSE surrogate for every LossFunction, not each
             // one's true objective (Poisson::operator() actually optimizes
@@ -347,9 +369,9 @@ struct SGDOptimizer final : public OptimizerBase {
 
         auto coeff = tree.GetCoefficients();
         auto const f0 = cost(coeff);
-        OptimizerSummary summary;
-        summary.InitialParameters = coeff;
-        summary.InitialCost = f0;
+        FitDiagnostics diag;
+        diag.InitialParameters = coeff;
+        diag.InitialCost = f0;
         auto rule = update_->Clone(coeff.size());
         SGDSolver<LossFunction> solver(&loss, rule.get());
 
@@ -358,16 +380,15 @@ struct SGDOptimizer final : public OptimizerBase {
         std::copy(x.begin(), x.end(), coeff.begin());
         auto const f1 = cost(coeff);
 
-        summary.FinalParameters = coeff;
-        summary.FinalCost = f1;
-        summary.Success = detail::CheckSuccess(f0, f1);
-        summary.Iterations = solver.Epochs();
+        diag.FinalParameters = coeff;
+        diag.FinalCost = f1;
+        diag.Iterations = solver.Epochs();
         auto const funEvals = loss.FunctionEvaluations();
         auto const jacEvals = loss.JacobianEvaluations();
         auto const rangeSize = range.Size();
-        summary.FunctionEvaluations = static_cast<std::size_t>(static_cast<double>(funEvals + jacEvals) * batchSize / rangeSize);
-        summary.JacobianEvaluations = summary.FunctionEvaluations;
-        return summary;
+        diag.FunctionEvaluations = static_cast<std::size_t>(static_cast<double>(funEvals + jacEvals) * batchSize / rangeSize);
+        diag.JacobianEvaluations = diag.FunctionEvaluations;
+        return detail::MakeFitOutcome(std::move(diag));
     }
 
     [[nodiscard]] auto ComputeLikelihood(Operon::Span<Operon::Scalar const> x, Operon::Span<Operon::Scalar const> y, Operon::Span<Operon::Scalar const> w) const -> Operon::Scalar override
@@ -409,7 +430,7 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
         , jitEval_{jitEvaluator}
     {}
 
-    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*rng*/, Operon::Tree const& tree) const -> OptimizerSummary final
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*rng*/, Operon::Tree const& tree) const -> FitOutcome final
     {
         auto const* dtable  = dtable_.get();
         auto const* problem = this->GetProblem();
@@ -424,9 +445,9 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
         JIT::CompileMeta const* meta = jitEval_->GetOrCompileJacobian(tree);
         if (!JacobianOnly && (!meta || !meta->fn)) { meta = jitEval_->GetOrCompile(tree); }
 
-        OptimizerSummary summary;
+        FitDiagnostics diag;
         auto x0 = tree.GetCoefficients();
-        summary.InitialParameters = x0;
+        diag.InitialParameters = x0;
 
         bool const hasFn    = meta && meta->fn;
         bool const hasJacFn = meta && meta->jacFn;
@@ -445,20 +466,19 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
                 Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1>> m0(x0.data(), std::ssize(x0));
                 Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
                 Eigen::LevenbergMarquardtSpace::Status status = lm.minimizeInit(m);
-                summary.InitialCost = summary.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
+                diag.InitialCost = diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
                 if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
                     do { status = lm.minimizeOneStep(m); }
                     while (status == Eigen::LevenbergMarquardtSpace::Running);
                 }
                 m0 = m;
             }
-            summary.FinalParameters       = x0;
-            summary.FinalCost             = lm.fnorm() * lm.fnorm() * 0.5;
-            summary.Iterations            = static_cast<int>(lm.iterations());
-            summary.FunctionEvaluations   = static_cast<int>(cf.ResidualCalls());
-            summary.JacobianEvaluations   = static_cast<int>(cf.JacobianCalls());
-            summary.Success               = detail::CheckSuccess(summary.InitialCost, summary.FinalCost);
-            return summary;
+            diag.FinalParameters       = x0;
+            diag.FinalCost             = lm.fnorm() * lm.fnorm() * 0.5;
+            diag.Iterations            = static_cast<int>(lm.iterations());
+            diag.FunctionEvaluations   = static_cast<int>(cf.ResidualCalls());
+            diag.JacobianEvaluations   = static_cast<int>(cf.JacobianCalls());
+            return detail::MakeFitOutcome(std::move(diag));
         }
 
         // Column pointer arrays are rebuilt from the tree (VarOrder is re-derivable;
@@ -505,20 +525,19 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
         Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
 
         Eigen::LevenbergMarquardtSpace::Status status = lm.minimizeInit(m);
-        summary.InitialCost = summary.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
+        diag.InitialCost = diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
         if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
             do { status = lm.minimizeOneStep(m); }
             while (status == Eigen::LevenbergMarquardtSpace::Running);
         }
         m0 = m;
 
-        summary.FinalParameters     = x0;
-        summary.FinalCost           = lm.fnorm() * lm.fnorm() * 0.5;
-        summary.Iterations          = static_cast<int>(lm.iterations());
-        summary.FunctionEvaluations = static_cast<int>(cf.ResidualCalls());
-        summary.JacobianEvaluations = static_cast<int>(cf.JacobianCalls());
-        summary.Success             = detail::CheckSuccess(summary.InitialCost, summary.FinalCost);
-        return summary;
+        diag.FinalParameters     = x0;
+        diag.FinalCost           = lm.fnorm() * lm.fnorm() * 0.5;
+        diag.Iterations          = static_cast<int>(lm.iterations());
+        diag.FunctionEvaluations = static_cast<int>(cf.ResidualCalls());
+        diag.JacobianEvaluations = static_cast<int>(cf.JacobianCalls());
+        return detail::MakeFitOutcome(std::move(diag));
     }
 
     auto GetDispatchTable() const -> DTable const* { return dtable_.get(); }

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <array>
 
-#include "operon/optimizer/optimizer.hpp" // for OptimizerSummary::FinalCost
+#include "operon/optimizer/optimizer.hpp" // for FitResult/FitFailure::FinalCost
 
 namespace Operon {
 
@@ -262,12 +262,12 @@ void GrammarEnumerationAlgorithm::ConsiderBest(Operon::Scalar fitness, Operon::T
 void GrammarEnumerationAlgorithm::Run(Operon::RandomGenerator& rng, Operon::ReportCallback report)
 {
     // Iterations() == 0 makes CoefficientOptimizer return a default-
-    // constructed OptimizerSummary (FinalCost == 0.0, Success == false)
-    // without ever calling optimizer_->Optimize() (see local_search.cpp) -
-    // every novel Expression would then tie at cost 0.0 and the top-K
-    // ranking below becomes meaningless. optimizer_ is caller-supplied and
-    // mutable (OptimizerBase::SetIterations()), so this is a real
-    // precondition, not just a theoretical one.
+    // constructed FitFailure (FinalCost == 0.0) without ever calling
+    // optimizer_->Optimize() (see local_search.cpp) - every novel Expression
+    // would then tie at cost 0.0 and the top-K ranking below becomes
+    // meaningless. optimizer_ is caller-supplied and mutable
+    // (OptimizerBase::SetIterations()), so this is a real precondition, not
+    // just a theoretical one.
     EXPECT(optimizer_->Iterations() > 0);
 
     Operon::CoefficientOptimizer coeffOptimizer{optimizer_};
@@ -277,13 +277,14 @@ void GrammarEnumerationAlgorithm::Run(Operon::RandomGenerator& rng, Operon::Repo
     // candidates per run, so a per-candidate heap allocation here adds up.
     std::vector<Operon::Scalar> evalBuf(evaluator_->GetProblem()->TrainingRange().Size());
     engine_.SetOnNovelExpression([&](Operon::Tree& tree) {
-        // Always take the optimizer's resulting tree, regardless of
-        // OptimizerSummary::Success - mirrors BasicOffspringGenerator's own
-        // evaluate step (operators/generator.hpp), which never branches on
-        // Success either. Fitness is then computed fresh via evaluator_
-        // rather than trusting OptimizerSummary's own cost fields, which
-        // reflect whatever internal loss optimizer_ happens to minimize
-        // (e.g. LM's sum-of-squares), not the user-selected ErrorMetric.
+        // Always take the optimizer's resulting tree, regardless of whether
+        // the fit outcome was FitResult or FitFailure - mirrors
+        // BasicOffspringGenerator's own evaluate step (operators/generator.hpp),
+        // which never branches on the outcome either. Fitness is then
+        // computed fresh via evaluator_ rather than trusting the outcome's
+        // own cost fields, which reflect whatever internal loss optimizer_
+        // happens to minimize (e.g. LM's sum-of-squares), not the
+        // user-selected ErrorMetric.
         tree = std::get<0>(coeffOptimizer(rng, tree));
         Operon::Individual ind{1};
         // Copy (not move) here: `tree` is a reference into the engine's own

--- a/source/operators/local_search.cpp
+++ b/source/operators/local_search.cpp
@@ -9,17 +9,20 @@
 
 namespace Operon {
 
-auto CoefficientOptimizer::operator()(Operon::RandomGenerator& rng, Operon::Tree tree) const -> std::tuple<Operon::Tree, OptimizerSummary> {
-    OptimizerSummary summary;
+auto CoefficientOptimizer::operator()(Operon::RandomGenerator& rng, Operon::Tree tree) const -> std::tuple<Operon::Tree, tl::expected<FitResult, FitFailure>> {
     auto const* optimizer = optimizer_.get();
 
     if (optimizer->Iterations() > 0) {
-        summary = optimizer->Optimize(rng, tree);
-
-        if (summary.Success) {
-            tree.SetCoefficients(summary.FinalParameters);
+        auto outcome = optimizer->Optimize(rng, tree);
+        if (outcome) {
+            tree.SetCoefficients(outcome->FinalParameters);
         }
+        return {tree, outcome};
     }
-    return {tree, summary};
+    // Iterations() == 0: matches the previous default-constructed
+    // OptimizerSummary (FinalCost == 0.0, Success == false) contract -
+    // GrammarEnumerationAlgorithm::Run's EXPECT(Iterations() > 0) depends on
+    // this remaining "unsuccessful", not on any specific cost value.
+    return {tree, tl::unexpected(FitFailure{})};
 }
 } // namespace Operon

--- a/test/source/implementation/optimizer.cpp
+++ b/test/source/implementation/optimizer.cpp
@@ -129,17 +129,19 @@ TEST_CASE("Parameter optimization", "[optimizer]") // NOLINT(readability-functio
 
     auto checkExact = [&](OptimizerBase& optimizer) -> void {
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(summary.FinalCost < summary.InitialCost);
-        CHECK(summary.FinalCost < tightTol);
-        for (auto const p : summary.FinalParameters) {
+        REQUIRE(summary.has_value());
+        CHECK(summary->FinalCost < summary->InitialCost);
+        CHECK(summary->FinalCost < tightTol);
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, paramTol));
         }
     };
 
     auto checkImproved = [&](OptimizerBase& optimizer) -> void {
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(summary.FinalCost < summary.InitialCost);
-        CHECK(summary.FinalCost < looseTol);
+        REQUIRE(summary.has_value());
+        CHECK(summary->FinalCost < summary->InitialCost);
+        CHECK(summary->FinalCost < looseTol);
     };
 
     SECTION("tiny solver") {
@@ -161,8 +163,9 @@ TEST_CASE("Parameter optimization", "[optimizer]") // NOLINT(readability-functio
         // Poisson loss on a continuous target: just verify it runs and improves
         LBFGSOptimizer<DTable, PoissonLoss<Operon::Scalar>> const optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(std::isfinite(summary.FinalCost));
-        CHECK(!summary.FinalParameters.empty());
+        REQUIRE(summary.has_value());
+        CHECK(std::isfinite(summary->FinalCost));
+        CHECK(!summary->FinalParameters.empty());
     }
 
     SECTION("sgd / gaussian") {
@@ -177,8 +180,9 @@ TEST_CASE("Parameter optimization", "[optimizer]") // NOLINT(readability-functio
         auto rule = std::make_unique<UpdateRule::Adam<Operon::Scalar>>(dim);
         SGDOptimizer<DTable, PoissonLoss<Operon::Scalar>> const optimizer{&dtable, &problem, *rule};
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(std::isfinite(summary.FinalCost));
-        CHECK(!summary.FinalParameters.empty());
+        REQUIRE(summary.has_value());
+        CHECK(std::isfinite(summary->FinalCost));
+        CHECK(!summary->FinalParameters.empty());
     }
 
 #if defined(HAVE_ASMJIT)
@@ -266,12 +270,12 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
 
     auto checkRecoversCleanSolution = [&](OptimizerBase& optimizer) -> void {
         auto summary = optimizer.Optimize(rng, tree);
-        // Success must reflect the *weighted* objective actually optimized -
-        // CoefficientOptimizer (local_search.cpp) only applies FinalParameters
-        // when Success is true, so a false negative here would silently drop
-        // a real weighted improvement.
-        CHECK(summary.Success);
-        for (auto const p : summary.FinalParameters) {
+        // The outcome must reflect the *weighted* objective actually
+        // optimized - CoefficientOptimizer (local_search.cpp) only applies
+        // FinalParameters when the outcome has a value, so a false failure
+        // here would silently drop a real weighted improvement.
+        CHECK(summary.has_value());
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, paramTol));
         }
     };
@@ -311,12 +315,12 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         auto rule = std::make_unique<UpdateRule::Adam<Operon::Scalar>>(dim);
         SGDOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem, *rule};
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(summary.Success);
+        CHECK(summary.has_value());
         // SGD converges more slowly than LM/L-BFGS on this problem within
         // the default iteration budget, so use a looser tolerance - the
         // point is confirming weights are picked up at all, not tight
         // convergence.
-        for (auto const p : summary.FinalParameters) {
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, 0.1F));
         }
     }
@@ -331,19 +335,20 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         // the fix.
         LBFGSOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
+        REQUIRE(summary.has_value());
 
         auto const range = problem.TrainingRange();
         auto const target = problem.TargetValues(range);
         auto const weights = *problem.Weights(range);
         Operon::Interpreter<Operon::Scalar, DTable> interpreter{&dtable, &fix.ds, &tree};
 
-        auto const pred0 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary.InitialParameters}, range);
+        auto const pred0 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary->InitialParameters}, range);
         auto const expectedInitialCost = 0.5 * Operon::SumOfSquaredErrors(pred0.begin(), pred0.end(), target.begin(), weights.begin());
-        CHECK_THAT(static_cast<double>(summary.InitialCost), Catch::Matchers::WithinRel(expectedInitialCost, 1e-3));
+        CHECK_THAT(static_cast<double>(summary->InitialCost), Catch::Matchers::WithinRel(expectedInitialCost, 1e-3));
 
-        auto const pred1 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary.FinalParameters}, range);
+        auto const pred1 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary->FinalParameters}, range);
         auto const expectedFinalCost = 0.5 * Operon::SumOfSquaredErrors(pred1.begin(), pred1.end(), target.begin(), weights.begin());
-        CHECK_THAT(static_cast<double>(summary.FinalCost), Catch::Matchers::WithinRel(expectedFinalCost, 1e-3));
+        CHECK_THAT(static_cast<double>(summary->FinalCost), Catch::Matchers::WithinRel(expectedFinalCost, 1e-3));
     }
 
     SECTION("lm / eigen: reported cost matches the weighted objective, not raw SSE") {
@@ -354,30 +359,31 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         // directly rather than relying on it transitively via Success/params.
         LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
+        REQUIRE(summary.has_value());
 
         auto const range = problem.TrainingRange();
         auto const target = problem.TargetValues(range);
         auto const weights = *problem.Weights(range);
         Operon::Interpreter<Operon::Scalar, DTable> interpreter{&dtable, &fix.ds, &tree};
 
-        auto const pred0 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary.InitialParameters}, range);
+        auto const pred0 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary->InitialParameters}, range);
         auto const expectedInitialCost = 0.5 * Operon::SumOfSquaredErrors(pred0.begin(), pred0.end(), target.begin(), weights.begin());
-        CHECK_THAT(static_cast<double>(summary.InitialCost), Catch::Matchers::WithinRel(expectedInitialCost, 1e-3));
+        CHECK_THAT(static_cast<double>(summary->InitialCost), Catch::Matchers::WithinRel(expectedInitialCost, 1e-3));
 
-        auto const pred1 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary.FinalParameters}, range);
+        auto const pred1 = interpreter.Evaluate(Operon::Span<Operon::Scalar const>{summary->FinalParameters}, range);
         auto const expectedFinalCost = 0.5 * Operon::SumOfSquaredErrors(pred1.begin(), pred1.end(), target.begin(), weights.begin());
-        CHECK_THAT(static_cast<double>(summary.FinalCost), Catch::Matchers::WithinRel(expectedFinalCost, 1e-3));
+        CHECK_THAT(static_cast<double>(summary->FinalCost), Catch::Matchers::WithinRel(expectedFinalCost, 1e-3));
     }
 
     SECTION("lbfgs / gaussian: CoefficientOptimizer actually applies the weighted-optimal coefficients") {
         // End-to-end check through the real call path (local_search.cpp),
         // not just Optimize() directly: CoefficientOptimizer gates
-        // SetCoefficients on summary.Success, so a mis-scored Success would
-        // silently discard a genuine weighted improvement here.
+        // SetCoefficients on the outcome having a value, so a mis-scored
+        // outcome would silently discard a genuine weighted improvement here.
         LBFGSOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem};
         Operon::CoefficientOptimizer const coeffOptimizer{&optimizer};
         auto [optimizedTree, summary] = coeffOptimizer(rng, tree);
-        REQUIRE(summary.Success);
+        REQUIRE(summary.has_value());
         auto const coeffs = optimizedTree.GetCoefficients();
         REQUIRE(!coeffs.empty());
         for (auto const c : coeffs) {
@@ -392,7 +398,8 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         fix.problem.GetDataset()->SetWeights(ones);
         LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
-        auto const p = summary.FinalParameters.front();
+        REQUIRE(summary.has_value());
+        auto const p = summary->FinalParameters.front();
         CHECK(std::abs(p - 1.0F) > paramTol);
     }
 
@@ -401,7 +408,8 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         fix.problem.GetDataset()->SetWeights(ones);
         LBFGSOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
-        auto const p = summary.FinalParameters.front();
+        REQUIRE(summary.has_value());
+        auto const p = summary->FinalParameters.front();
         CHECK(std::abs(p - 1.0F) > paramTol);
     }
 
@@ -418,18 +426,20 @@ TEST_CASE("Weighted parameter optimization", "[optimizer]")
         LBFGSOptimizer<DTable, PoissonLoss<Operon::Scalar>> const optimizerZeroed{&dtable, &problem};
         Operon::RandomGenerator rngZeroed{0};
         auto summaryZeroed = optimizerZeroed.Optimize(rngZeroed, tree);
+        REQUIRE(summaryZeroed.has_value());
 
         std::vector<Operon::Scalar> ones(WeightedOptimizerFixture::Nrow, Operon::Scalar{1});
         fix.problem.GetDataset()->SetWeights(ones);
         LBFGSOptimizer<DTable, PoissonLoss<Operon::Scalar>> const optimizerOnes{&dtable, &problem};
         Operon::RandomGenerator rngOnes{0};
         auto summaryOnes = optimizerOnes.Optimize(rngOnes, tree);
+        REQUIRE(summaryOnes.has_value());
 
-        REQUIRE(summaryZeroed.FinalParameters.size() == summaryOnes.FinalParameters.size());
-        for (auto i = 0UL; i < summaryZeroed.FinalParameters.size(); ++i) {
-            CHECK_THAT(summaryZeroed.FinalParameters[i], Catch::Matchers::WithinRel(summaryOnes.FinalParameters[i], 1e-5F));
+        REQUIRE(summaryZeroed->FinalParameters.size() == summaryOnes->FinalParameters.size());
+        for (auto i = 0UL; i < summaryZeroed->FinalParameters.size(); ++i) {
+            CHECK_THAT(summaryZeroed->FinalParameters[i], Catch::Matchers::WithinRel(summaryOnes->FinalParameters[i], 1e-5F));
         }
-        CHECK_THAT(static_cast<double>(summaryZeroed.FinalCost), Catch::Matchers::WithinRel(static_cast<double>(summaryOnes.FinalCost), 1e-5));
+        CHECK_THAT(static_cast<double>(summaryZeroed->FinalCost), Catch::Matchers::WithinRel(static_cast<double>(summaryOnes->FinalCost), 1e-5));
     }
 }
 
@@ -507,7 +517,8 @@ TEST_CASE("Weighted parameter optimization with non-zero training range start", 
     SECTION("lbfgs / gaussian") {
         LBFGSOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
-        for (auto const p : summary.FinalParameters) {
+        REQUIRE(summary.has_value());
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, paramTol));
         }
     }
@@ -517,7 +528,8 @@ TEST_CASE("Weighted parameter optimization with non-zero training range start", 
         auto rule = std::make_unique<UpdateRule::Adam<Operon::Scalar>>(dim);
         SGDOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem, *rule};
         auto summary = optimizer.Optimize(rng, tree);
-        for (auto const p : summary.FinalParameters) {
+        REQUIRE(summary.has_value());
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, 0.1F));
         }
     }
@@ -535,7 +547,8 @@ TEST_CASE("Weighted parameter optimization with non-zero training range start", 
 
         LBFGSOptimizer<DTable, GaussianLoss<Operon::Scalar>> optimizer{&dtable, &problem};
         auto summary = optimizer.Optimize(rng, tree);
-        for (auto const p : summary.FinalParameters) {
+        REQUIRE(summary.has_value());
+        for (auto const p : summary->FinalParameters) {
             CHECK_THAT(p, Catch::Matchers::WithinAbs(1.0F, paramTol));
         }
     }
@@ -643,10 +656,15 @@ TEST_CASE("SGD update rules", "[optimizer]")
     for (auto const& rule : rules) {
         SGDOptimizer<DTable, GaussianLoss<Operon::Scalar>> const optimizer{&dtable, &problem, *rule};
         auto summary = optimizer.Optimize(rng, tree);
-        CHECK(summary.Iterations > 0);
+        // Not gated on summary.has_value(): some rules (see YamAdam note
+        // below) may not actually improve the cost on this fixture, but
+        // diagnostics are populated either way (FitResult/FitFailure both
+        // carry them) - this test only cares that the run itself is sane.
+        auto const& diag = Diagnostics(summary);
+        CHECK(diag.Iterations > 0);
         // YamAdam applies the raw (summed) gradient as its first step (step size ≈ 1),
         // which overshoots on unnormalized losses with large n. We only require finite output.
-        CHECK(std::isfinite(summary.FinalCost));
+        CHECK(std::isfinite(diag.FinalCost));
     }
 }
 

--- a/test/source/performance/autodiff.cpp
+++ b/test/source/performance/autodiff.cpp
@@ -238,7 +238,7 @@ TEST_CASE("Optimizer performance", "[performance]")
                 for (auto const& tree : trees) {
                     Operon::LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> const optimizer{&dt, &problem};
                     auto summary = optimizer.Optimize(rng, tree);
-                    sz += summary.FinalParameters.size();
+                    sz += Operon::Diagnostics(summary).FinalParameters.size();
                 }
                 return sz;
             });

--- a/test/source/performance/evaluation.cpp
+++ b/test/source/performance/evaluation.cpp
@@ -494,7 +494,7 @@ TEST_CASE("JIT LM optimizer performance", "[performance][jit][optimizer]")
          .run("lm (interpreter)", [&]() {
              for (auto& tree : trees) {
                  auto summary = lmOpt.Optimize(rd, tree);
-                 nb::doNotOptimizeAway(summary.FinalCost);
+                 nb::doNotOptimizeAway(Operon::Diagnostics(summary).FinalCost);
              }
          });
 
@@ -502,7 +502,7 @@ TEST_CASE("JIT LM optimizer performance", "[performance][jit][optimizer]")
          .run("lm (jit residuals)", [&]() {
              for (auto& tree : trees) {
                  auto summary = jitLmOpt.Optimize(rd, tree);
-                 nb::doNotOptimizeAway(summary.FinalCost);
+                 nb::doNotOptimizeAway(Operon::Diagnostics(summary).FinalCost);
              }
          });
 


### PR DESCRIPTION
## Summary

This is D2, the last item in the (now local-only) architecture remediation
plan: replace `OptimizerSummary`'s `Success` bool plus cost fields with a
`tl::expected`-based outcome type.

- New types in `optimizer.hpp`: `FitDiagnostics` (the fields every `Optimize()`
  call always produces), `FitResult`/`FitFailure` (both derive from it), and
  `FitOutcome = tl::expected<FitResult, FitFailure>`. `tl::expected`, not
  `std::expected`, matching this codebase's established precedent.
- `detail::MakeFitOutcome(FitDiagnostics)` replaces the ~8-line
  summary-assembly tail block that was duplicated near-identically across
  all 6 `Optimize()` overrides (LM-Tiny, LM-Eigen, LBFGS, SGD, and the JIT
  LM optimizer's two internal paths).
- `Diagnostics(FitOutcome const&)` gives read access to the shared fields
  regardless of outcome - needed because `BasicOffspringGenerator::Generate`
  and `GrammarEnumerationAlgorithm::Run` both deliberately never branch on
  success (see their existing comments), only `CoefficientOptimizer` does
  (gating whether fitted coefficients get written back into the tree).
- `CoefficientOptimizer`'s `Iterations() == 0` early-return now returns
  `tl::unexpected(FitFailure{})`, preserving the exact "unsuccessful"
  contract `GrammarEnumerationAlgorithm::Run`'s `EXPECT(Iterations() > 0)`
  depends on.
- Test updates are mechanical (`.Success` -> `.has_value()`, field access via
  `->`), except one real fix: `optimizer.cpp`'s "SGD update rules" test
  never actually checked `Success` (its own comment already anticipates some
  update rules not improving cost) - now reads through `Diagnostics()`
  instead of requiring success, matching its original intent exactly.

## Test plan
- [x] Full build (library, CLI, tests, example) succeeds in the nix devShell
- [x] All 194 test cases / 23366 assertions pass (`~[performance]` filter)
- [x] pyoperon builds cleanly against this branch via a local flake path
      override, including a binding-side shim (`ToPySummary`) in
      `source/optimizer.cpp` that flattens `FitOutcome` back into the same
      field-level `OptimizerSummary` Python API - lands as its own pyoperon
      PR once this merges