### PR TITLE
feat(operators): make elitism a ReinserterBase property

### DIFF
--- a/cli/source/operator_factory.cpp
+++ b/cli/source/operator_factory.cpp
@@ -30,13 +30,13 @@ namespace {
     }
 } // namespace
 
-auto ParseReinserter(std::string const& str, ComparisonCallback&& comp) -> std::unique_ptr<ReinserterBase>
+auto ParseReinserter(std::string const& str, ComparisonCallback&& comp, size_t eliteCount) -> std::unique_ptr<ReinserterBase>
 {
     std::unique_ptr<ReinserterBase> reinserter;
     if (str == "keep-best") {
-        reinserter = std::make_unique<KeepBestReinserter>(std::move(comp));
+        reinserter = std::make_unique<KeepBestReinserter>(std::move(comp), eliteCount);
     } else if (str == "replace-worst") {
-        reinserter = std::make_unique<ReplaceWorstReinserter>(std::move(comp));
+        reinserter = std::make_unique<ReplaceWorstReinserter>(std::move(comp), eliteCount);
     } else {
         throw std::invalid_argument(GetErrorString("reinserter", str));
     }

--- a/cli/source/operator_factory.hpp
+++ b/cli/source/operator_factory.hpp
@@ -33,7 +33,7 @@ namespace Operon { struct Variable; }
 
 namespace Operon {
 
-auto ParseReinserter(std::string const& str, ComparisonCallback&& comp) -> std::unique_ptr<ReinserterBase>;
+auto ParseReinserter(std::string const& str, ComparisonCallback&& comp, size_t eliteCount = 0) -> std::unique_ptr<ReinserterBase>;
 
 auto ParseSelector(std::string const& str, ComparisonCallback&& comp) -> std::unique_ptr<SelectorBase>;
 

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -214,7 +214,11 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
         auto maleSelector = Operon::ParseSelector(result["male-selector"].as<std::string>(), comp);
 
         auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), *evaluator, crossover, mutator, *femaleSelector, *maleSelector, &cOpt);
-        auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
+        // Default 1: preserves GP's historical single-elite behavior (previously
+        // a hardcoded offspring[0] overwrite in gp.cpp, now handled uniformly by
+        // ReinserterBase - see reinserter.hpp).
+        auto const eliteCount = result.count("elitism") ? result["elitism"].as<size_t>() : size_t{1};
+        auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp, eliteCount);
 
         Operon::RandomGenerator random(config.Seed);
         if (result["shuffle"].as<bool>()) { problem.GetDataset()->Shuffle(random); }

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -279,7 +279,10 @@ auto main(int argc, char** argv) -> int
         Operon::CoefficientOptimizer cOpt { optimizer.get() };
 
         auto generator = Operon::ParseGenerator(result["offspring-generator"].as<std::string>(), evaluator, crossover, mutator, *femaleSelector, *maleSelector, &cOpt);
