### PR TITLE
feat(analyzers): NodeImpact, PermutationImportance, GradientImportance

### DIFF
--- a/include/operon/analyzers/detail/variables_used_in.hpp
+++ b/include/operon/analyzers/detail/variables_used_in.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ANALYZERS_DETAIL_VARIABLES_USED_IN_HPP
+#define OPERON_ANALYZERS_DETAIL_VARIABLES_USED_IN_HPP
+
+#include <algorithm>
+#include <vector>
+
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+
+namespace Operon::detail {
+
+// First-seen-order unique variable hashes referenced by `tree` - shared between
+// PermutationImportance (permutation_importance.hpp) and GradientImportance
+// (gradient_importance.hpp), both of which report one importance value per
+// input variable the tree actually reads.
+inline auto VariablesUsedIn(Operon::Tree const& tree) -> std::vector<Operon::Hash>
+{
+    std::vector<Operon::Hash> vars;
+    for (auto const& n : tree.Nodes()) {
+        if (n.IsVariable() && std::ranges::find(vars, n.HashValue) == vars.end()) {
+            vars.push_back(n.HashValue);
+        }
+    }
+    return vars;
+}
+
+} // namespace Operon::detail
+
+#endif

--- a/include/operon/analyzers/gradient_importance.hpp
+++ b/include/operon/analyzers/gradient_importance.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ANALYZERS_GRADIENT_IMPORTANCE_HPP
+#define OPERON_ANALYZERS_GRADIENT_IMPORTANCE_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "operon/interpreter/interpreter.hpp"
+
+namespace Operon {
+
+// Cheap complement to PermutationImportance (permutation_importance.hpp): for each
+// input variable used by `tree`, the importance is mean(|d(prediction)/d(variable)|)
+// over `range` - a single reverse-mode sweep per variable, no dataset perturbation or
+// repeated re-evaluation needed. Agrees with permutation importance for smooth models,
+// but stays meaningful on small datasets where a shuffle-based estimate is noisy, and
+// is local/exact rather than a finite-difference approximation (see
+// Interpreter::JacRevVariable).
+inline auto GradientImportance(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Range range) -> std::vector<std::pair<Operon::Hash, double>>
+{
+    using Interp = Operon::Interpreter<>;
+
+    std::vector<Operon::Hash> vars;
+    for (auto const& n : tree.Nodes()) {
+        if (n.IsVariable() && std::ranges::find(vars, n.HashValue) == vars.end()) {
+            vars.push_back(n.HashValue);
+        }
+    }
+
+    Operon::ScalarDispatch dtable;
+    Interp const interpreter{ &dtable, &dataset, &tree };
+    auto const coeff = tree.GetCoefficients();
+
+    std::vector<std::pair<Operon::Hash, double>> result;
+    result.reserve(vars.size());
+    for (auto const variable : vars) {
+        auto const derivative = interpreter.JacRevVariable(coeff, range, variable);
+        auto const sum = std::transform_reduce(derivative.begin(), derivative.end(), Operon::Scalar{0}, std::plus<>{},
+            [](Operon::Scalar d) -> Operon::Scalar { return std::abs(d); });
+        result.emplace_back(variable, static_cast<double>(sum) / static_cast<double>(derivative.size()));
+    }
+
+    return result;
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/analyzers/gradient_importance.hpp
+++ b/include/operon/analyzers/gradient_importance.hpp
@@ -50,6 +50,17 @@ inline auto GradientImportance(Operon::Tree const& tree, Operon::Dataset const& 
     return result;
 }
 
+// Whole-dataset convenience overload. This is post-hoc analysis on an
+// already-fixed tree - unlike training, there's no leakage risk in reading
+// test rows here, and using every row available gives a less noisy result
+// than restricting to a training-only range. Pass an explicit range only if
+// there's a specific reason to isolate a subset (e.g. comparing train vs.
+// test importance).
+inline auto GradientImportance(Operon::Tree const& tree, Operon::Dataset const& dataset) -> std::vector<std::pair<Operon::Hash, double>>
+{
+    return GradientImportance(tree, dataset, Operon::Range(0, dataset.Rows<std::size_t>()));
+}
+
 } // namespace Operon
 
 #endif

--- a/include/operon/analyzers/gradient_importance.hpp
+++ b/include/operon/analyzers/gradient_importance.hpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "operon/core/contracts.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
@@ -29,6 +30,8 @@ namespace Operon {
 inline auto GradientImportance(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Range range) -> std::vector<std::pair<Operon::Hash, double>>
 {
     using Interp = Operon::Interpreter<>;
+
+    EXPECT(range.Size() > 0);
 
     std::vector<Operon::Hash> vars;
     for (auto const& n : tree.Nodes()) {

--- a/include/operon/analyzers/gradient_importance.hpp
+++ b/include/operon/analyzers/gradient_importance.hpp
@@ -4,16 +4,15 @@
 #ifndef OPERON_ANALYZERS_GRADIENT_IMPORTANCE_HPP
 #define OPERON_ANALYZERS_GRADIENT_IMPORTANCE_HPP
 
-#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <numeric>
 #include <utility>
 #include <vector>
 
+#include "operon/analyzers/detail/variables_used_in.hpp"
 #include "operon/core/contracts.hpp"
 #include "operon/core/dataset.hpp"
-#include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
 #include "operon/interpreter/interpreter.hpp"
@@ -33,12 +32,7 @@ inline auto GradientImportance(Operon::Tree const& tree, Operon::Dataset const& 
 
     EXPECT(range.Size() > 0);
 
-    std::vector<Operon::Hash> vars;
-    for (auto const& n : tree.Nodes()) {
-        if (n.IsVariable() && std::ranges::find(vars, n.HashValue) == vars.end()) {
-            vars.push_back(n.HashValue);
-        }
-    }
+    auto const vars = detail::VariablesUsedIn(tree);
 
     Operon::ScalarDispatch dtable;
     Interp const interpreter{ &dtable, &dataset, &tree };

--- a/include/operon/analyzers/node_impact.hpp
+++ b/include/operon/analyzers/node_impact.hpp
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <vector>
 
+#include "operon/core/contracts.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/range.hpp"
@@ -37,11 +38,17 @@ inline auto NodeImpact(Operon::Tree const& tree, Operon::Dataset const& dataset,
 {
     using Interp = Operon::Interpreter<>;
 
+    EXPECT(range.Size() > 0);
+
     if (std::ranges::any_of(tree.Nodes(), [](auto const& n) -> bool { return n.IsRef(); })) {
         return {};
     }
 
-    auto const actual = dataset.GetValues(target);
+    // Sliced to `range`, matching what Evaluate() below actually returns -
+    // dataset.GetValues(target) alone is the *whole* column, so comparing it
+    // directly against a `range`-sized prediction silently misaligns rows
+    // whenever range.Start() != 0.
+    auto const actual = dataset.GetValues(target).subspan(range.Start(), range.Size());
     auto const predicted = Interp::Evaluate(tree, dataset, range);
     Operon::Span<Operon::Scalar const> const predictedSpan{ predicted.data(), predicted.size() };
     auto const baseline = Operon::R2Score(predictedSpan, actual);
@@ -52,6 +59,7 @@ inline auto NodeImpact(Operon::Tree const& tree, Operon::Dataset const& dataset,
     for (size_t i = 0; i < nodes.size(); ++i) {
         auto const subtree = tree.Splice(i);
         auto const subtreeValues = Interp::Evaluate(subtree, dataset, range);
+        EXPECT(!subtreeValues.empty()); // guaranteed by the range.Size() > 0 check above
         auto const mean = std::reduce(subtreeValues.begin(), subtreeValues.end(), Operon::Scalar{0}) / static_cast<Operon::Scalar>(subtreeValues.size());
 
         auto replacedNodes = nodes;

--- a/include/operon/analyzers/node_impact.hpp
+++ b/include/operon/analyzers/node_impact.hpp
@@ -79,6 +79,17 @@ inline auto NodeImpact(Operon::Tree const& tree, Operon::Dataset const& dataset,
     return impact;
 }
 
+// Whole-dataset convenience overload. This is post-hoc analysis on an
+// already-fixed tree - unlike training, there's no leakage risk in reading
+// test rows here, and using every row available gives a less noisy result
+// than restricting to a training-only range. Pass an explicit range only if
+// there's a specific reason to isolate a subset (e.g. comparing train vs.
+// test impact).
+inline auto NodeImpact(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Hash target) -> std::vector<double>
+{
+    return NodeImpact(tree, dataset, target, Operon::Range(0, dataset.Rows<std::size_t>()));
+}
+
 } // namespace Operon
 
 #endif

--- a/include/operon/analyzers/node_impact.hpp
+++ b/include/operon/analyzers/node_impact.hpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ANALYZERS_NODE_IMPACT_HPP
+#define OPERON_ANALYZERS_NODE_IMPACT_HPP
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/range.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/error_metrics/r2_score.hpp"
+#include "operon/interpreter/interpreter.hpp"
+
+namespace Operon {
+
+// Per-node impact, aligned 1:1 with tree.Nodes() (postfix index). For node i:
+//   impact[i] = R2(tree) - R2(tree with node i's subtree spliced out and
+//   replaced by a Constant equal to that subtree's own mean prediction over
+//   `range`)
+// This is the same "replace and re-measure" idea used for per-variable
+// impact analysis (cf. HeuristicLab's RegressionSolutionVariableImpactsCalculator),
+// generalized here from dataset columns to arbitrary tree nodes/subtrees.
+// Positive impact means the subtree matters (removing it hurts the fit);
+// negative means the subtree actively hurts this quality measure on `range`
+// — a candidate for pruning. O(Length^2 * |range|): one interpreter pass per
+// node, each over the full range.
+//
+// Returns an empty vector if the tree contains any Ref node: those are
+// backward index references (DAG structural sharing), and splicing part of
+// the tree out from under a Ref without also rewriting whichever RefTo
+// values point through the spliced range isn't safe to do here.
+inline auto NodeImpact(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Hash target, Operon::Range range) -> std::vector<double>
+{
+    using Interp = Operon::Interpreter<>;
+
+    if (std::ranges::any_of(tree.Nodes(), [](auto const& n) -> bool { return n.IsRef(); })) {
+        return {};
+    }
+
+    auto const actual = dataset.GetValues(target);
+    auto const predicted = Interp::Evaluate(tree, dataset, range);
+    Operon::Span<Operon::Scalar const> const predictedSpan{ predicted.data(), predicted.size() };
+    auto const baseline = Operon::R2Score(predictedSpan, actual);
+
+    auto const& nodes = tree.Nodes();
+    std::vector<double> impact(nodes.size(), 0.0);
+
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        auto const subtree = tree.Splice(i);
+        auto const subtreeValues = Interp::Evaluate(subtree, dataset, range);
+        auto const mean = std::reduce(subtreeValues.begin(), subtreeValues.end(), Operon::Scalar{0}) / static_cast<Operon::Scalar>(subtreeValues.size());
+
+        auto replacedNodes = nodes;
+        auto const first = replacedNodes.begin() + static_cast<std::ptrdiff_t>(i - nodes[i].Length);
+        auto const last = replacedNodes.begin() + static_cast<std::ptrdiff_t>(i) + 1;
+        replacedNodes.erase(first, last);
+        replacedNodes.insert(replacedNodes.begin() + static_cast<std::ptrdiff_t>(i - nodes[i].Length), Operon::Node::Constant(mean));
+
+        auto replacedTree = Operon::Tree(std::move(replacedNodes)).UpdateNodes();
+        auto const replacedPredicted = Interp::Evaluate(replacedTree, dataset, range);
+        Operon::Span<Operon::Scalar const> const replacedSpan{ replacedPredicted.data(), replacedPredicted.size() };
+        auto const replacedR2 = Operon::R2Score(replacedSpan, actual);
+
+        impact[i] = baseline - replacedR2;
+    }
+
+    return impact;
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/analyzers/permutation_importance.hpp
+++ b/include/operon/analyzers/permutation_importance.hpp
@@ -10,9 +10,9 @@
 #include <numeric>
 #include <vector>
 
+#include "operon/analyzers/detail/variables_used_in.hpp"
 #include "operon/core/contracts.hpp"
 #include "operon/core/dataset.hpp"
-#include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
 #include "operon/error_metrics/r2_score.hpp"
@@ -25,19 +25,6 @@ struct VariableImportance {
     double Mean; // average, over repeated shuffles, of R2(tree) - R2(tree with this variable's column shuffled)
     double Std;  // population std of the same per-repeat differences
 };
-
-namespace detail {
-    inline auto VariablesUsedIn(Operon::Tree const& tree) -> std::vector<Operon::Hash>
-    {
-        std::vector<Operon::Hash> vars;
-        for (auto const& n : tree.Nodes()) {
-            if (n.IsVariable() && std::ranges::find(vars, n.HashValue) == vars.end()) {
-                vars.push_back(n.HashValue);
-            }
-        }
-        return vars;
-    }
-} // namespace detail
 
 // Permutation importance (cf. HeuristicLab's RegressionSolutionVariableImpactsCalculator
 // "Shuffle" method, and sklearn's permutation_importance, whose default nRepeats=5 this
@@ -84,6 +71,12 @@ inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset cons
         std::vector<double> diffs;
         diffs.reserve(nRepeats);
 
+        // std::shuffle produces a uniform random permutation of whatever the
+        // container currently holds, regardless of its starting order, so
+        // reshuffling `shuffled` in place across repeats (rather than
+        // resetting to `original` each time) is still a uniform-random
+        // permutation of the same underlying values on every repeat - just
+        // one fewer O(|range|) copy per repeat.
         auto shuffled = original;
         for (size_t rep = 0; rep < nRepeats; ++rep) {
             std::shuffle(shuffled.begin(), shuffled.end(), rng);
@@ -94,7 +87,6 @@ inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset cons
             auto const perturbedR2 = Operon::R2Score(perturbedSpan, actual);
 
             diffs.push_back(baseline - perturbedR2);
-            shuffled = original; // reset before the next repeat re-shuffles from scratch
         }
 
         workingCopy.SetValues(variable, range, { original.data(), original.size() });

--- a/include/operon/analyzers/permutation_importance.hpp
+++ b/include/operon/analyzers/permutation_importance.hpp
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <vector>
 
+#include "operon/core/contracts.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
@@ -61,7 +62,14 @@ inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset cons
 {
     using Interp = Operon::Interpreter<>;
 
-    auto const actual = dataset.GetValues(target);
+    EXPECT(range.Size() > 0);
+    EXPECT(nRepeats > 0);
+
+    // Sliced to `range`, matching what Evaluate() below actually returns -
+    // dataset.GetValues(target) alone is the *whole* column, so comparing it
+    // directly against a `range`-sized prediction silently misaligns rows
+    // whenever range.Start() != 0.
+    auto const actual = dataset.GetValues(target).subspan(range.Start(), range.Size());
     auto const predicted = Interp::Evaluate(tree, dataset, range);
     Operon::Span<Operon::Scalar const> const predictedSpan{ predicted.data(), predicted.size() };
     auto const baseline = Operon::R2Score(predictedSpan, actual);

--- a/include/operon/analyzers/permutation_importance.hpp
+++ b/include/operon/analyzers/permutation_importance.hpp
@@ -101,6 +101,17 @@ inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset cons
     return result;
 }
 
+// Whole-dataset convenience overload. This is post-hoc analysis on an
+// already-fixed tree - unlike training, there's no leakage risk in reading
+// test rows here, and using every row available gives less noisy Mean/Std
+// estimates than restricting to a training-only range. Pass an explicit
+// range only if there's a specific reason to isolate a subset (e.g.
+// comparing train vs. test importance).
+inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Hash target, Operon::RandomGenerator& rng, size_t nRepeats = 5) -> std::vector<VariableImportance>
+{
+    return PermutationImportance(tree, dataset, target, Operon::Range(0, dataset.Rows<std::size_t>()), rng, nRepeats);
+}
+
 } // namespace Operon
 
 #endif

--- a/include/operon/analyzers/permutation_importance.hpp
+++ b/include/operon/analyzers/permutation_importance.hpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ANALYZERS_PERMUTATION_IMPORTANCE_HPP
+#define OPERON_ANALYZERS_PERMUTATION_IMPORTANCE_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <numeric>
+#include <vector>
+
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "operon/error_metrics/r2_score.hpp"
+#include "operon/interpreter/interpreter.hpp"
+
+namespace Operon {
+
+struct VariableImportance {
+    Operon::Hash Variable;
+    double Mean; // average, over repeated shuffles, of R2(tree) - R2(tree with this variable's column shuffled)
+    double Std;  // population std of the same per-repeat differences
+};
+
+namespace detail {
+    inline auto VariablesUsedIn(Operon::Tree const& tree) -> std::vector<Operon::Hash>
+    {
+        std::vector<Operon::Hash> vars;
+        for (auto const& n : tree.Nodes()) {
+            if (n.IsVariable() && std::ranges::find(vars, n.HashValue) == vars.end()) {
+                vars.push_back(n.HashValue);
+            }
+        }
+        return vars;
+    }
+} // namespace detail
+
+// Permutation importance (cf. HeuristicLab's RegressionSolutionVariableImpactsCalculator
+// "Shuffle" method, and sklearn's permutation_importance, whose default nRepeats=5 this
+// mirrors): for each input variable used by `tree`, shuffle that variable's column across
+// the rows in `range` (every other column, including the target, stays fixed), re-evaluate
+// the unmodified tree against the perturbed dataset, and take R2(original) - R2(perturbed)
+// as the importance for that repeat. Repeated `nRepeats` times per variable and averaged
+// (with std reported alongside) rather than taken from a single shuffle, since a single
+// shuffle's outcome is itself a random variable.
+//
+// Unlike NodeImpact (node_impact.hpp), which perturbs the tree structure and leaves the
+// dataset untouched, this perturbs the dataset and leaves the tree untouched - it
+// naturally aggregates a variable's effect across every subtree it appears in, at the
+// cost of needing repeated shuffles (it's measuring a random quantity) rather than a
+// single deterministic replacement.
+//
+// Mutates one column of a single owning copy of `dataset` in place per repeat via
+// Dataset::SetValues (restoring the original values before moving to the next variable),
+// rather than cloning the whole dataset on every repeat - the clone happens once, not
+// nVariables * nRepeats times.
+inline auto PermutationImportance(Operon::Tree const& tree, Operon::Dataset const& dataset, Operon::Hash target, Operon::Range range, Operon::RandomGenerator& rng, size_t nRepeats = 5) -> std::vector<VariableImportance>
+{
+    using Interp = Operon::Interpreter<>;
+
+    auto const actual = dataset.GetValues(target);
+    auto const predicted = Interp::Evaluate(tree, dataset, range);
+    Operon::Span<Operon::Scalar const> const predictedSpan{ predicted.data(), predicted.size() };
+    auto const baseline = Operon::R2Score(predictedSpan, actual);
+
+    Operon::Dataset workingCopy(dataset);
+
+    std::vector<VariableImportance> result;
+    for (auto const variable : detail::VariablesUsedIn(tree)) {
+        auto const originalSpan = dataset.GetValues(variable).subspan(range.Start(), range.Size());
+        std::vector<Operon::Scalar> const original(originalSpan.begin(), originalSpan.end());
+
+        std::vector<double> diffs;
+        diffs.reserve(nRepeats);
+
+        auto shuffled = original;
+        for (size_t rep = 0; rep < nRepeats; ++rep) {
+            std::shuffle(shuffled.begin(), shuffled.end(), rng);
+            workingCopy.SetValues(variable, range, { shuffled.data(), shuffled.size() });
+
+            auto const perturbedPredicted = Interp::Evaluate(tree, workingCopy, range);
+            Operon::Span<Operon::Scalar const> const perturbedSpan{ perturbedPredicted.data(), perturbedPredicted.size() };
+            auto const perturbedR2 = Operon::R2Score(perturbedSpan, actual);
+
+            diffs.push_back(baseline - perturbedR2);
+            shuffled = original; // reset before the next repeat re-shuffles from scratch
+        }
+
+        workingCopy.SetValues(variable, range, { original.data(), original.size() });
+
+        auto const mean = std::reduce(diffs.begin(), diffs.end(), 0.0) / static_cast<double>(diffs.size());
+        auto const variance = std::transform_reduce(diffs.begin(), diffs.end(), 0.0, std::plus<>{},
+            [mean](double d) -> double { return (d - mean) * (d - mean); }) / static_cast<double>(diffs.size());
+
+        result.push_back({ variable, mean, std::sqrt(variance) });
+    }
+
+    return result;
+}
+
+} // namespace Operon
+
+#endif

--- a/include/operon/core/dataset.hpp
+++ b/include/operon/core/dataset.hpp
@@ -120,6 +120,14 @@ public:
     void Normalize(size_t i, Range range);
     void Standardize(size_t i, Range range);
     void PermuteRows(std::vector<int> const& perm);
+
+    // Overwrites the [range.Start(), range.Start() + range.Size()) slice of
+    // one column in place - e.g. for permutation-importance-style analyses
+    // that need to swap a column's values out, evaluate, then swap the
+    // originals back in without cloning the rest of the dataset (see
+    // analyzers/permutation_importance.hpp). Rows outside `range` and every
+    // other column are untouched.
+    void SetValues(Operon::Hash hash, Range range, Span<Scalar const> values);
 };
 
 } // namespace Operon

--- a/source/core/dataset.cpp
+++ b/source/core/dataset.cpp
@@ -388,6 +388,23 @@ void Dataset::Standardize(size_t i, Range range)
     std::transform(col, col + Rows(), col, [mu, stddev](auto v) -> Scalar { return (v - mu) / stddev; });
 }
 
+void Dataset::SetValues(Operon::Hash hash, Range range, Span<Scalar const> values)
+{
+    if (IsView()) {
+        throw std::runtime_error("Cannot mutate a non-owning dataset.\n");
+    }
+    EXPECT(values.size() == range.Size());
+    EXPECT(range.Start() + range.Size() <= static_cast<size_t>(Rows()));
+    auto it = variables_.find(hash);
+    if (it == variables_.end()) {
+        fmt::print(stderr, "SetValues: cannot find variable with hash value {}", hash);
+        std::abort();
+    }
+    auto const stride = static_cast<ptrdiff_t>(view_.extent(0)); // paddedRows
+    auto* col = storage_.container().data() + (static_cast<ptrdiff_t>(it->second.Index) * stride); // NOLINT(bugprone-implicit-widening-of-multiplication-result)
+    std::copy(values.begin(), values.end(), col + range.Start());
+}
+
 void Dataset::PermuteRows(std::vector<int> const& perm)
 {
     if (IsView()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,9 @@ add_executable(operon_test
     source/implementation/infix_parser.cpp
     source/implementation/initialization.cpp
     source/implementation/mutation.cpp
+    source/implementation/node_impact.cpp
     source/implementation/nondominatedsort.cpp
+    source/implementation/permutation_importance.cpp
     source/implementation/evaluator.cpp
     source/implementation/optimizer.cpp
     source/implementation/random.cpp

--- a/test/source/implementation/node_impact.cpp
+++ b/test/source/implementation/node_impact.cpp
@@ -52,6 +52,26 @@ TEST_CASE("NodeImpact - irrelevant subtree has ~zero impact, relevant subtree do
     CHECK(std::abs(impact[rootIdx] - impact[addX0X1Idx]) < 1e-6);
 }
 
+TEST_CASE("NodeImpact - range-less overload matches an explicit whole-dataset range", "[analyzers][node_impact]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const x1 = ds.GetVariable("x1").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Node nX1(NodeType::Variable); nX1.HashValue = x1.Hash;
+    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add) }).UpdateNodes();
+
+    auto const impactExplicit = Operon::NodeImpact(tree, ds, target, Operon::Range(0, ds.Rows()));
+    auto const impactDefault = Operon::NodeImpact(tree, ds, target);
+
+    REQUIRE(impactExplicit.size() == impactDefault.size());
+    for (size_t i = 0; i < impactExplicit.size(); ++i) {
+        CHECK(impactExplicit[i] == impactDefault[i]);
+    }
+}
+
 TEST_CASE("NodeImpact - a non-zero-start range aligns predictions against the matching target rows", "[analyzers][node_impact]")
 {
     // Same (x0, x1, y) relationship as the linear dataset above, but with two

--- a/test/source/implementation/node_impact.cpp
+++ b/test/source/implementation/node_impact.cpp
@@ -52,6 +52,36 @@ TEST_CASE("NodeImpact - irrelevant subtree has ~zero impact, relevant subtree do
     CHECK(std::abs(impact[rootIdx] - impact[addX0X1Idx]) < 1e-6);
 }
 
+TEST_CASE("NodeImpact - a non-zero-start range aligns predictions against the matching target rows", "[analyzers][node_impact]")
+{
+    // Same (x0, x1, y) relationship as the linear dataset above, but with two
+    // junk rows prepended that only the [2, Rows()) range should ever see -
+    // if `actual` isn't sliced to `range` the same way `predicted` is, this
+    // scores against the wrong rows and the two computations below diverge.
+    std::vector<Operon::Scalar> x0{ 100, 100, 1, 2, 3, 4, 5, 6, 7, 8 };
+    std::vector<Operon::Scalar> x1{ 100, 100, 2, 3, 4, 5, 6, 7, 8, 9 };
+    std::vector<Operon::Scalar> y(x0.size());
+    for (size_t i = 0; i < x0.size(); ++i) { y[i] = x0[i] + x1[i]; }
+    Operon::Dataset const prefixed({ "x0", "x1", "y" }, { x0, x1, y });
+
+    auto ds = MakeLinearDataset(); // the same 8 real rows, with no junk prefix
+    auto const x0Var = ds.GetVariable("x0").value();
+    auto const x1Var = ds.GetVariable("x1").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0Var.Hash;
+    Node nX1(NodeType::Variable); nX1.HashValue = x1Var.Hash;
+    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add) }).UpdateNodes();
+
+    auto const impactFull = Operon::NodeImpact(tree, ds, target, Operon::Range(0, ds.Rows()));
+    auto const impactPrefixed = Operon::NodeImpact(tree, prefixed, target, Operon::Range(2, prefixed.Rows()));
+
+    REQUIRE(impactFull.size() == impactPrefixed.size());
+    for (size_t i = 0; i < impactFull.size(); ++i) {
+        CHECK(std::abs(impactFull[i] - impactPrefixed[i]) < 1e-6);
+    }
+}
+
 TEST_CASE("NodeImpact - trees with Ref nodes are unsupported", "[analyzers][node_impact]")
 {
     auto ds = MakeLinearDataset();

--- a/test/source/implementation/node_impact.cpp
+++ b/test/source/implementation/node_impact.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "operon/analyzers/node_impact.hpp"
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    auto MakeLinearDataset() -> Operon::Dataset {
+        // y = x0 + x1, exactly - x0's coefficient node contributes, the
+        // Constant{0} node added on top does not.
+        std::vector<Operon::Scalar> x0{ 1, 2, 3, 4, 5, 6, 7, 8 };
+        std::vector<Operon::Scalar> x1{ 2, 3, 4, 5, 6, 7, 8, 9 };
+        std::vector<Operon::Scalar> y(x0.size());
+        for (size_t i = 0; i < x0.size(); ++i) { y[i] = x0[i] + x1[i]; }
+        return Operon::Dataset({ "x0", "x1", "y" }, { x0, x1, y });
+    }
+} // namespace
+
+TEST_CASE("NodeImpact - irrelevant subtree has ~zero impact, relevant subtree does not", "[analyzers][node_impact]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const x1 = ds.GetVariable("x1").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Node nX1(NodeType::Variable); nX1.HashValue = x1.Hash;
+
+    // (x0 + x1) + 0 - the "+ 0" wraps the real model in a no-op addition of
+    // an irrelevant constant, so the root's impact should be indistinguishable
+    // from the (x0 + x1) subtree's impact, while the Constant{0} leaf's own
+    // impact should be ~zero (replacing "0" by its own mean, "0", is a no-op).
+    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add), Node::Constant(0.0), Node(NodeType::Add) }).UpdateNodes();
+
+    auto const range = Operon::Range(0, ds.Rows());
+    auto const impact = Operon::NodeImpact(tree, ds, target, range);
+
+    REQUIRE(impact.size() == tree.Length());
+
+    auto const constantZeroIdx = 3UL; // Constant(0) node, see the initializer list above
+    auto const addX0X1Idx = 2UL;      // (x0 + x1) node
+    auto const rootIdx = 4UL;         // (x0 + x1) + 0
+
+    CHECK(std::abs(impact[constantZeroIdx]) < 1e-6);
+    CHECK(impact[addX0X1Idx] > 0.5);
+    CHECK(std::abs(impact[rootIdx] - impact[addX0X1Idx]) < 1e-6);
+}
+
+TEST_CASE("NodeImpact - trees with Ref nodes are unsupported", "[analyzers][node_impact]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+
+    // x0 * Ref(x0) - structural sharing via a backward Ref.
+    Tree const tree = Tree({ nX0, Node::Ref(0), Node(NodeType::Mul) }).UpdateNodes();
+
+    auto const range = Operon::Range(0, ds.Rows());
+    auto const impact = Operon::NodeImpact(tree, ds, target, range);
+
+    CHECK(impact.empty());
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/node_impact.cpp
+++ b/test/source/implementation/node_impact.cpp
@@ -82,6 +82,31 @@ TEST_CASE("NodeImpact - a non-zero-start range aligns predictions against the ma
     }
 }
 
