### PR TITLE
fix(core): Tree::Simplify() must resync before scanning past a same-pass fold

### DIFF
--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -291,7 +291,7 @@ auto Tree::Simplify() -> Tree& {
                 if (handled) {
                     foldToConst(i, val); // n.Value == 1.0 for all function nodes
                     changed = true;
-                    continue;
+                    break; // see the `if (changed) { break; }` below - same reasoning
                 }
             }
 
@@ -421,6 +421,18 @@ auto Tree::Simplify() -> Tree& {
             }
             default: break;
             }
+
+            // A fold/rewrite at index i can leave any node's Length stale
+            // relative to the physical array (erase_if/UpdateNodes haven't
+            // run yet this pass) - Indices()/Children() for any later j
+            // read Length to step between siblings (see
+            // Subtree::SubtreeIterator::operator++), so continuing this
+            // scan past a just-mutated node risks walking off into
+            // already-disabled leftover nodes instead of the true next
+            // sibling. Bail out to resync (erase_if + UpdateNodes) before
+            // any later index is examined; the outer while(changed) picks
+            // the scan back up from a consistent array.
+            if (changed) { break; }
         }
 
         if (changed) {

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -422,16 +422,21 @@ auto Tree::Simplify() -> Tree& {
             default: break;
             }
 
-            // A fold/rewrite at index i can leave any node's Length stale
-            // relative to the physical array (erase_if/UpdateNodes haven't
-            // run yet this pass) - Indices()/Children() for any later j
-            // read Length to step between siblings (see
-            // Subtree::SubtreeIterator::operator++), so continuing this
-            // scan past a just-mutated node risks walking off into
-            // already-disabled leftover nodes instead of the true next
-            // sibling. Bail out to resync (erase_if + UpdateNodes) before
-            // any later index is examined; the outer while(changed) picks
-            // the scan back up from a consistent array.
+            // foldToConst above overwrites node i in place as a Length-0
+            // Constant leaf, while erase_if/UpdateNodes haven't run yet this
+            // pass - Indices()/Children() for any later j read Length to
+            // step between siblings (see Subtree::SubtreeIterator::
+            // operator++), so continuing this scan past a just-folded node
+            // risks walking off into already-disabled leftover nodes instead
+            // of the true next sibling. The other rewrites in this switch
+            // (identity/annihilator disables, Pow/Sqrt type rewrites) don't
+            // touch Length and would be safe to keep scanning past, but
+            // bailing out unconditionally on any `changed` is simplest and
+            // cheap here - Simplify() only runs per-candidate in
+            // algorithms/enumeration.cpp, not in the GP hot loop. Resync
+            // (erase_if + UpdateNodes) before any later index is examined;
+            // the outer while(changed) picks the scan back up from a
+            // consistent array.
             if (changed) { break; }
         }
 

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -289,6 +289,27 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         CHECK(tree[1].Type == NT::Abs);
         CHECK(tree[0].IsVariable());
     }
+
+    SECTION("regression: a same-pass fold must not corrupt an outer node's sibling lookup") {
+        // x + (2 + 3): the inner Add(2,3) folds to Const(5) via foldToConst,
+        // which overwrites that node in place as a bare Constant leaf
+        // (Length 0) *within the same linear pass* that later visits the
+        // outer Add. The outer Add's own child lookup (Indices(), see
+        // Subtree::SubtreeIterator::operator++ in subtree.hpp) steps back
+        // between siblings using Length - if it reads the inner Add's
+        // now-zeroed Length instead of its original span, it lands on a
+        // leftover disabled node instead of `x`, and can spuriously see both
+        // "children" as constant, collapsing the whole expression (losing
+        // the Variable dependency entirely) instead of correctly leaving a
+        // Var+Const(5).
+        Operon::Vector<Node> ns{ Var(), Const(2), Const(3), Node(NT::Add), Node(NT::Add) };
+        auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        REQUIRE(tree.Length() == 3);
+        CHECK(tree[0].IsVariable());
+        REQUIRE(tree[1].IsConstant());
+        CHECK(tree[1].Value == Catch::Approx(5.0));
+        CHECK(tree[2].Type == NT::Add);
+    }
 }
 
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary
`Tree::Simplify()`'s constant-folding (`foldToConst`) overwrites a node in place as a bare `Constant` leaf, resetting its `Length` to 0 - but this happens mid-scan, before the pass's single end-of-loop `erase_if`+`UpdateNodes()` resync. A later (ancestor) node's own child lookup (`Indices()`/`Children()`, via `Subtree::SubtreeIterator::operator++`, which steps between siblings using `Length`) can read that just-zeroed `Length` instead of the node's true original span, landing on a stale/disabled leftover node instead of the real sibling. On a tree with multiple foldable subexpressions this can spuriously make an ancestor's children look all-constant, cascading to collapse the entire expression into a single scalar - discarding real variable dependence.

Fixed by bailing out to resync immediately after any single fold, rather than letting a whole pass batch up multiple folds before resyncing. This mirrors the same protective pattern already used in `Tree::Reduce()` (which never has this bug, since it never rewrites a node's `Length` mid-scan) and in symreg-cpp's `Sentence::Simplify()`, which breaks out of its scan the instant any node gets disabled.

## Reproduction
Confirmed via `operon_nsgp`-generated Friedman-I Pareto front models: re-parsing a model's exported infix expression and calling `.Simplify()` on it collapsed a real, previously R2≈0.80 model down to a single constant.

## Test plan
- [x] `nix develop --command cmake --build build`
- [x] `./build/test/operon_test '~[performance]'` - 195 test cases, 23328 assertions, all pass
- [x] New regression test (`test/source/implementation/details.cpp`, "Tree::Simplify" test case): `Var + (2 + 3)` must simplify to `Var + Const(5)`, not collapse to a bare constant - fails on the pre-fix code (`tree.Length() == 1` instead of 3), passes after the fix