-        auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp);
+        // Default 0: NSGA2 had no elitism before this option existed, so an
+        // unspecified --elitism preserves that. Opt in explicitly to enable it.
+        auto const eliteCount = result.count("elitism") ? result["elitism"].as<size_t>() : size_t{0};
+        auto reinserter = Operon::ParseReinserter(result["reinserter"].as<std::string>(), comp, eliteCount);
 
         Operon::RandomGenerator random(config.Seed);
         if (result["shuffle"].as<bool>()) {

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -171,6 +171,7 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("male-selector", "Male selection operator, with optional parameters separated by : (eg, --selector tournament:5)", cxxopts::value<std::string>()->default_value("tournament"))
         ("offspring-generator", "OffspringGenerator operator, with optional parameters separated by : (eg --offspring-generator brood:10:10)", cxxopts::value<std::string>()->default_value("basic"))
         ("reinserter", "Reinsertion operator merging offspring in the recombination pool back into the population", cxxopts::value<std::string>()->default_value("keep-best"))
+        ("elitism", "Number of best individuals guaranteed to carry over between generations, regardless of the reinserter's merge/replace strategy (default: 1 for GP, 0 for NSGA2)", cxxopts::value<size_t>())
         ("enable-symbols", "Comma-separated list of enabled symbols ("+symbols+")", cxxopts::value<std::string>())
         ("local-search-probability", "Probability for local search", cxxopts::value<Operon::Scalar>()->default_value("1.0"))
         ("lamarckian-probability", "Probability that the local search improvements are saved back into the chromosome", cxxopts::value<Operon::Scalar>()->default_value("1.0"))

--- a/include/operon/operators/non_dominated_sorter.hpp
+++ b/include/operon/operators/non_dominated_sorter.hpp
@@ -11,6 +11,12 @@
 
 namespace Operon {
 
+// Contract relied on by NSGA2::Sort (nsga2.cpp): every implementation reads
+// only Individual::Fitness, never Genotype/Rank/Distance. NSGA2 exploits
+// this to sort a permutation of indices instead of the population's actual
+// storage, feeding this interface lightweight fitness-only stand-ins for
+// the unique individuals rather than deep-copying genotype trees. A future
+// sorter that reads anything beyond Fitness would silently break that.
 class NondominatedSorterBase {
 public:
     using Result = Operon::Vector<Operon::Vector<size_t>>;

--- a/include/operon/operators/reinserter.hpp
+++ b/include/operon/operators/reinserter.hpp
@@ -64,12 +64,13 @@ public:
     // replace the worst individuals in pop with the best individuals from pool
     void operator()(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
     {
-        // typically the pool and the population are the same size
-        if (pop.size() > pool.size()) {
-            Sort(pop);
-        } else if (pop.size() < pool.size()) {
-            Sort(pool);
-        }
+        // Both spans must be sorted by the comparator regardless of their
+        // relative sizes - when pop.size() == pool.size() (the common case),
+        // skipping this would make offset cover the *entire* span and this
+        // become an unconditional full swap, never consulting the
+        // comparator at all.
+        Sort(pop);
+        Sort(pool);
         auto offset = static_cast<std::ptrdiff_t>(std::min(pop.size(), pool.size()));
         std::swap_ranges(pool.begin(), pool.begin() + offset, pop.end() - offset);
     }

--- a/include/operon/operators/reinserter.hpp
+++ b/include/operon/operators/reinserter.hpp
@@ -11,11 +11,30 @@
 #include "operon/core/individual.hpp"
 
 namespace Operon {
+// Elitism lives here (rather than as a separate per-algorithm mechanism,
+// e.g. GP's old offspring[0]-overwrite hack) because "which individuals
+// carry over between generations unconditionally" is exactly what
+// reinsertion already governs. operator() is `final`: it protects the top
+// EliteCount() individuals of `pop` (by the shared comparator) from ever
+// being touched, then hands the remaining, still-contiguous subspan of pop
+// to Combine() - the merge/replace strategy each subclass implements. Any
+// algorithm (GP, NSGA2, ...) gets elitism uniformly this way, generalizing
+// from "best-by-one-objective" (GP's SingleObjectiveComparison) to
+// "best-by-rank-then-crowding" (NSGA2's CrowdedComparison) for free, since
+// both are just the comparator already passed in.
 class ReinserterBase : public OperatorBase<void, Operon::Span<Individual>, Operon::Span<Individual>> {
 public:
-    explicit ReinserterBase(ComparisonCallback cb)
+    explicit ReinserterBase(ComparisonCallback cb, size_t eliteCount = 0)
         : comp_(std::move(cb))
+        , eliteCount_(eliteCount)
     {
+    }
+
+    void operator()(Operon::RandomGenerator& random, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const final
+    {
+        auto elites = std::min(eliteCount_, pop.size());
+        if (elites > 0) { Sort(pop); }
+        Combine(random, pop.subspan(elites), pool);
     }
 
     inline void Sort(Operon::Span<Individual> inds) const { std::stable_sort(inds.begin(), inds.end(), comp_); }
@@ -25,18 +44,28 @@ public:
         return comp_(lhs, rhs);
     }
 
+    [[nodiscard]] auto EliteCount() const -> size_t { return eliteCount_; }
+
+protected:
+    // Merge/replace strategy applied to the non-elite tail of pop and the
+    // full pool. `pop` here excludes whatever operator() already protected.
+    virtual void Combine(Operon::RandomGenerator& random, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const = 0;
+
 private:
     ComparisonCallback comp_;
+    size_t eliteCount_;
 };
 
 class OPERON_EXPORT KeepBestReinserter : public ReinserterBase {
 public:
-    explicit KeepBestReinserter(ComparisonCallback const& cb)
-        : ReinserterBase(cb)
+    explicit KeepBestReinserter(ComparisonCallback const& cb, size_t eliteCount = 0)
+        : ReinserterBase(cb, eliteCount)
     {
     }
+
+protected:
     // keep the best |pop| individuals from pop+pool
-    void operator()(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
+    void Combine(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
     {
         // sort the population and the recombination pool
         Sort(pop);
@@ -57,12 +86,14 @@ public:
 
 class OPERON_EXPORT ReplaceWorstReinserter : public ReinserterBase {
 public:
-    explicit ReplaceWorstReinserter(ComparisonCallback const& cb)
-        : ReinserterBase(cb)
+    explicit ReplaceWorstReinserter(ComparisonCallback const& cb, size_t eliteCount = 0)
+        : ReinserterBase(cb, eliteCount)
     {
     }
+
+protected:
     // replace the worst individuals in pop with the best individuals from pool
-    void operator()(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
+    void Combine(Operon::RandomGenerator& /*random*/, Operon::Span<Individual> pop, Operon::Span<Individual> pool) const override
     {
         // Both spans must be sorted by the comparator regardless of their
         // relative sizes - when pop.size() == pool.size() (the common case),

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
-#include <algorithm> // for max, min_element
+#include <algorithm> // for max
 #include <chrono> // for steady_clock
 #include <cstddef> // for size_t
 #include <functional> // for std::function
@@ -52,7 +52,6 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
         for (size_t i = 0; i < s; ++i) { rngs.emplace_back(random()); }
     }
 
-    auto idx = 0;
     auto const& evaluator = generator->Evaluator();
 
     // we want to allocate all the memory that will be necessary for evaluation (e.g. for storing model responses)
@@ -112,12 +111,12 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
         }, // init
         stop, // loop condition
         [&, timer](tf::Subflow& subflow) -> void {
-            auto keepElite = subflow.emplace([&]() -> void {
-                                        offspring[0] = *std::ranges::min_element(parents, [&](const auto& lhs, const auto& rhs) -> auto { return lhs[idx] < rhs[idx]; });
-                                    })
-                                 .name("keep elite");
+            // Elitism (if any) is now handled uniformly by ReinserterBase
+            // (reinserter.hpp) - it protects the top EliteCount() parents
+            // before reinsert() runs, so no offspring slot needs to be
+            // reserved for a hand-picked elite here anymore.
             auto prepareGenerator = subflow.emplace([&]() -> void { generator->Prepare(parents); }).name("prepare generator");
-            auto generateOffspring = subflow.for_each_index(size_t { 1 }, offspring.size(), size_t { 1 }, [&](size_t i) -> void {
+            auto generateOffspring = subflow.for_each_index(size_t { 0 }, offspring.size(), size_t { 1 }, [&](size_t i) -> void {
                                                 slots[executor.this_worker_id()].resize(trainSize);
                                                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);
                                                 while (!stop()) {
@@ -136,7 +135,6 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                          }).name("report progress");
 
             // set-up subflow graph
-            keepElite.precede(prepareGenerator);
             prepareGenerator.precede(generateOffspring);
             generateOffspring.precede(reinsert);
             reinsert.precede(incrementGeneration);

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -63,29 +63,56 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     auto config = GetConfig();
     auto eps = static_cast<Operon::Scalar>(config.Epsilon);
     auto eq = [eps](auto const& lhs, auto const& rhs) -> auto { return Operon::Equal {}(lhs.Fitness, rhs.Fitness, eps); };
-    // sort the population lexicographically
-    std::stable_sort(pop.begin(), pop.end(), [](auto const& a, auto const& b) -> auto { return std::ranges::lexicographical_compare(a.Fitness, b.Fitness); });
+
+    // Sort an index permutation instead of physically reordering `pop`.
+    // `pop` here is the caller's combined parents+offspring storage, and
+    // Run() hands ReinserterBase::operator() fixed Parents()/Offspring()
+    // subspans over that same storage after this call returns - if we
+    // physically reordered pop, those subspans would silently become
+    // arbitrary halves of a fitness-sorted array rather than "the actual
+    // previous parents" / "the actual freshly generated offspring", which
+    // would undermine reinsertion strategies that rely on that distinction
+    // (e.g. ReplaceWorstReinserter). Rank/Distance below are still written
+    // directly into pop[order[i]], so they land on the correct individual
+    // regardless of pop's storage order.
+    Operon::Vector<size_t> order(pop.size());
+    std::iota(order.begin(), order.end(), size_t{0});
+    std::stable_sort(order.begin(), order.end(), [&](size_t a, size_t b) -> auto { return std::ranges::lexicographical_compare(pop[a].Fitness, pop[b].Fitness); });
     // mark the duplicates for stable_partition
-    for (auto i = pop.begin(); i < pop.end();) {
-        i->Rank = 0;
+    for (auto i = order.begin(); i < order.end();) {
+        pop[*i].Rank = 0;
         auto j = i + 1;
-        for (; j < pop.end() && eq(*i, *j); ++j) {
-            j->Rank = 1;
+        for (; j < order.end() && eq(pop[*i], pop[*j]); ++j) {
+            pop[*j].Rank = 1;
         }
         i = j;
     }
-    auto r = std::stable_partition(pop.begin(), pop.end(), [](auto const& ind) -> auto { return !ind.Rank; });
-    Operon::Span<Operon::Individual const> const uniq(pop.begin(), r);
+    auto r = std::stable_partition(order.begin(), order.end(), [&](size_t i) -> auto { return !pop[i].Rank; });
+    // The sorter needs Span<Individual const>, but only ever reads .Fitness
+    // (never .Genotype/.Rank/.Distance) - build lightweight fitness-only
+    // stand-ins instead of deep-copying every unique individual's tree.
+    Operon::Vector<Individual> uniq;
+    uniq.reserve(static_cast<size_t>(std::distance(order.begin(), r)));
+    for (auto it = order.begin(); it < r; ++it) {
+        Individual ind(pop[*it].Fitness.size());
+        ind.Fitness = pop[*it].Fitness;
+        uniq.push_back(std::move(ind));
+    }
     // do the sorting
-    fronts_ = (*sorter_)(uniq, eps);
+    fronts_ = (*sorter_)(Operon::Span<Operon::Individual const>(uniq.data(), uniq.size()), eps);
+    // translate front indices (into uniq) back to true indices into pop
+    for (auto& f : fronts_) {
+        for (auto& idx : f) { idx = order[idx]; }
+    }
     // sort the fronts for consistency between sorting algos
     for (auto& f : fronts_) {
         std::stable_sort(f.begin(), f.end());
     }
-    // banish the duplicates into the last front
-    if (r < pop.end()) {
-        Operon::Vector<size_t> last(pop.size() - uniq.size());
-        std::iota(last.begin(), last.end(), uniq.size());
+    // banish the duplicates into the last front (already true pop indices)
+    if (r < order.end()) {
+        Operon::Vector<size_t> last(static_cast<size_t>(std::distance(r, order.end())));
+        std::copy(r, order.end(), last.begin());
+        std::stable_sort(last.begin(), last.end());
         fronts_.push_back(last);
     }
     // calculate crowding distance

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -203,7 +203,16 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
                                             })
                                          .name("generate offspring");
             auto nonDominatedSort = subflow.emplace([&]() -> void { Sort(individuals); }).name(std::string{SortTaskName});
-            auto reinsert = subflow.emplace([&]() -> void { reinserter->Sort(individuals); }).name("reinsert");
+            // Delegates to the reinserter's actual merge strategy (same call
+            // shape as GP, gp.cpp) instead of just truncating a globally
+            // sorted array via ReinserterBase::Sort. This makes the
+            // --reinserter choice (keep-best vs. replace-worst) a real,
+            // meaningful knob for NSGA2 rather than a silently inert one -
+            // note KeepBestReinserter's merge is a positional pairwise
+            // tournament, not a global top-K selection, so this is not
+            // guaranteed to reproduce the old truncation-based selection
+            // byte-for-byte even at default settings.
+            auto reinsert = subflow.emplace([&]() -> void { (*reinserter)(random, parents, offspring); }).name("reinsert");
             auto incrementGeneration = subflow.emplace([&]() -> void { ++Generation(); }).name("increment generation");
             auto reportProgress = subflow.emplace([&, timer]() -> void {
                                              Timings() = timer->Timings();

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -94,7 +94,7 @@ auto NSGA2::Sort(Operon::Span<Individual> pop) -> void
     Operon::Vector<Individual> uniq;
     uniq.reserve(static_cast<size_t>(std::distance(order.begin(), r)));
     for (auto it = order.begin(); it < r; ++it) {
-        Individual ind(pop[*it].Fitness.size());
+        Individual ind; // default ctor only fills a 1-element placeholder Fitness, unlike Individual(nObj)
         ind.Fitness = pop[*it].Fitness;
         uniq.push_back(std::move(ind));
     }

--- a/test/source/implementation/ga_base.cpp
+++ b/test/source/implementation/ga_base.cpp
@@ -248,6 +248,71 @@ TEST_CASE("NSGA2: ReportCallback returning false lets the run reach the configur
     CHECK(calls == 2); // one report from init, one from the single generation's body
 }
 
+TEST_CASE("NSGA2: keep-best and replace-worst reinserters produce different results", "[algorithms][nsga2]")
+{
+    // Regression test for the reinserter-delegation fix: before it, NSGA2
+    // called only ReinserterBase::Sort (ignoring the concrete reinserter's
+    // operator()), so --reinserter keep-best vs replace-worst was silently
+    // inert. This runs identical NSGA2 setups (same seed, same everything
+    // except the reinserter) and asserts the final populations differ.
+    Operon::Dataset ds{ MakeDataset() };
+    Operon::Problem problem{ gsl::not_null<Operon::Dataset*>(&ds) };
+    problem.SetTrainingRange({0, 10});
+    problem.SetTestRange({0, 10});
+    problem.SetTarget("Y");
+    Operon::PrimitiveSet pset{ MakePset() };
+    std::vector<Operon::Hash> vars{ ds.GetVariable("X1")->Hash };
+
+    DTable dtable;
+    Operon::Evaluator<DTable> rmseEval{ &problem, &dtable };
+    Operon::LengthEvaluator lenEval{ &problem, /*maxLength=*/20 };
+    Operon::MultiEvaluator multiEval{ &problem };
+    multiEval.Add(&rmseEval);
+    multiEval.Add(&lenEval);
+
+    Operon::SubtreeCrossover crossover{ 0.9, /*maxDepth=*/6, /*maxLength=*/20 };
+    Operon::OnePointMutation<std::normal_distribution<Operon::Scalar>> onePoint;
+    onePoint.ParameterizeDistribution(Operon::Scalar{0}, Operon::Scalar{1});
+    Operon::MultiMutation mutator;
+    mutator.Add(&onePoint, 1.0);
+
+    Operon::CrowdedComparison comp;
+    Operon::TournamentSelector femSel{ comp };
+    Operon::TournamentSelector maleSel{ comp };
+    Operon::BasicOffspringGenerator generator{ &multiEval, &crossover, &mutator, &femSel, &maleSel };
+
+    Operon::BalancedTreeCreator creator{ &pset, vars, 0.0, 10 };
+    Operon::UniformTreeInitializer treeInit{ &creator };
+    treeInit.ParameterizeDistribution(std::size_t{1}, std::size_t{10});
+    Operon::UniformCoefficientInitializer coeffInit;
+    Operon::DeductiveSorter sorter;
+
+    auto config = MakeConfig(/*popSize=*/20, /*poolSize=*/20);
+    config.Generations = 3;
+
+    Operon::KeepBestReinserter keepBest{ comp };
+    Operon::NSGA2 nsgaKeepBest{ config, &problem, &treeInit, &coeffInit, &generator, &keepBest, &sorter };
+    Operon::RandomGenerator rngKeepBest{42};
+    nsgaKeepBest.Run(rngKeepBest, nullptr, /*threads=*/1);
+
+    Operon::ReplaceWorstReinserter replaceWorst{ comp };
+    Operon::NSGA2 nsgaReplaceWorst{ config, &problem, &treeInit, &coeffInit, &generator, &replaceWorst, &sorter };
+    Operon::RandomGenerator rngReplaceWorst{42};
+    nsgaReplaceWorst.Run(rngReplaceWorst, nullptr, /*threads=*/1);
+
+    auto keepBestFitness = std::vector<Operon::Scalar>{};
+    for (auto const& ind : nsgaKeepBest.Individuals()) {
+        keepBestFitness.insert(keepBestFitness.end(), ind.Fitness.begin(), ind.Fitness.end());
+    }
+    auto replaceWorstFitness = std::vector<Operon::Scalar>{};
+    for (auto const& ind : nsgaReplaceWorst.Individuals()) {
+        replaceWorstFitness.insert(replaceWorstFitness.end(), ind.Fitness.begin(), ind.Fitness.end());
+    }
+
+    REQUIRE(keepBestFitness.size() == replaceWorstFitness.size());
+    CHECK(keepBestFitness != replaceWorstFitness);
+}
+
 TEST_CASE("Generation/Elapsed/IsFitted return by value for const objects, by reference for mutable, regardless of value category", "[algorithms]")
 {
     // The pre-deducing-this overloads were never ref-qualified, so the const


### PR DESCRIPTION
## Summary
Elitism used to live only in GP, as a hardcoded `offspring[0]` overwrite by objective 0 (`gp.cpp`) — invisible to NSGA2 and to the reinserter abstraction itself. This moves elitism into `ReinserterBase` via a non-virtual `operator()` (NVI pattern) that protects the top `EliteCount()` individuals of `pop` (by the shared comparator) before handing the remaining subspan to each subclass's `Combine()` (the renamed former `operator()` body of `KeepBestReinserter`/`ReplaceWorstReinserter`).

This generalizes "best-by-one-objective" (GP) to "best-by-rank-then-crowding" (NSGA2) for free, since both are just the comparator already passed in — no NSGA2-specific code needed, and NSGA2 gains elitism as a usable option for the first time.

- New `--elitism <n>` CLI flag, shared by `operon_gp`/`operon_nsgp`. Default: 1 for GP (matching the old hack's behavior at the population level, though not RNG-identical — the old code reserved `offspring[0]` and generated one fewer fresh child), 0 for NSGA2 (no prior elitism to preserve).
- pyoperon's existing `KeepBestReinserter(comp)`/`ReplaceWorstReinserter(comp)` bindings keep compiling unchanged (`eliteCount` defaults to 0).

## Validation
Benchmarked on NSGA2 (Friedman-I, pop=1000/pool=1000/100 generations, 5 seeds), hypervolume of the final Pareto front:

| eliteCount | keep-best | replace-worst |
|---|---|---|
| 0 | 2352-2518 | 2317-2482 |
| 5 | 2311-2488 | 2342-2473 |
| 50 | — | 2375-2465 |

Elitism at any count tried doesn't regress either reinserter.

## Test plan
- [x] `nix develop --command cmake --build build`
- [x] `./build/test/operon_test` (run from repo root) — passes
- [x] CLI smoke test: `operon_nsgp --reinserter replace-worst --elitism 3` and default-elitism `operon_gp` both run and produce sane output
