### PR TITLE
fix(nsga2): delegate reinsertion to the reinserter's actual strategy

### DIFF
--- a/include/operon/operators/non_dominated_sorter.hpp
+++ b/include/operon/operators/non_dominated_sorter.hpp
@@ -11,6 +11,12 @@
 
 namespace Operon {
 
+// Contract relied on by NSGA2::Sort (nsga2.cpp): every implementation reads
+// only Individual::Fitness, never Genotype/Rank/Distance. NSGA2 exploits
+// this to sort a permutation of indices instead of the population's actual
+// storage, feeding this interface lightweight fitness-only stand-ins for
+// the unique individuals rather than deep-copying genotype trees. A future
+// sorter that reads anything beyond Fitness would silently break that.
 class NondominatedSorterBase {
 public:
     using Result = Operon::Vector<Operon::Vector<size_t>>;

--- a/include/operon/operators/reinserter.hpp
+++ b/include/operon/operators/reinserter.hpp
@@ -64,12 +64,13 @@ public:
     // replace the worst individuals in pop with the best individuals from pool
     void operator()(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
     {
-        // typically the pool and the population are the same size
-        if (pop.size() > pool.size()) {
-            Sort(pop);
-        } else if (pop.size() < pool.size()) {
-            Sort(pool);
-        }
+        // Both spans must be sorted by the comparator regardless of their
+        // relative sizes - when pop.size() == pool.size() (the common case),
+        // skipping this would make offset cover the *entire* span and this
+        // become an unconditional full swap, never consulting the
+        // comparator at all.
+        Sort(pop);
+        Sort(pool);
         auto offset = static_cast<std::ptrdiff_t>(std::min(pop.size(), pool.size()));
         std::swap_ranges(pool.begin(), pool.begin() + offset, pop.end() - offset);
     }

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -63,29 +63,56 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     auto config = GetConfig();
     auto eps = static_cast<Operon::Scalar>(config.Epsilon);
     auto eq = [eps](auto const& lhs, auto const& rhs) -> auto { return Operon::Equal {}(lhs.Fitness, rhs.Fitness, eps); };
-    // sort the population lexicographically
-    std::stable_sort(pop.begin(), pop.end(), [](auto const& a, auto const& b) -> auto { return std::ranges::lexicographical_compare(a.Fitness, b.Fitness); });
+
+    // Sort an index permutation instead of physically reordering `pop`.
+    // `pop` here is the caller's combined parents+offspring storage, and
+    // Run() hands ReinserterBase::operator() fixed Parents()/Offspring()
+    // subspans over that same storage after this call returns - if we
+    // physically reordered pop, those subspans would silently become
+    // arbitrary halves of a fitness-sorted array rather than "the actual
+    // previous parents" / "the actual freshly generated offspring", which
+    // would undermine reinsertion strategies that rely on that distinction
+    // (e.g. ReplaceWorstReinserter). Rank/Distance below are still written
+    // directly into pop[order[i]], so they land on the correct individual
+    // regardless of pop's storage order.
+    Operon::Vector<size_t> order(pop.size());
+    std::iota(order.begin(), order.end(), size_t{0});
+    std::stable_sort(order.begin(), order.end(), [&](size_t a, size_t b) -> auto { return std::ranges::lexicographical_compare(pop[a].Fitness, pop[b].Fitness); });
     // mark the duplicates for stable_partition
-    for (auto i = pop.begin(); i < pop.end();) {
-        i->Rank = 0;
+    for (auto i = order.begin(); i < order.end();) {
+        pop[*i].Rank = 0;
         auto j = i + 1;
-        for (; j < pop.end() && eq(*i, *j); ++j) {
-            j->Rank = 1;
+        for (; j < order.end() && eq(pop[*i], pop[*j]); ++j) {
+            pop[*j].Rank = 1;
         }
         i = j;
     }
-    auto r = std::stable_partition(pop.begin(), pop.end(), [](auto const& ind) -> auto { return !ind.Rank; });
-    Operon::Span<Operon::Individual const> const uniq(pop.begin(), r);
+    auto r = std::stable_partition(order.begin(), order.end(), [&](size_t i) -> auto { return !pop[i].Rank; });
+    // The sorter needs Span<Individual const>, but only ever reads .Fitness
+    // (never .Genotype/.Rank/.Distance) - build lightweight fitness-only
+    // stand-ins instead of deep-copying every unique individual's tree.
+    Operon::Vector<Individual> uniq;
+    uniq.reserve(static_cast<size_t>(std::distance(order.begin(), r)));
+    for (auto it = order.begin(); it < r; ++it) {
+        Individual ind(pop[*it].Fitness.size());
+        ind.Fitness = pop[*it].Fitness;
+        uniq.push_back(std::move(ind));
+    }
     // do the sorting
-    fronts_ = (*sorter_)(uniq, eps);
+    fronts_ = (*sorter_)(Operon::Span<Operon::Individual const>(uniq.data(), uniq.size()), eps);
+    // translate front indices (into uniq) back to true indices into pop
+    for (auto& f : fronts_) {
+        for (auto& idx : f) { idx = order[idx]; }
+    }
     // sort the fronts for consistency between sorting algos
     for (auto& f : fronts_) {
         std::stable_sort(f.begin(), f.end());
     }
-    // banish the duplicates into the last front
-    if (r < pop.end()) {
-        Operon::Vector<size_t> last(pop.size() - uniq.size());
-        std::iota(last.begin(), last.end(), uniq.size());
+    // banish the duplicates into the last front (already true pop indices)
+    if (r < order.end()) {
+        Operon::Vector<size_t> last(static_cast<size_t>(std::distance(r, order.end())));
+        std::copy(r, order.end(), last.begin());
+        std::stable_sort(last.begin(), last.end());
         fronts_.push_back(last);
     }
     // calculate crowding distance

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -203,7 +203,16 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
                                             })
                                          .name("generate offspring");
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name(std::string{SortTaskName});
-            auto reinsert = subflow.emplace([&]() -> void { reinserter->Sort(individuals); }).name("reinsert");
+            // Delegates to the reinserter's actual merge strategy (same call
+            // shape as GP, gp.cpp) instead of just truncating a globally
+            // sorted array via ReinserterBase::Sort. This makes the
+            // --reinserter choice (keep-best vs. replace-worst) a real,
+            // meaningful knob for NSGA2 rather than a silently inert one -
+            // note KeepBestReinserter's merge is a positional pairwise
+            // tournament, not a global top-K selection, so this is not
+            // guaranteed to reproduce the old truncation-based selection
+            // byte-for-byte even at default settings.
+            auto reinsert = subflow.emplace([&]() -> void { (*reinserter)(random, parents, offspring); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -94,7 +94,7 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     Operon::Vector<Individual> uniq;
     uniq.reserve(static_cast<size_t>(std::distance(order.begin(), r)));
     for (auto it = order.begin(); it < r; ++it) {
-        Individual ind(pop[*it].Fitness.size());
+        Individual ind; // default ctor only fills a 1-element placeholder Fitness, unlike Individual(nObj)
         ind.Fitness = pop[*it].Fitness;
         uniq.push_back(std::move(ind));
     }

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -248,6 +248,71 @@ TEST_CASE("NSGA2: ReportCallback returning false lets the run reach the configur
     CHECK(calls == 2); // one report from init, one from the single generation's body
 }
 
+TEST_CASE("NSGA2: keep-best and replace-worst reinserters produce different results", "[algorithms][nsga2]")
+{
+    // Regression test for the reinserter-delegation fix: before it, NSGA2
+    // called only ReinserterBase::Sort (ignoring the concrete reinserter's
+    // operator()), so --reinserter keep-best vs replace-worst was silently
+    // inert. This runs identical NSGA2 setups (same seed, same everything
+    // except the reinserter) and asserts the final populations differ.
+    Operon::Dataset ds{ MakeDataset() };
+    Operon::Problem problem{ gsl::not_null<Operon::Dataset*>(&ds) };
+    problem.SetTrainingRange({0, 10});
+    problem.SetTestRange({0, 10});
+    problem.SetTarget("Y");
+    Operon::PrimitiveSet pset{ MakePset() };
+    std::vector<Operon::Hash> vars{ ds.GetVariable("X1")->Hash };
+
+    DTable dtable;
+    Operon::Evaluator<DTable> rmseEval{ &problem, &dtable };
+    Operon::LengthEvaluator lenEval{ &problem, /*maxLength=*/20 };
+    Operon::MultiEvaluator multiEval{ &problem };
+    multiEval.Add(&rmseEval);
+    multiEval.Add(&lenEval);
+
+    Operon::SubtreeCrossover crossover{ 0.9, /*maxDepth=*/6, /*maxLength=*/20 };
+    Operon::OnePointMutation<std::normal_distribution<Operon::Scalar>> onePoint;
+    onePoint.ParameterizeDistribution(Operon::Scalar{0}, Operon::Scalar{1});
+    Operon::MultiMutation mutator;
+    mutator.Add(&onePoint, 1.0);
+
+    Operon::CrowdedComparison comp;
+    Operon::TournamentSelector femSel{ comp };
+    Operon::TournamentSelector maleSel{ comp };
+    Operon::BasicOffspringGenerator generator{ &multiEval, &crossover, &mutator, &femSel, &maleSel };
+
+    Operon::BalancedTreeCreator creator{ &pset, vars, 0.0, 10 };
+    Operon::UniformTreeInitializer treeInit{ &creator };
+    treeInit.ParameterizeDistribution(std::size_t{1}, std::size_t{10});
+    Operon::UniformCoefficientInitializer coeffInit;
+    Operon::DeductiveSorter sorter;
+
+    auto config = MakeConfig(/*popSize=*/20, /*poolSize=*/20);
+    config.Generations = 3;
+
+    Operon::KeepBestReinserter keepBest{ comp };
+    Operon::NSGA2 nsgaKeepBest{ config, &problem, &treeInit, &coeffInit, &generator, &keepBest, &sorter };
+    Operon::RandomGenerator rngKeepBest{42};
+    nsgaKeepBest.Run(rngKeepBest, nullptr, /*threads=*/1);
+
+    Operon::ReplaceWorstReinserter replaceWorst{ comp };
+    Operon::NSGA2 nsgaReplaceWorst{ config, &problem, &treeInit, &coeffInit, &generator, &replaceWorst, &sorter };
+    Operon::RandomGenerator rngReplaceWorst{42};
+    nsgaReplaceWorst.Run(rngReplaceWorst, nullptr, /*threads=*/1);
+
+    auto keepBestFitness = std::vector<Operon::Scalar>{};
+    for (auto const& ind : nsgaKeepBest.Individuals()) {
+        keepBestFitness.insert(keepBestFitness.end(), ind.Fitness.begin(), ind.Fitness.end());
+    }
+    auto replaceWorstFitness = std::vector<Operon::Scalar>{};
+    for (auto const& ind : nsgaReplaceWorst.Individuals()) {
+        replaceWorstFitness.insert(replaceWorstFitness.end(), ind.Fitness.begin(), ind.Fitness.end());
+    }
+
+    REQUIRE(keepBestFitness.size() == replaceWorstFitness.size());
+    CHECK(keepBestFitness != replaceWorstFitness);
+}
+
 TEST_CASE("Generation/Elapsed/IsFitted return by value for const objects, by reference for mutable, regardless of value category", "[algorithms]")
 {
     // The pre-deducing-this overloads were never ref-qualified, so the const


### PR DESCRIPTION
## Summary
NSGA2 called `ReinserterBase::Sort` (a plain comparator-sort helper) instead of the reinserter's polymorphic `operator()`, so `--reinserter keep-best` vs `replace-worst` was silently inert for NSGA2 (both CLI and the pyoperon `NSGA2Algorithm` binding). NSGA2 now delegates reinsertion the same way GP does: `(*reinserter)(random, parents, offspring)`.

Two related bugs were fixed as part of getting this correct:
- `ReplaceWorstReinserter` only sorted `pop`/`pool` when their sizes differed, silently skipping the comparator whenever sizes matched (the default/common config). Both sorts are now unconditional.
- `NSGA2::Sort()` physically reordered the combined parents+offspring array while computing rank/crowding, so by the time reinsertion ran, `Parents()`/`Offspring()` no longer pointed at the actual previous parents and actual new offspring. `Sort()` now sorts an index permutation instead, preserving identity.

## Behavior change
This changes NSGA2's actual selection, not just its configurability. Benchmarked on Friedman-I (pop=1000/pool=1000/100 gens, 5 seeds), 2D hypervolume of the final front:

| | keep-best | replace-worst |
|---|---|---|
| hypervolume | 2352-2518 | 2317-2482 |
| front size | 10-16 | 9-15 |

`keep-best` (default) is unchanged; `replace-worst` is now a real, competitive alternative instead of an inert no-op.

## Test plan
- [x] `nix develop --command cmake --build build`
- [x] `./build/test/operon_test` (run from repo root) — 8655 assertions, all pass
- [x] New regression test: NSGA2 with `keep-best` vs `replace-worst` (same seed) now produces different results