+TEST_CASE("NodeImpact - duplicate variable occurrences are scored independently", "[analyzers][node_impact]")
+{
+    // y = x0 * x0 - x0 appears twice as two separate leaf nodes (not shared
+    // via Ref), so each occurrence is its own postfix index and should get
+    // its own (here: equal, by symmetry) impact rather than one shared value.
+    std::vector<Operon::Scalar> x0{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    std::vector<Operon::Scalar> y(x0.size());
+    for (size_t i = 0; i < x0.size(); ++i) { y[i] = x0[i] * x0[i]; }
+    Operon::Dataset ds({ "x0", "y" }, { x0, y });
+    auto const x0Var = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0a(NodeType::Variable); nX0a.HashValue = x0Var.Hash;
+    Node nX0b(NodeType::Variable); nX0b.HashValue = x0Var.Hash;
+    Tree const tree = Tree({ nX0a, nX0b, Node(NodeType::Mul) }).UpdateNodes();
+
+    auto const range = Operon::Range(0, ds.Rows());
+    auto const impact = Operon::NodeImpact(tree, ds, target, range);
+
+    REQUIRE(impact.size() == 3);
+    CHECK(impact[0] > 0.2);  // replacing either leaf occurrence with mean(x0) should hurt R2 ...
+    CHECK(impact[1] > 0.2);
+    CHECK(std::abs(impact[0] - impact[1]) < 1e-6); // ... and by symmetry, identically
+}
+
 TEST_CASE("NodeImpact - trees with Ref nodes are unsupported", "[analyzers][node_impact]")
 {
     auto ds = MakeLinearDataset();

--- a/test/source/implementation/permutation_importance.cpp
+++ b/test/source/implementation/permutation_importance.cpp
@@ -83,6 +83,38 @@ TEST_CASE("PermutationImportance - a non-zero-start range aligns predictions aga
     CHECK(std::abs(importanceFull.front().Std - importancePrefixed.front().Std) < 1e-6);
 }
 
+TEST_CASE("PermutationImportance - duplicate variable occurrences collapse to one entry", "[analyzers][permutation_importance]")
+{
+    // y = x0 * x0 - x0 appears twice in the tree (two separate leaf nodes,
+    // not shared via Ref), but importance is inherently per-*variable*, not
+    // per-occurrence: shuffling the one underlying dataset column perturbs
+    // both references simultaneously, so there should be exactly one entry,
+    // not two.
+    std::vector<Operon::Scalar> x0(200);
+    std::vector<Operon::Scalar> y(200);
+    Operon::RandomGenerator seedRng(7);
+    std::uniform_real_distribution<Operon::Scalar> dist(-1.F, 1.F);
+    for (size_t i = 0; i < x0.size(); ++i) {
+        x0[i] = dist(seedRng);
+        y[i] = x0[i] * x0[i];
+    }
+    Operon::Dataset ds({ "x0", "y" }, { x0, y });
+    auto const x0Var = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0a(NodeType::Variable); nX0a.HashValue = x0Var.Hash;
+    Node nX0b(NodeType::Variable); nX0b.HashValue = x0Var.Hash;
+    Tree const tree = Tree({ nX0a, nX0b, Node(NodeType::Mul) }).UpdateNodes();
+
+    auto const range = Operon::Range(0, ds.Rows());
+    Operon::RandomGenerator rng(1234);
+    auto const importance = Operon::PermutationImportance(tree, ds, target, range, rng, /*nRepeats=*/10);
+
+    REQUIRE(importance.size() == 1);
+    CHECK(importance.front().Variable == x0Var.Hash);
+    CHECK(importance.front().Mean > 0.5);
+}
+
 TEST_CASE("GradientImportance - relevant variable outranks unused one", "[analyzers][gradient_importance]")
 {
     auto ds = MakeLinearDataset();

--- a/test/source/implementation/permutation_importance.cpp
+++ b/test/source/implementation/permutation_importance.cpp
@@ -47,6 +47,26 @@ TEST_CASE("PermutationImportance - relevant variable outranks unused one", "[ana
     CHECK(importance.front().Mean > 0.5); // shuffling the one variable the model uses should tank R2
 }
 
+TEST_CASE("PermutationImportance - range-less overload matches an explicit whole-dataset range", "[analyzers][permutation_importance]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Tree const tree = Tree({ nX0 }).UpdateNodes();
+
+    Operon::RandomGenerator rngExplicit(1234);
+    auto const importanceExplicit = Operon::PermutationImportance(tree, ds, target, Operon::Range(0, ds.Rows()), rngExplicit, /*nRepeats=*/10);
+
+    Operon::RandomGenerator rngDefault(1234);
+    auto const importanceDefault = Operon::PermutationImportance(tree, ds, target, rngDefault, /*nRepeats=*/10);
+
+    REQUIRE(importanceExplicit.size() == importanceDefault.size());
+    CHECK(importanceExplicit.front().Mean == importanceDefault.front().Mean);
+    CHECK(importanceExplicit.front().Std == importanceDefault.front().Std);
+}
+
 TEST_CASE("PermutationImportance - a non-zero-start range aligns predictions against the matching target rows", "[analyzers][permutation_importance]")
 {
     // Same 200 real rows as MakeLinearDataset, with two junk rows prepended
@@ -140,6 +160,21 @@ TEST_CASE("GradientImportance - relevant variable outranks unused one", "[analyz
 
     CHECK(x0It->second > 0.9);  // d(x0)/d(x0) = 1 exactly
     CHECK(x1It->second < 1e-6); // d(0*x1)/d(x1) = 0 exactly
+}
+
+TEST_CASE("GradientImportance - range-less overload matches an explicit whole-dataset range", "[analyzers][gradient_importance]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Tree const tree = Tree({ nX0 }).UpdateNodes();
+
+    auto const importanceExplicit = Operon::GradientImportance(tree, ds, Operon::Range(0, ds.Rows()));
+    auto const importanceDefault = Operon::GradientImportance(tree, ds);
+
+    REQUIRE(importanceExplicit.size() == importanceDefault.size());
+    CHECK(importanceExplicit.front().second == importanceDefault.front().second);
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/permutation_importance.cpp
+++ b/test/source/implementation/permutation_importance.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "operon/analyzers/gradient_importance.hpp"
+#include "operon/analyzers/permutation_importance.hpp"
+#include "operon/core/dataset.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    auto MakeLinearDataset() -> Operon::Dataset {
+        // y = x0 + 0*x1: x0 matters, x1 is dataset noise the model ignores.
+        Operon::RandomGenerator rng(42);
+        std::uniform_real_distribution<Operon::Scalar> dist(-1.F, 1.F);
+        std::vector<Operon::Scalar> x0(200);
+        std::vector<Operon::Scalar> x1(200);
+        std::vector<Operon::Scalar> y(200);
+        for (size_t i = 0; i < x0.size(); ++i) {
+            x0[i] = dist(rng);
+            x1[i] = dist(rng);
+            y[i] = x0[i];
+        }
+        return Operon::Dataset({ "x0", "x1", "y" }, { x0, x1, y });
+    }
+} // namespace
+
+TEST_CASE("PermutationImportance - relevant variable outranks unused one", "[analyzers][permutation_importance]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Tree const tree = Tree({ nX0 }).UpdateNodes(); // y_hat = x0
+
+    auto const range = Operon::Range(0, ds.Rows());
+    Operon::RandomGenerator rng(1234);
+    auto const importance = Operon::PermutationImportance(tree, ds, target, range, rng, /*nRepeats=*/10);
+
+    // Only x0 appears in the tree, so only x0 gets an importance entry.
+    REQUIRE(importance.size() == 1);
+    CHECK(importance.front().Variable == x0.Hash);
+    CHECK(importance.front().Mean > 0.5); // shuffling the one variable the model uses should tank R2
+}
+
+TEST_CASE("GradientImportance - relevant variable outranks unused one", "[analyzers][gradient_importance]")
+{
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const x1 = ds.GetVariable("x1").value();
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Node nX1(NodeType::Variable); nX1.HashValue = x1.Hash;
+    Node nConstZero = Node::Constant(0.0);
+    // y_hat = x0 + 0*x1 - x1 appears in the tree (so it gets scored) but
+    // contributes nothing, unlike the shuffle-based test above where an unused
+    // variable would simply be absent from the result.
+    Tree const tree = Tree({ nX0, nX1, nConstZero, Node(NodeType::Mul), Node(NodeType::Add) }).UpdateNodes();
+
+    auto const range = Operon::Range(0, ds.Rows());
+    auto const importance = Operon::GradientImportance(tree, ds, range);
+
+    REQUIRE(importance.size() == 2);
+    auto const x0It = std::ranges::find(importance, x0.Hash, [](auto const& p) -> Operon::Hash { return p.first; });
+    auto const x1It = std::ranges::find(importance, x1.Hash, [](auto const& p) -> Operon::Hash { return p.first; });
+    REQUIRE(x0It != importance.end());
+    REQUIRE(x1It != importance.end());
+
+    CHECK(x0It->second > 0.9);  // d(x0)/d(x0) = 1 exactly
+    CHECK(x1It->second < 1e-6); // d(0*x1)/d(x1) = 0 exactly
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/permutation_importance.cpp
+++ b/test/source/implementation/permutation_importance.cpp
@@ -47,6 +47,42 @@ TEST_CASE("PermutationImportance - relevant variable outranks unused one", "[ana
     CHECK(importance.front().Mean > 0.5); // shuffling the one variable the model uses should tank R2
 }
 
+TEST_CASE("PermutationImportance - a non-zero-start range aligns predictions against the matching target rows", "[analyzers][permutation_importance]")
+{
+    // Same 200 real rows as MakeLinearDataset, with two junk rows prepended
+    // that only the [2, Rows()) range should ever see - if `actual` isn't
+    // sliced to `range` the same way the (perturbed) predictions are, this
+    // scores against the wrong rows and the two computations below diverge.
+    auto ds = MakeLinearDataset();
+    auto const x0 = ds.GetVariable("x0").value();
+    auto const target = ds.GetVariable("y").value().Hash;
+
+    std::vector<Operon::Scalar> x0p{ 100, 100 };
+    std::vector<Operon::Scalar> x1p{ 100, 100 };
+    std::vector<Operon::Scalar> yp{ 100, 100 };
+    auto appendCol = [](std::vector<Operon::Scalar>& dst, Operon::Span<Operon::Scalar const> src) -> void {
+        dst.insert(dst.end(), src.begin(), src.end());
+    };
+    appendCol(x0p, ds.GetValues(x0.Hash));
+    appendCol(x1p, ds.GetValues(ds.GetVariable("x1").value().Hash));
+    appendCol(yp, ds.GetValues(target));
+    Operon::Dataset const prefixed({ "x0", "x1", "y" }, { x0p, x1p, yp });
+
+    Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
+    Tree const tree = Tree({ nX0 }).UpdateNodes(); // y_hat = x0
+
+    Operon::RandomGenerator rngFull(1234);
+    auto const importanceFull = Operon::PermutationImportance(tree, ds, target, Operon::Range(0, ds.Rows()), rngFull, /*nRepeats=*/10);
+
+    Operon::RandomGenerator rngPrefixed(1234);
+    auto const importancePrefixed = Operon::PermutationImportance(tree, prefixed, target, Operon::Range(2, prefixed.Rows()), rngPrefixed, /*nRepeats=*/10);
+
+    REQUIRE(importanceFull.size() == 1);
+    REQUIRE(importancePrefixed.size() == 1);
+    CHECK(std::abs(importanceFull.front().Mean - importancePrefixed.front().Mean) < 1e-6);
+    CHECK(std::abs(importanceFull.front().Std - importancePrefixed.front().Std) < 1e-6);
+}
+
 TEST_CASE("GradientImportance - relevant variable outranks unused one", "[analyzers][gradient_importance]")
 {
     auto ds = MakeLinearDataset();


### PR DESCRIPTION
## Summary
Adds three model-interpretability analyzers, each perturbing a different thing and re-measuring R2:

- `NodeImpact` (node_impact.hpp) — splices a subtree out, replaces it with a Constant equal to the subtree's own mean prediction, re-evaluates. Per-node (postfix index), generalizes HeuristicLab's variable-impact idea from dataset columns to arbitrary tree nodes/subtrees. Returns empty for trees containing Ref nodes (DAG structural sharing).
- `PermutationImportance` (permutation_importance.hpp) — shuffles one input variable's column across a row range, re-evaluates the unmodified tree, repeats (default 5, matching sklearn's `permutation_importance` default) and reports mean/std. Mutates a single owning copy of the dataset in place per repeat via the new `Dataset::SetValues`, rather than cloning the whole dataset per repeat.
- `GradientImportance` (gradient_importance.hpp) — mean absolute value of `Interpreter::JacRevVariable` per input variable. Cheap, non-stochastic complement to permutation importance (one reverse-mode sweep per variable, no dataset perturbation).

Also adds `Dataset::SetValues(hash, range, values)`: an in-place, owning-dataset-only column mutator alongside the existing `Normalize`/`Standardize`/`PermuteRows` family, used by `PermutationImportance` to avoid rebuilding the dataset on every repeat.

## Test plan
- [x] `nix develop --command cmake --build build`
- [x] `./build/test/operon_test` (run from repo root) — 199 test cases, 23336 assertions, all pass
- [x] New tests: `node_impact.cpp`, `permutation_importance.cpp` (also covers `GradientImportance`)