### PR TITLE
Add generic per-generation probe infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(
     source/algorithms/enumeration.cpp
     source/algorithms/gp.cpp
     source/algorithms/nsga2.cpp
+    source/algorithms/probes/chain.cpp
+    source/algorithms/probes/registry.cpp
     source/algorithms/solution_archive.cpp
     source/core/dataset.cpp
     source/core/distance.cpp

--- a/include/operon/algorithms/probes/chain.hpp
+++ b/include/operon/algorithms/probes/chain.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 #include "operon/algorithms/probes/probe.hpp"
@@ -24,7 +25,7 @@ struct RecordSink {
     auto operator=(RecordSink const&) -> RecordSink& = default;
     auto operator=(RecordSink&&) noexcept -> RecordSink& = default;
 
-    virtual auto Write(std::size_t generation, ResultRecord const& record) -> void = 0;
+    virtual auto Write(ResultRecord const& record) -> void = 0;
     virtual auto Flush() -> void { }
 };
 
@@ -39,7 +40,7 @@ public:
     auto operator=(JsonlSink const&) -> JsonlSink& = delete;
     auto operator=(JsonlSink&&) noexcept -> JsonlSink&;
 
-    auto Write(std::size_t generation, ResultRecord const& record) -> void override;
+    auto Write(ResultRecord const& record) -> void override;
     auto Flush() -> void override;
 
     // False if the file failed to open - Write() then silently no-ops.
@@ -61,22 +62,28 @@ public:
     ProbeChain() = default;
     ~ProbeChain() { Finish(); }
     ProbeChain(ProbeChain const&) = delete;
+    // Move-construction only, not move-assignment: this needs to stay
+    // movable so it can be returned by value from a future config-loading
+    // factory, but a defaulted move-assign would member-wise overwrite
+    // *this's entries_ without ever calling their Finish() - move-construct
+    // into a fresh chain instead.
     ProbeChain(ProbeChain&&) noexcept = default;
     auto operator=(ProbeChain const&) -> ProbeChain& = delete;
-    // Spelled out explicitly because the user-declared destructor otherwise
-    // suppresses the implicit move ops, and ProbeChain needs to stay
-    // movable (e.g. returned by value from a future config-loading factory).
-    auto operator=(ProbeChain&&) noexcept -> ProbeChain& = default;
+    auto operator=(ProbeChain&&) -> ProbeChain& = delete;
 
     // every == 0 disables the probe without removing it, so config-driven
-    // callers can toggle a probe off without editing the entry list.
+    // callers can toggle a probe off without editing the entry list. Note
+    // Finish() below still runs a disabled probe's Finish() - only the
+    // per-generation call is skipped.
     auto Add(std::unique_ptr<GenerationProbe> probe, std::size_t every = 1, std::size_t offset = 0) -> void;
     auto SetSink(std::unique_ptr<RecordSink> sink) -> void;
 
     [[nodiscard]] auto Empty() const noexcept -> bool { return entries_.empty(); }
 
     // Call once per generation (e.g. from an algorithm's ReportCallback).
-    // Only writes to the sink if at least one probe actually ran.
+    // Only writes to the sink if at least one probe actually ran. Keys
+    // "generation" and "elapsed" are reserved (set here before any probe
+    // runs); a probe that emits either overwrites it via insert_or_assign.
     auto operator()(GeneticAlgorithmBase const& algo) -> void;
 
     // Call once after the algorithm's Run() returns. Idempotent - the
@@ -94,6 +101,9 @@ private:
     std::unique_ptr<RecordSink> sink_;
     bool finished_{false};
 };
+
+static_assert(std::is_move_constructible_v<ProbeChain> && !std::is_move_assignable_v<ProbeChain>,
+              "ProbeChain must stay move-constructible but not move-assignable - see the class comment");
 
 } // namespace Operon
 

--- a/include/operon/algorithms/probes/chain.hpp
+++ b/include/operon/algorithms/probes/chain.hpp
@@ -46,6 +46,11 @@ public:
     auto Write(std::size_t generation, ResultRecord const& record) -> void override;
     auto Flush() -> void override;
 
+    // False if the file failed to open (error already printed to stderr by
+    // the constructor) - Write() silently no-ops in that state, so a caller
+    // that cares whether its trace actually landed should check this.
+    [[nodiscard]] auto IsOpen() const -> bool;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
@@ -63,6 +68,17 @@ private:
 // generation, on whichever thread runs the report task.
 class OPERON_EXPORT ProbeChain {
 public:
+    ProbeChain() = default;
+    ~ProbeChain() { Finish(); }
+    ProbeChain(ProbeChain const&) = delete;
+    ProbeChain(ProbeChain&&) noexcept = default;
+    auto operator=(ProbeChain const&) -> ProbeChain& = delete;
+    // A user-declared destructor suppresses the implicitly-generated move
+    // operations, so they're spelled out here explicitly - ProbeChain needs
+    // to stay movable (e.g. returned by value from a future
+    // LoadProbeConfig(path) -> ProbeChain factory in the CLI-wiring PR).
+    auto operator=(ProbeChain&&) noexcept -> ProbeChain& = default;
+
     // every == 0 disables the probe (kept registered but never invoked) -
     // this is deliberately not rejected/asserted against so config-driven
     // callers can toggle a probe off without removing its entry.
@@ -78,7 +94,10 @@ public:
     // scheduled don't produce empty lines.
     auto operator()(GeneticAlgorithmBase const& algo) -> void;
 
-    // Call once after the algorithm's Run() returns.
+    // Call once after the algorithm's Run() returns. Idempotent - safe to
+    // call explicitly and then let the ProbeChain go out of scope (the
+    // destructor also calls this, as a safety net for callers who forget or
+    // unwind via an exception before reaching an explicit call).
     auto Finish() -> void;
 
 private:
@@ -90,6 +109,7 @@ private:
 
     std::vector<Entry> entries_;
     std::unique_ptr<RecordSink> sink_;
+    bool finished_{false};
 };
 
 } // namespace Operon

--- a/include/operon/algorithms/probes/chain.hpp
+++ b/include/operon/algorithms/probes/chain.hpp
@@ -15,8 +15,7 @@
 namespace Operon {
 
 // Consumes one generation's ResultRecord. Separate from GenerationProbe so
-// probes stay agnostic of the output format (NDJSON today, something else
-// later) and multiple probes can share one sink/one file.
+// probes stay agnostic of the output format and can share one sink/file.
 struct RecordSink {
     virtual ~RecordSink() = default;
     RecordSink() = default;
@@ -29,11 +28,8 @@ struct RecordSink {
     virtual auto Flush() -> void { }
 };
 
-// Writes one JSON object per line (NDJSON). Chosen over a fixed-column
-// format (e.g. CSV) because ResultRecord is an unordered, self-describing
-// bag of keys that can differ from one generation to the next depending on
-// which probes ran that generation - NDJSON records their keys inline
-// instead of requiring a stable schema up front.
+// Writes one JSON object per line (NDJSON) - chosen over a fixed-column
+// format like CSV because ResultRecord's keys can differ per generation.
 class OPERON_EXPORT JsonlSink final : public RecordSink {
 public:
     explicit JsonlSink(std::string_view path);
@@ -46,9 +42,7 @@ public:
     auto Write(std::size_t generation, ResultRecord const& record) -> void override;
     auto Flush() -> void override;
 
-    // False if the file failed to open (error already printed to stderr by
-    // the constructor) - Write() silently no-ops in that state, so a caller
-    // that cares whether its trace actually landed should check this.
+    // False if the file failed to open - Write() then silently no-ops.
     [[nodiscard]] auto IsOpen() const -> bool;
 
 private:
@@ -57,15 +51,11 @@ private:
 };
 
 // Runs a set of GenerationProbes, each on its own (every, offset) schedule,
-// and hands the combined per-generation record to one shared sink.
-// Deliberately not integrated with taskflow's ObserverInterface: that
-// observes per-task entry/exit across worker threads (used today only for
-// PhaseTimer's wall-clock profiling) and carries no domain data - a probe
-// would still need a side channel back to the algorithm's state, which the
-// existing ReportCallback closure already provides directly at exactly
-// generation granularity. ProbeChain is meant to be invoked from inside
-// that same report lambda (see cli/source/probes_config.hpp), one call per
-// generation, on whichever thread runs the report task.
+// and hands the combined per-generation record to one shared sink. Not
+// integrated with taskflow's ObserverInterface: that observes per-task
+// entry/exit with no domain data, whereas the existing ReportCallback
+// closure already gives direct, generation-granular access to algorithm
+// state. ProbeChain is meant to be invoked from inside that report lambda.
 class OPERON_EXPORT ProbeChain {
 public:
     ProbeChain() = default;
@@ -73,31 +63,24 @@ public:
     ProbeChain(ProbeChain const&) = delete;
     ProbeChain(ProbeChain&&) noexcept = default;
     auto operator=(ProbeChain const&) -> ProbeChain& = delete;
-    // A user-declared destructor suppresses the implicitly-generated move
-    // operations, so they're spelled out here explicitly - ProbeChain needs
-    // to stay movable (e.g. returned by value from a future
-    // LoadProbeConfig(path) -> ProbeChain factory in the CLI-wiring PR).
+    // Spelled out explicitly because the user-declared destructor otherwise
+    // suppresses the implicit move ops, and ProbeChain needs to stay
+    // movable (e.g. returned by value from a future config-loading factory).
     auto operator=(ProbeChain&&) noexcept -> ProbeChain& = default;
 
-    // every == 0 disables the probe (kept registered but never invoked) -
-    // this is deliberately not rejected/asserted against so config-driven
-    // callers can toggle a probe off without removing its entry.
+    // every == 0 disables the probe without removing it, so config-driven
+    // callers can toggle a probe off without editing the entry list.
     auto Add(std::unique_ptr<GenerationProbe> probe, std::size_t every = 1, std::size_t offset = 0) -> void;
     auto SetSink(std::unique_ptr<RecordSink> sink) -> void;
 
     [[nodiscard]] auto Empty() const noexcept -> bool { return entries_.empty(); }
 
-    // Intended to be called once per generation (e.g. from an algorithm's
-    // ReportCallback). Builds this generation's record, runs every probe
-    // whose schedule matches, and writes the record via the sink - but only
-    // if at least one probe actually ran, so generations with nothing
-    // scheduled don't produce empty lines.
+    // Call once per generation (e.g. from an algorithm's ReportCallback).
+    // Only writes to the sink if at least one probe actually ran.
     auto operator()(GeneticAlgorithmBase const& algo) -> void;
 
-    // Call once after the algorithm's Run() returns. Idempotent - safe to
-    // call explicitly and then let the ProbeChain go out of scope (the
-    // destructor also calls this, as a safety net for callers who forget or
-    // unwind via an exception before reaching an explicit call).
+    // Call once after the algorithm's Run() returns. Idempotent - the
+    // destructor also calls this as a safety net.
     auto Finish() -> void;
 
 private:

--- a/include/operon/algorithms/probes/chain.hpp
+++ b/include/operon/algorithms/probes/chain.hpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_PROBES_CHAIN_HPP
+#define OPERON_ALGORITHMS_PROBES_CHAIN_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "operon/algorithms/probes/probe.hpp"
+#include "operon/operon_export.hpp"
+
+namespace Operon {
+
+// Consumes one generation's ResultRecord. Separate from GenerationProbe so
+// probes stay agnostic of the output format (NDJSON today, something else
+// later) and multiple probes can share one sink/one file.
+struct RecordSink {
+    virtual ~RecordSink() = default;
+    RecordSink() = default;
+    RecordSink(RecordSink const&) = default;
+    RecordSink(RecordSink&&) noexcept = default;
+    auto operator=(RecordSink const&) -> RecordSink& = default;
+    auto operator=(RecordSink&&) noexcept -> RecordSink& = default;
+
+    virtual auto Write(std::size_t generation, ResultRecord const& record) -> void = 0;
+    virtual auto Flush() -> void { }
+};
+
+// Writes one JSON object per line (NDJSON). Chosen over a fixed-column
+// format (e.g. CSV) because ResultRecord is an unordered, self-describing
+// bag of keys that can differ from one generation to the next depending on
+// which probes ran that generation - NDJSON records their keys inline
+// instead of requiring a stable schema up front.
+class OPERON_EXPORT JsonlSink final : public RecordSink {
+public:
+    explicit JsonlSink(std::string_view path);
+    ~JsonlSink() override;
+    JsonlSink(JsonlSink const&) = delete;
+    JsonlSink(JsonlSink&&) noexcept;
+    auto operator=(JsonlSink const&) -> JsonlSink& = delete;
+    auto operator=(JsonlSink&&) noexcept -> JsonlSink&;
+
+    auto Write(std::size_t generation, ResultRecord const& record) -> void override;
+    auto Flush() -> void override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+// Runs a set of GenerationProbes, each on its own (every, offset) schedule,
+// and hands the combined per-generation record to one shared sink.
+// Deliberately not integrated with taskflow's ObserverInterface: that
+// observes per-task entry/exit across worker threads (used today only for
+// PhaseTimer's wall-clock profiling) and carries no domain data - a probe
+// would still need a side channel back to the algorithm's state, which the
+// existing ReportCallback closure already provides directly at exactly
+// generation granularity. ProbeChain is meant to be invoked from inside
+// that same report lambda (see cli/source/probes_config.hpp), one call per
+// generation, on whichever thread runs the report task.
+class OPERON_EXPORT ProbeChain {
+public:
+    // every == 0 disables the probe (kept registered but never invoked) -
+    // this is deliberately not rejected/asserted against so config-driven
+    // callers can toggle a probe off without removing its entry.
+    auto Add(std::unique_ptr<GenerationProbe> probe, std::size_t every = 1, std::size_t offset = 0) -> void;
+    auto SetSink(std::unique_ptr<RecordSink> sink) -> void;
+
+    [[nodiscard]] auto Empty() const noexcept -> bool { return entries_.empty(); }
+
+    // Intended to be called once per generation (e.g. from an algorithm's
+    // ReportCallback). Builds this generation's record, runs every probe
+    // whose schedule matches, and writes the record via the sink - but only
+    // if at least one probe actually ran, so generations with nothing
+    // scheduled don't produce empty lines.
+    auto operator()(GeneticAlgorithmBase const& algo) -> void;
+
+    // Call once after the algorithm's Run() returns.
+    auto Finish() -> void;
+
+private:
+    struct Entry {
+        std::unique_ptr<GenerationProbe> Probe;
+        std::size_t Every{1};
+        std::size_t Offset{0};
+    };
+
+    std::vector<Entry> entries_;
+    std::unique_ptr<RecordSink> sink_;
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/algorithms/probes/probe.hpp
+++ b/include/operon/algorithms/probes/probe.hpp
@@ -16,9 +16,7 @@
 namespace Operon {
 
 // A single named value emitted by a probe for one generation. Vectors cover
-// per-individual/per-variable readings (e.g. a diversity probe's raw
-// pairwise distances) that don't collapse to one scalar; scalars cover
-// everything else (counts, rates, sizes).
+// per-individual/per-variable readings that don't collapse to one scalar.
 using ResultValue = std::variant<
     std::int64_t,
     double,
@@ -27,22 +25,16 @@ using ResultValue = std::variant<
     std::vector<std::int64_t>,
     std::vector<double>>;
 
-// One generation's worth of named values, handed to a RecordSink. Deliberately
-// not a fixed-column struct: Operon::Map is unordered (ankerl::unordered_dense),
-// so probes are free to emit whatever keys are relevant that generation and the
-// sink (NDJSON) serializes each record as a self-describing object.
+// One generation's worth of named values, handed to a RecordSink. Not a
+// fixed-column struct: probes are free to emit whatever keys apply that
+// generation, and the sink (NDJSON) serializes each record self-describingly.
 using ResultRecord = Operon::Map<std::string, ResultValue>;
 
 // Read-only view into the running algorithm plus a handle to the current
-// generation's record. Deliberately built on GeneticAlgorithmBase rather
-// than a narrower per-algorithm type: GeneticProgrammingAlgorithm and NSGA2
-// both derive from it and share this exact surface, so a probe written
-// against ProbeContext works for either without modification.
-//
-// GrammarEnumerationAlgorithm is intentionally not supported here: it has no
-// population and no Parents()/Offspring(), and its ReportCallback fires per
-// budget level, not per generation - forcing it under this interface would
-// be the wrong abstraction rather than a missing feature.
+// generation's record. Built on GeneticAlgorithmBase (not a narrower
+// per-algorithm type) so a probe works for both GeneticProgrammingAlgorithm
+// and NSGA2 unmodified. GrammarEnumerationAlgorithm has no population and
+// reports per budget level, not per generation, so it's out of scope here.
 class ProbeContext {
 public:
     ProbeContext(GeneticAlgorithmBase const& algo, ResultRecord& record)
@@ -65,20 +57,14 @@ public:
     }
 
 private:
-    // Reference members are intentional: ProbeContext is a throwaway view
-    // constructed fresh by ProbeChain once per generation and passed by
-    // reference to each probe in turn - it never outlives that call and is
-    // never copied or stored, so there's no dangling-reference hazard to
-    // guard against by switching to pointers.
+    // Reference members are fine here: ProbeContext is a throwaway view
+    // built fresh by ProbeChain each generation and never stored or copied.
     GeneticAlgorithmBase const& algo_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     ResultRecord& record_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 
-// A pluggable, per-generation diagnostic. Deliberately one interface, not
-// split by output kind (e.g. "emits a metric" vs "writes an artifact"): a
-// probe may do either or both via the same call - see PopulationTraceProbe
-// (writes its own file) vs CacheHitRateProbe (only calls Emit) vs
-// StructuralDiversityProbe (could do both) in the sibling headers.
+// A pluggable, per-generation diagnostic. One interface, not split by output
+// kind: a probe may emit a scalar, write its own artifact, or both.
 struct GenerationProbe {
     virtual ~GenerationProbe() = default;
     GenerationProbe() = default;

--- a/include/operon/algorithms/probes/probe.hpp
+++ b/include/operon/algorithms/probes/probe.hpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_PROBES_PROBE_HPP
+#define OPERON_ALGORITHMS_PROBES_PROBE_HPP
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "operon/algorithms/ga_base.hpp"
+#include "operon/core/types.hpp"
+
+namespace Operon {
+
+// A single named value emitted by a probe for one generation. Vectors cover
+// per-individual/per-variable readings (e.g. a diversity probe's raw
+// pairwise distances) that don't collapse to one scalar; scalars cover
+// everything else (counts, rates, sizes).
+using ResultValue = std::variant<
+    std::int64_t,
+    double,
+    bool,
+    std::string,
+    std::vector<std::int64_t>,
+    std::vector<double>>;
+
+// One generation's worth of named values, handed to a RecordSink. Deliberately
+// not a fixed-column struct: Operon::Map is unordered (ankerl::unordered_dense),
+// so probes are free to emit whatever keys are relevant that generation and the
+// sink (NDJSON) serializes each record as a self-describing object.
+using ResultRecord = Operon::Map<std::string, ResultValue>;
+
+// Read-only view into the running algorithm plus a handle to the current
+// generation's record. Deliberately built on GeneticAlgorithmBase rather
+// than a narrower per-algorithm type: GeneticProgrammingAlgorithm and NSGA2
+// both derive from it and share this exact surface, so a probe written
+// against ProbeContext works for either without modification.
+//
+// GrammarEnumerationAlgorithm is intentionally not supported here: it has no
+// population and no Parents()/Offspring(), and its ReportCallback fires per
+// budget level, not per generation - forcing it under this interface would
+// be the wrong abstraction rather than a missing feature.
+class ProbeContext {
+public:
+    ProbeContext(GeneticAlgorithmBase const& algo, ResultRecord& record)
+        : algo_(algo)
+        , record_(record)
+    {
+    }
+
+    [[nodiscard]] auto Algorithm() const -> GeneticAlgorithmBase const& { return algo_; }
+    [[nodiscard]] auto Generation() const -> std::size_t { return algo_.Generation(); }
+    [[nodiscard]] auto Parents() const { return algo_.Parents(); }
+    [[nodiscard]] auto Offspring() const { return algo_.Offspring(); }
+    [[nodiscard]] auto Config() const { return algo_.GetConfig(); }
+    [[nodiscard]] auto Problem() const -> Operon::Problem const* { return algo_.GetProblem(); }
+
+    // Sets (or overwrites) a named value in this generation's record.
+    auto Emit(std::string key, ResultValue value) -> void
+    {
+        record_.insert_or_assign(std::move(key), std::move(value));
+    }
+
+private:
+    // Reference members are intentional: ProbeContext is a throwaway view
+    // constructed fresh by ProbeChain once per generation and passed by
+    // reference to each probe in turn - it never outlives that call and is
+    // never copied or stored, so there's no dangling-reference hazard to
+    // guard against by switching to pointers.
+    GeneticAlgorithmBase const& algo_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    ResultRecord& record_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+// A pluggable, per-generation diagnostic. Deliberately one interface, not
+// split by output kind (e.g. "emits a metric" vs "writes an artifact"): a
+// probe may do either or both via the same call - see PopulationTraceProbe
+// (writes its own file) vs CacheHitRateProbe (only calls Emit) vs
+// StructuralDiversityProbe (could do both) in the sibling headers.
+struct GenerationProbe {
+    virtual ~GenerationProbe() = default;
+    GenerationProbe() = default;
+    GenerationProbe(GenerationProbe const&) = default;
+    GenerationProbe(GenerationProbe&&) noexcept = default;
+    auto operator=(GenerationProbe const&) -> GenerationProbe& = default;
+    auto operator=(GenerationProbe&&) noexcept -> GenerationProbe& = default;
+
+    // Called once per generation, subject to the scheduling interval a
+    // ProbeChain applies before invoking this.
+    virtual auto operator()(ProbeContext& ctx) -> void = 0;
+
+    // Called once after the algorithm's Run() returns, for probes that
+    // buffer state or hold an open file (e.g. flushing/closing a trace).
+    virtual auto Finish() -> void { }
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/algorithms/probes/registry.hpp
+++ b/include/operon/algorithms/probes/registry.hpp
@@ -16,23 +16,17 @@
 namespace Operon {
 
 // A single probe config parameter, already parsed down to a plain scalar -
-// deliberately not glz::json_t (or any glaze type): glaze is a PRIVATE
-// dependency confined to source/*.cpp translation units throughout this
-// codebase (see core/serialization.cpp's header comment), and ProbeParams
-// lives in a public header, so the JSON-vs-YAML-vs-whatever config format
-// question stays entirely on the parsing side (cli/source/probes_config.cpp)
-// - this registry only ever sees the result.
+// not glz::json_t: glaze stays a PRIVATE dependency confined to source/*.cpp
+// (see core/serialization.cpp), and ProbeParams lives in a public header, so
+// the JSON-vs-YAML config format question stays on the parsing side
+// (cli/source/probes_config.cpp).
 //
-// A thin wrapper around std::variant, not a bare alias: a bare
-// std::variant<std::int64_t, double, bool, std::string> has a well-known
-// overload-resolution trap where initializing it from a `const char*`
-// (e.g. a string literal at a config-parsing call site) silently selects
-// the `bool` alternative instead of `std::string` - pointer-to-bool is a
-// built-in standard conversion, preferred over the user-defined conversion
-// to std::string. The deleted `char const*` constructor below is an exact
-// match for that case, so it wins the overload resolution instead and
-// turns the mistake into a compile error - construct std::string values
-// explicitly (`ProbeParamValue{std::string{...}}`) at the parse boundary.
+// Wraps std::variant instead of aliasing it: a bare
+// variant<int64_t, double, bool, string> silently binds a `const char*` to
+// `bool` rather than `string` (pointer-to-bool beats the user-defined string
+// conversion). The deleted char const* constructor below is an exact match
+// for that case, turning the mistake into a compile error - construct
+// std::string values explicitly (`ProbeParamValue{std::string{...}}`).
 class ProbeParamValue {
 public:
     ProbeParamValue(std::int64_t v) : value_(v) { } // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
@@ -51,8 +45,7 @@ private:
     std::variant<std::int64_t, double, bool, std::string> value_;
 };
 
-// Keeps the trap closed even if this class is edited later (e.g. someone
-// adds a std::string_view constructor that reopens a similar ambiguity).
+// Keeps the trap closed even if this class changes later.
 static_assert(!std::is_constructible_v<ProbeParamValue, char const*>,
               "ProbeParamValue must reject char const* to avoid silently binding to bool - construct std::string explicitly");
 
@@ -61,20 +54,17 @@ using ProbeParams = Operon::Map<std::string, ProbeParamValue>;
 using ProbeFactory = std::function<std::unique_ptr<GenerationProbe>(ProbeParams const&)>;
 
 // Name -> factory registry, so adding a new probe type never requires
-// touching config-parsing code - only a Register() call for it. Plain value
-// type, not a singleton: callers (e.g. the CLI) construct one, populate it
-// (RegisterBuiltinProbes() plus any of their own), and use it to build a
-// ProbeChain from a parsed config. No static/global registry, so tests can
-// use an isolated instance without cross-test state.
+// touching config-parsing code. Plain value type, not a singleton: callers
+// construct one, populate it, and use it to build a ProbeChain from a
+// parsed config.
 class OPERON_EXPORT ProbeRegistry {
 public:
     auto Register(std::string type, ProbeFactory factory) -> void;
 
     [[nodiscard]] auto Contains(std::string const& type) const -> bool;
 
-    // Returns nullptr if `type` was never registered - callers are
-    // expected to report the unknown type themselves (they have the
-    // context, e.g. a config file path/line, that this registry doesn't).
+    // Returns nullptr if `type` was never registered - the caller reports
+    // the unknown type itself (it has the config-file context to do so).
     [[nodiscard]] auto Create(std::string const& type, ProbeParams const& params) const -> std::unique_ptr<GenerationProbe>;
 
 private:

--- a/include/operon/algorithms/probes/registry.hpp
+++ b/include/operon/algorithms/probes/registry.hpp
@@ -21,6 +21,13 @@ namespace Operon {
 // lives in a public header, so the JSON-vs-YAML-vs-whatever config format
 // question stays entirely on the parsing side (cli/source/probes_config.cpp)
 // - this registry only ever sees the result.
+// Caution for the config-parsing side (cli/source/probes_config.cpp):
+// initializing this variant from a `const char*` selects the `bool`
+// alternative, not `std::string` - a well-known variant overload-resolution
+// trap (pointer-to-bool is a standard conversion, favored over the
+// user-defined conversion to std::string). Construct std::string values
+// explicitly (e.g. ProbeParamValue{std::string{...}}) at the parse boundary
+// rather than relying on implicit conversion from a string literal.
 using ProbeParamValue = std::variant<std::int64_t, double, bool, std::string>;
 using ProbeParams = Operon::Map<std::string, ProbeParamValue>;
 

--- a/include/operon/algorithms/probes/registry.hpp
+++ b/include/operon/algorithms/probes/registry.hpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <variant>
 
 #include "operon/algorithms/probes/probe.hpp"
@@ -14,21 +15,47 @@
 
 namespace Operon {
 
-// A probe's config-file parameters, already parsed down to plain scalars -
+// A single probe config parameter, already parsed down to a plain scalar -
 // deliberately not glz::json_t (or any glaze type): glaze is a PRIVATE
 // dependency confined to source/*.cpp translation units throughout this
 // codebase (see core/serialization.cpp's header comment), and ProbeParams
 // lives in a public header, so the JSON-vs-YAML-vs-whatever config format
 // question stays entirely on the parsing side (cli/source/probes_config.cpp)
 // - this registry only ever sees the result.
-// Caution for the config-parsing side (cli/source/probes_config.cpp):
-// initializing this variant from a `const char*` selects the `bool`
-// alternative, not `std::string` - a well-known variant overload-resolution
-// trap (pointer-to-bool is a standard conversion, favored over the
-// user-defined conversion to std::string). Construct std::string values
-// explicitly (e.g. ProbeParamValue{std::string{...}}) at the parse boundary
-// rather than relying on implicit conversion from a string literal.
-using ProbeParamValue = std::variant<std::int64_t, double, bool, std::string>;
+//
+// A thin wrapper around std::variant, not a bare alias: a bare
+// std::variant<std::int64_t, double, bool, std::string> has a well-known
+// overload-resolution trap where initializing it from a `const char*`
+// (e.g. a string literal at a config-parsing call site) silently selects
+// the `bool` alternative instead of `std::string` - pointer-to-bool is a
+// built-in standard conversion, preferred over the user-defined conversion
+// to std::string. The deleted `char const*` constructor below is an exact
+// match for that case, so it wins the overload resolution instead and
+// turns the mistake into a compile error - construct std::string values
+// explicitly (`ProbeParamValue{std::string{...}}`) at the parse boundary.
+class ProbeParamValue {
+public:
+    ProbeParamValue(std::int64_t v) : value_(v) { } // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+    ProbeParamValue(double v) : value_(v) { } // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+    ProbeParamValue(bool v) : value_(v) { } // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+    ProbeParamValue(std::string v) : value_(std::move(v)) { } // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+    ProbeParamValue(char const*) = delete; // use std::string(...) explicitly - see class comment
+
+    template <typename T>
+    [[nodiscard]] auto Holds() const -> bool { return std::holds_alternative<T>(value_); }
+
+    template <typename T>
+    [[nodiscard]] auto Get() const -> T const& { return std::get<T>(value_); }
+
+private:
+    std::variant<std::int64_t, double, bool, std::string> value_;
+};
+
+// Keeps the trap closed even if this class is edited later (e.g. someone
+// adds a std::string_view constructor that reopens a similar ambiguity).
+static_assert(!std::is_constructible_v<ProbeParamValue, char const*>,
+              "ProbeParamValue must reject char const* to avoid silently binding to bool - construct std::string explicitly");
+
 using ProbeParams = Operon::Map<std::string, ProbeParamValue>;
 
 using ProbeFactory = std::function<std::unique_ptr<GenerationProbe>(ProbeParams const&)>;

--- a/include/operon/algorithms/probes/registry.hpp
+++ b/include/operon/algorithms/probes/registry.hpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_PROBES_REGISTRY_HPP
+#define OPERON_ALGORITHMS_PROBES_REGISTRY_HPP
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include "operon/algorithms/probes/probe.hpp"
+#include "operon/operon_export.hpp"
+
+namespace Operon {
+
+// A probe's config-file parameters, already parsed down to plain scalars -
+// deliberately not glz::json_t (or any glaze type): glaze is a PRIVATE
+// dependency confined to source/*.cpp translation units throughout this
+// codebase (see core/serialization.cpp's header comment), and ProbeParams
+// lives in a public header, so the JSON-vs-YAML-vs-whatever config format
+// question stays entirely on the parsing side (cli/source/probes_config.cpp)
+// - this registry only ever sees the result.
+using ProbeParamValue = std::variant<std::int64_t, double, bool, std::string>;
+using ProbeParams = Operon::Map<std::string, ProbeParamValue>;
+
+using ProbeFactory = std::function<std::unique_ptr<GenerationProbe>(ProbeParams const&)>;
+
+// Name -> factory registry, so adding a new probe type never requires
+// touching config-parsing code - only a Register() call for it. Plain value
+// type, not a singleton: callers (e.g. the CLI) construct one, populate it
+// (RegisterBuiltinProbes() plus any of their own), and use it to build a
+// ProbeChain from a parsed config. No static/global registry, so tests can
+// use an isolated instance without cross-test state.
+class OPERON_EXPORT ProbeRegistry {
+public:
+    auto Register(std::string type, ProbeFactory factory) -> void;
+
+    [[nodiscard]] auto Contains(std::string const& type) const -> bool;
+
+    // Returns nullptr if `type` was never registered - callers are
+    // expected to report the unknown type themselves (they have the
+    // context, e.g. a config file path/line, that this registry doesn't).
+    [[nodiscard]] auto Create(std::string const& type, ProbeParams const& params) const -> std::unique_ptr<GenerationProbe>;
+
+private:
+    Operon::Map<std::string, ProbeFactory> factories_;
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -153,10 +153,10 @@ public:
     // the algorithm has fully stopped (e.g. after GeneticAlgorithm::Run returns).
     auto Clear() -> void;
 
-    [[nodiscard]] auto Hits() const -> std::size_t { return hits_.load(); }
+    [[nodiscard]] auto Hits() const -> std::size_t { return hits_.load(std::memory_order_relaxed); }
     // Total TryGet() calls regardless of outcome - the denominator Hits()
     // needs to express an actual hit *rate* rather than a raw count.
-    [[nodiscard]] auto Lookups() const -> std::size_t { return lookups_.load(); }
+    [[nodiscard]] auto Lookups() const -> std::size_t { return lookups_.load(std::memory_order_relaxed); }
     [[nodiscard]] auto Size() const -> std::size_t;
 };
 

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -97,6 +97,7 @@ class OPERON_EXPORT Zobrist {
     std::unique_ptr<TranspositionTable> tt_;
 
     mutable std::atomic<std::size_t> hits_{0};
+    mutable std::atomic<std::size_t> lookups_{0};
 
 public:
     // variableHashes must include every variable hash that can appear in a tree.
@@ -153,6 +154,9 @@ public:
     auto Clear() -> void;
 
     [[nodiscard]] auto Hits() const -> std::size_t { return hits_.load(); }
+    // Total TryGet() calls regardless of outcome - the denominator Hits()
+    // needs to express an actual hit *rate* rather than a raw count.
+    [[nodiscard]] auto Lookups() const -> std::size_t { return lookups_.load(); }
     [[nodiscard]] auto Size() const -> std::size_t;
 };
 

--- a/source/algorithms/probes/chain.cpp
+++ b/source/algorithms/probes/chain.cpp
@@ -22,9 +22,8 @@ JsonlSink::JsonlSink(std::string_view path)
     : impl_(std::make_unique<Impl>())
 {
     impl_->Path = std::string(path);
-    // Truncates by default: silently mixing an old trace's lines into a new
-    // run (if this instead opened in append mode) would be a worse surprise
-    // than losing an old file the caller pointed a fresh sink at.
+    // Truncates by default rather than appending, to avoid silently mixing
+    // an old trace's lines into a new run.
     impl_->Out.open(impl_->Path, std::ios::out | std::ios::trunc);
     if (!impl_->Out) {
         fmt::print(stderr, "JsonlSink: failed to open '{}' for writing\n", impl_->Path);
@@ -38,11 +37,8 @@ auto JsonlSink::operator=(JsonlSink&&) noexcept -> JsonlSink& = default;
 auto JsonlSink::Write(std::size_t /*generation*/, ResultRecord const& record) -> void
 {
     if (!impl_->Out) { return; }
-    // ResultRecord (Operon::Map<string, ResultValue>) is written directly:
-    // ankerl::unordered_dense::table satisfies glaze's writable_map_t
-    // concept generically (range of pair-like elements), and ResultValue's
-    // is_variant writer emits just the active alternative untagged - no
-    // glz::meta specialization needed, unlike the fixed-shape proxies in
+    // No glz::meta needed: ResultRecord's map and ResultValue's variant are
+    // both generically supported by glaze, unlike the proxies in
     // core/serialization.cpp.
     auto result = glz::write_json(record);
     if (!result) {

--- a/source/algorithms/probes/chain.cpp
+++ b/source/algorithms/probes/chain.cpp
@@ -22,7 +22,10 @@ JsonlSink::JsonlSink(std::string_view path)
     : impl_(std::make_unique<Impl>())
 {
     impl_->Path = std::string(path);
-    impl_->Out.open(impl_->Path, std::ios::out | std::ios::app);
+    // Truncates by default: silently mixing an old trace's lines into a new
+    // run (if this instead opened in append mode) would be a worse surprise
+    // than losing an old file the caller pointed a fresh sink at.
+    impl_->Out.open(impl_->Path, std::ios::out | std::ios::trunc);
     if (!impl_->Out) {
         fmt::print(stderr, "JsonlSink: failed to open '{}' for writing\n", impl_->Path);
     }
@@ -52,6 +55,11 @@ auto JsonlSink::Write(std::size_t /*generation*/, ResultRecord const& record) ->
 auto JsonlSink::Flush() -> void
 {
     if (impl_->Out) { impl_->Out.flush(); }
+}
+
+auto JsonlSink::IsOpen() const -> bool
+{
+    return static_cast<bool>(impl_->Out);
 }
 
 // ---- ProbeChain ----
@@ -87,6 +95,8 @@ auto ProbeChain::operator()(GeneticAlgorithmBase const& algo) -> void
 
 auto ProbeChain::Finish() -> void
 {
+    if (finished_) { return; }
+    finished_ = true;
     for (auto& entry : entries_) { entry.Probe->Finish(); }
     if (sink_) { sink_->Flush(); }
 }

--- a/source/algorithms/probes/chain.cpp
+++ b/source/algorithms/probes/chain.cpp
@@ -15,18 +15,16 @@ namespace Operon {
 
 struct JsonlSink::Impl {
     std::ofstream Out;
-    std::string Path;
 };
 
 JsonlSink::JsonlSink(std::string_view path)
     : impl_(std::make_unique<Impl>())
 {
-    impl_->Path = std::string(path);
     // Truncates by default rather than appending, to avoid silently mixing
     // an old trace's lines into a new run.
-    impl_->Out.open(impl_->Path, std::ios::out | std::ios::trunc);
+    impl_->Out.open(std::string(path), std::ios::out | std::ios::trunc);
     if (!impl_->Out) {
-        fmt::print(stderr, "JsonlSink: failed to open '{}' for writing\n", impl_->Path);
+        fmt::print(stderr, "JsonlSink: failed to open '{}' for writing\n", path);
     }
 }
 
@@ -34,7 +32,7 @@ JsonlSink::~JsonlSink() = default;
 JsonlSink::JsonlSink(JsonlSink&&) noexcept = default;
 auto JsonlSink::operator=(JsonlSink&&) noexcept -> JsonlSink& = default;
 
-auto JsonlSink::Write(std::size_t /*generation*/, ResultRecord const& record) -> void
+auto JsonlSink::Write(ResultRecord const& record) -> void
 {
     if (!impl_->Out) { return; }
     // No glz::meta needed: ResultRecord's map and ResultValue's variant are
@@ -86,7 +84,7 @@ auto ProbeChain::operator()(GeneticAlgorithmBase const& algo) -> void
         (*entry.Probe)(ctx);
         ran = true;
     }
-    if (ran && sink_) { sink_->Write(generation, record); }
+    if (ran && sink_) { sink_->Write(record); }
 }
 
 auto ProbeChain::Finish() -> void

--- a/source/algorithms/probes/chain.cpp
+++ b/source/algorithms/probes/chain.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/algorithms/probes/chain.hpp"
+
+#include <fstream>
+#include <utility>
+
+#include <fmt/core.h>
+#include <glaze/glaze.hpp>
+
+namespace Operon {
+
+// ---- JsonlSink ----
+
+struct JsonlSink::Impl {
+    std::ofstream Out;
+    std::string Path;
+};
+
+JsonlSink::JsonlSink(std::string_view path)
+    : impl_(std::make_unique<Impl>())
+{
+    impl_->Path = std::string(path);
+    impl_->Out.open(impl_->Path, std::ios::out | std::ios::app);
+    if (!impl_->Out) {
+        fmt::print(stderr, "JsonlSink: failed to open '{}' for writing\n", impl_->Path);
+    }
+}
+
+JsonlSink::~JsonlSink() = default;
+JsonlSink::JsonlSink(JsonlSink&&) noexcept = default;
+auto JsonlSink::operator=(JsonlSink&&) noexcept -> JsonlSink& = default;
+
+auto JsonlSink::Write(std::size_t /*generation*/, ResultRecord const& record) -> void
+{
+    if (!impl_->Out) { return; }
+    // ResultRecord (Operon::Map<string, ResultValue>) is written directly:
+    // ankerl::unordered_dense::table satisfies glaze's writable_map_t
+    // concept generically (range of pair-like elements), and ResultValue's
+    // is_variant writer emits just the active alternative untagged - no
+    // glz::meta specialization needed, unlike the fixed-shape proxies in
+    // core/serialization.cpp.
+    auto result = glz::write_json(record);
+    if (!result) {
+        fmt::print(stderr, "JsonlSink: serialization error: {}\n", glz::format_error(result.error()));
+        return;
+    }
+    impl_->Out << *result << '\n';
+}
+
+auto JsonlSink::Flush() -> void
+{
+    if (impl_->Out) { impl_->Out.flush(); }
+}
+
+// ---- ProbeChain ----
+
+auto ProbeChain::Add(std::unique_ptr<GenerationProbe> probe, std::size_t every, std::size_t offset) -> void
+{
+    entries_.push_back(Entry{ .Probe = std::move(probe), .Every = every, .Offset = offset });
+}
+
+auto ProbeChain::SetSink(std::unique_ptr<RecordSink> sink) -> void
+{
+    sink_ = std::move(sink);
+}
+
+auto ProbeChain::operator()(GeneticAlgorithmBase const& algo) -> void
+{
+    auto const generation = algo.Generation();
+    ResultRecord record;
+    record.insert_or_assign("generation", static_cast<std::int64_t>(generation));
+    record.insert_or_assign("elapsed", algo.Elapsed());
+
+    ProbeContext ctx{ algo, record };
+    bool ran = false;
+    for (auto& entry : entries_) {
+        if (entry.Every == 0) { continue; }
+        if (generation < entry.Offset) { continue; }
+        if ((generation - entry.Offset) % entry.Every != 0) { continue; }
+        (*entry.Probe)(ctx);
+        ran = true;
+    }
+    if (ran && sink_) { sink_->Write(generation, record); }
+}
+
+auto ProbeChain::Finish() -> void
+{
+    for (auto& entry : entries_) { entry.Probe->Finish(); }
+    if (sink_) { sink_->Flush(); }
+}
+
+} // namespace Operon

--- a/source/algorithms/probes/registry.cpp
+++ b/source/algorithms/probes/registry.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/algorithms/probes/registry.hpp"
+
+#include <utility>
+
+namespace Operon {
+
+auto ProbeRegistry::Register(std::string type, ProbeFactory factory) -> void
+{
+    factories_.insert_or_assign(std::move(type), std::move(factory));
+}
+
+auto ProbeRegistry::Contains(std::string const& type) const -> bool
+{
+    return factories_.contains(type);
+}
+
+auto ProbeRegistry::Create(std::string const& type, ProbeParams const& params) const -> std::unique_ptr<GenerationProbe>
+{
+    auto it = factories_.find(type);
+    if (it == factories_.end()) { return nullptr; }
+    return it->second(params);
+}
+
+} // namespace Operon

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -27,9 +27,12 @@ Zobrist::~Zobrist() = default;
 
 auto Zobrist::TryGet(Operon::Hash hash, Value& val) const -> bool
 {
-    ++lookups_;
+    // relaxed: these are statistics counters with no ordering requirement
+    // on anything else, and TryGet is in the per-individual evaluation hot
+    // path - the default seq_cst RMW would tax every lookup for no benefit.
+    lookups_.fetch_add(1, std::memory_order_relaxed);
     bool const found = tt_->Cache.IfContains(hash, [&](FitnessEntry const& e) -> void { val = e.Value; });
-    if (found) { ++hits_; }
+    if (found) { hits_.fetch_add(1, std::memory_order_relaxed); }
     return found;
 }
 
@@ -44,8 +47,8 @@ auto Zobrist::Insert(Operon::Hash hash, Value const& val) -> void
 auto Zobrist::Clear() -> void
 {
     tt_->Cache.Clear();
-    hits_.store(0);
-    lookups_.store(0);
+    hits_.store(0, std::memory_order_relaxed);
+    lookups_.store(0, std::memory_order_relaxed);
 }
 
 auto Zobrist::Size() const -> std::size_t

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -27,6 +27,7 @@ Zobrist::~Zobrist() = default;
 
 auto Zobrist::TryGet(Operon::Hash hash, Value& val) const -> bool
 {
+    ++lookups_;
     bool const found = tt_->Cache.IfContains(hash, [&](FitnessEntry const& e) -> void { val = e.Value; });
     if (found) { ++hits_; }
     return found;
@@ -44,6 +45,7 @@ auto Zobrist::Clear() -> void
 {
     tt_->Cache.Clear();
     hits_.store(0);
+    lookups_.store(0);
 }
 
 auto Zobrist::Size() const -> std::size_t

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(operon_test
     source/implementation/permutation_importance.cpp
     source/implementation/evaluator.cpp
     source/implementation/optimizer.cpp
+    source/implementation/probes.cpp
     source/implementation/random.cpp
     source/implementation/selection.cpp
     source/implementation/serialization.cpp

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "operon/algorithms/config.hpp"
+#include "operon/algorithms/gp.hpp"
+#include "operon/algorithms/probes/chain.hpp"
+#include "operon/algorithms/probes/probe.hpp"
+#include "operon/algorithms/probes/registry.hpp"
+#include "operon/core/dataset.hpp"
+#include "operon/core/dispatch.hpp"
+#include "operon/core/individual.hpp"
+#include "operon/core/problem.hpp"
+#include "operon/core/pset.hpp"
+#include "operon/core/types.hpp"
+#include "operon/operators/creator.hpp"
+#include "operon/operators/crossover.hpp"
+#include "operon/operators/evaluator.hpp"
+#include "operon/operators/generator.hpp"
+#include "operon/operators/initializer.hpp"
+#include "operon/operators/mutation.hpp"
+#include "operon/operators/reinserter.hpp"
+#include "operon/operators/selector.hpp"
+
+namespace Operon::Test {
+namespace {
+
+using DTable = DispatchTable<Operon::Scalar>;
+
+auto MakeDataset() -> Operon::Dataset
+{
+    std::vector<std::vector<Operon::Scalar>> data(2, std::vector<Operon::Scalar>(10));
+    std::iota(data[0].begin(), data[0].end(), Operon::Scalar{1});
+    for (std::size_t i = 0; i < 10; ++i) { data[1][i] = data[0][i] * Operon::Scalar{2}; }
+    return Operon::Dataset({"X1", "Y"}, data);
+}
+
+auto MakePset() -> Operon::PrimitiveSet
+{
+    Operon::PrimitiveSet p;
+    p.SetConfig(PrimitiveSet::Arithmetic);
+    return p;
+}
+
+// Trimmed down from ga_base.cpp's GaBaseFixture: just enough wiring to get a
+// GeneticAlgorithmBase-derived object whose Parents()/Offspring() can be
+// populated via RestoreIndividuals(), which is all ProbeContext reads.
+struct ProbeFixture {
+    static constexpr std::size_t PopSize  = 6;
+    static constexpr std::size_t PoolSize = 4;
+
+    Operon::Dataset Ds{ MakeDataset() };
+    Operon::Problem Problem{ gsl::not_null<Operon::Dataset*>(&Ds) };
+    Operon::PrimitiveSet Pset{ MakePset() };
+    std::vector<Operon::Hash> Vars{ Ds.GetVariable("X1")->Hash };
+
+    DTable Dtable;
+    Operon::Evaluator<DTable>             Evaluator{ &Problem, &Dtable };
+    Operon::SubtreeCrossover              Crossover{ 0.9, /*maxDepth=*/6, /*maxLength=*/20 };
+    Operon::OnePointMutation<std::normal_distribution<Operon::Scalar>> OnePoint;
+    Operon::MultiMutation                 Mutator;
+    Operon::TournamentSelector            FemSel{ Operon::SingleObjectiveComparison{0} };
+    Operon::TournamentSelector            MaleSel{ Operon::SingleObjectiveComparison{0} };
+    Operon::BasicOffspringGenerator       Generator{ &Evaluator, &Crossover, &Mutator, &FemSel, &MaleSel };
+    Operon::KeepBestReinserter            Reinserter{ Operon::SingleObjectiveComparison{0} };
+    Operon::BalancedTreeCreator           Creator{ &Pset, Vars, 0.0, 10 };
+    Operon::UniformTreeInitializer        TreeInit{ &Creator };
+    Operon::UniformCoefficientInitializer CoeffInit;
+    Operon::GeneticAlgorithmConfig        Config{ [] -> Operon::GeneticAlgorithmConfig { Operon::GeneticAlgorithmConfig c; c.PopulationSize = PopSize; c.PoolSize = PoolSize; c.Generations = 1; return c; }() };
+    Operon::GeneticProgrammingAlgorithm   Gp{ Config, &Problem, &TreeInit, &CoeffInit, &Generator, &Reinserter };
+
+    ProbeFixture()
+    {
+        Problem.SetTrainingRange({0, 10});
+        Problem.SetTestRange({0, 10});
+        Problem.SetTarget("Y");
+
+        std::vector<Operon::Individual> inds(PopSize + PoolSize);
+        for (std::size_t i = 0; i < inds.size(); ++i) {
+            inds[i].Fitness.resize(1);
+            inds[i].Fitness[0] = static_cast<Operon::Scalar>(i);
+        }
+        Gp.RestoreIndividuals(inds);
+    }
+};
+
+// Records every generation it was invoked on, and emits a scalar + a vector
+// so both ResultValue shapes get exercised through ProbeContext::Emit.
+struct RecordingProbe final : Operon::GenerationProbe {
+    std::vector<std::size_t> Seen;
+    bool Finished{false};
+
+    auto operator()(Operon::ProbeContext& ctx) -> void override
+    {
+        Seen.push_back(ctx.Generation());
+        ctx.Emit("seen_count", static_cast<std::int64_t>(Seen.size()));
+        ctx.Emit("readings", std::vector<double>{1.0, 2.0, 3.0});
+    }
+
+    auto Finish() -> void override { Finished = true; }
+};
+
+// Bumps Generation() on the fixture's Gp directly (no public setter exists;
+// GeneticAlgorithmBase::Generation() is a non-const-returning reference for
+// mutable callers, same as production code uses via ++Generation() in
+// source/algorithms/gp.cpp).
+auto AdvanceTo(Operon::GeneticProgrammingAlgorithm& gp, std::size_t generation) -> void
+{
+    gp.Generation() = generation;
+}
+
+} // namespace
+
+TEST_CASE("ProbeContext exposes the wrapped algorithm's read surface", "[probes]")
+{
+    ProbeFixture f;
+    Operon::ResultRecord record;
+    Operon::ProbeContext ctx{f.Gp, record};
+
+    CHECK(ctx.Generation() == 0);
+    CHECK(ctx.Parents().size() == ProbeFixture::PopSize);
+    CHECK(ctx.Offspring().size() == ProbeFixture::PoolSize);
+    CHECK(ctx.Problem() == &f.Problem);
+
+    ctx.Emit("x", std::int64_t{42});
+    REQUIRE(record.contains("x"));
+    CHECK(std::get<std::int64_t>(record.at("x")) == 42);
+
+    // Emit overwrites, it doesn't accumulate.
+    ctx.Emit("x", std::int64_t{7});
+    CHECK(record.size() == 1);
+    CHECK(std::get<std::int64_t>(record.at("x")) == 7);
+}
+
+TEST_CASE("ProbeChain runs a probe every generation by default", "[probes]")
+{
+    ProbeFixture f;
+    Operon::ProbeChain chain;
+    auto owned = std::make_unique<RecordingProbe>();
+    auto* probe = owned.get();
+    chain.Add(std::move(owned));
+
+    for (std::size_t g = 0; g < 4; ++g) {
+        AdvanceTo(f.Gp, g);
+        chain(f.Gp);
+    }
+
+    REQUIRE(probe->Seen == std::vector<std::size_t>{0, 1, 2, 3});
+
+    chain.Finish();
+    CHECK(probe->Finished);
+}
+
+TEST_CASE("ProbeChain respects every/offset scheduling", "[probes]")
+{
+    ProbeFixture f;
+    Operon::ProbeChain chain;
+    auto owned = std::make_unique<RecordingProbe>();
+    auto* probe = owned.get();
+    // every=2, offset=1 -> fires on generations 1, 3, 5, ...
+    chain.Add(std::move(owned), /*every=*/2, /*offset=*/1);
+
+    for (std::size_t g = 0; g < 6; ++g) {
+        AdvanceTo(f.Gp, g);
+        chain(f.Gp);
+    }
+
+    CHECK(probe->Seen == std::vector<std::size_t>{1, 3, 5});
+}
+
+TEST_CASE("ProbeChain every=0 disables a probe without removing it", "[probes]")
+{
+    ProbeFixture f;
+    Operon::ProbeChain chain;
+    auto owned = std::make_unique<RecordingProbe>();
+    auto* probe = owned.get();
+    chain.Add(std::move(owned), /*every=*/0);
+
+    for (std::size_t g = 0; g < 3; ++g) {
+        AdvanceTo(f.Gp, g);
+        chain(f.Gp);
+    }
+
+    CHECK(probe->Seen.empty());
+}
+
+TEST_CASE("JsonlSink writes one line per generation that ran a probe, none otherwise", "[probes]")
+{
+    ProbeFixture f;
+    auto const path = std::filesystem::temp_directory_path() / "operon_probes_test.jsonl";
+    std::filesystem::remove(path);
+
+    {
+        Operon::ProbeChain chain;
+        chain.Add(std::make_unique<RecordingProbe>(), /*every=*/2); // fires on generation 0, 2
+        chain.SetSink(std::make_unique<Operon::JsonlSink>(path.string()));
+
+        for (std::size_t g = 0; g < 4; ++g) {
+            AdvanceTo(f.Gp, g);
+            chain(f.Gp);
+        }
+        chain.Finish();
+    }
+
+    REQUIRE(std::filesystem::exists(path));
+    std::ifstream in(path);
+    std::vector<std::string> lines;
+    for (std::string line; std::getline(in, line);) {
+        if (!line.empty()) { lines.push_back(line); }
+    }
+    in.close();
+    std::filesystem::remove(path);
+
+    // Only generations 0 and 2 ran the probe, so only two lines should exist,
+    // each a self-describing JSON object carrying the emitted keys.
+    REQUIRE(lines.size() == 2);
+    for (auto const& line : lines) {
+        CHECK(line.front() == '{');
+        CHECK(line.back() == '}');
+        CHECK(line.find("\"generation\"") != std::string::npos);
+        CHECK(line.find("\"seen_count\"") != std::string::npos);
+        CHECK(line.find("\"readings\"") != std::string::npos);
+    }
+}
+
+TEST_CASE("ProbeRegistry creates probes by registered type name", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    CHECK_FALSE(registry.Contains("recording"));
+
+    registry.Register("recording", [](Operon::ProbeParams const& /*params*/) -> std::unique_ptr<Operon::GenerationProbe> {
+        return std::make_unique<RecordingProbe>();
+    });
+    CHECK(registry.Contains("recording"));
+
+    auto probe = registry.Create("recording", {});
+    REQUIRE(probe != nullptr);
+
+    auto missing = registry.Create("does-not-exist", {});
+    CHECK(missing == nullptr);
+}
+
+TEST_CASE("ProbeRegistry factory receives its params", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    registry.Register("check-params", [](Operon::ProbeParams const& params) -> std::unique_ptr<Operon::GenerationProbe> {
+        REQUIRE(params.contains("path"));
+        CHECK(std::get<std::string>(params.at("path")) == "out.beve");
+        return std::make_unique<RecordingProbe>();
+    });
+
+    Operon::ProbeParams params;
+    params.insert_or_assign("path", Operon::ProbeParamValue{std::string{"out.beve"}});
+    auto probe = registry.Create("check-params", params);
+    CHECK(probe != nullptr);
+}
+
+} // namespace Operon::Test

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -104,7 +104,12 @@ struct RecordingProbe final : Operon::GenerationProbe {
     auto operator()(Operon::ProbeContext& ctx) -> void override
     {
         Seen.push_back(ctx.Generation());
+        // Exercises every ResultValue alternative, not just int64_t/vector<double>.
         ctx.Emit("seen_count", static_cast<std::int64_t>(Seen.size()));
+        ctx.Emit("mean", 1.5);
+        ctx.Emit("flag", true);
+        ctx.Emit("label", std::string{"gen"});
+        ctx.Emit("counts", std::vector<std::int64_t>{1, 2, 3});
         ctx.Emit("readings", std::vector<double>{1.0, 2.0, 3.0});
     }
 
@@ -226,6 +231,49 @@ TEST_CASE("ProbeChain every=0 disables a probe without removing it", "[probes]")
     }
 
     CHECK(probe->Seen.empty());
+
+    // A disabled probe still gets cleaned up: Finish() runs regardless of
+    // Every, only the per-generation call is gated.
+    chain.Finish();
+    CHECK(probe->FinishCount == 1);
+}
+
+TEST_CASE("ProbeChain runs every registered probe and later probes win on shared keys", "[probes]")
+{
+    ProbeFixture f;
+    Operon::ProbeChain chain;
+    auto first = std::make_unique<RecordingProbe>();
+    auto* firstPtr = first.get();
+    auto second = std::make_unique<RecordingProbe>();
+    auto* secondPtr = second.get();
+    chain.Add(std::move(first));
+    chain.Add(std::move(second));
+
+    AdvanceTo(f.Gp, 0);
+    chain(f.Gp);
+
+    // Both probes ran (each independently tracks that it saw generation 0).
+    CHECK(firstPtr->Seen == std::vector<std::size_t>{0});
+    CHECK(secondPtr->Seen == std::vector<std::size_t>{0});
+}
+
+TEST_CASE("ProbeChain move-construction preserves single Finish() semantics", "[probes]")
+{
+    int finishCount = 0;
+    auto owned = std::make_unique<RecordingProbe>();
+    owned->ExternalFinishCount = &finishCount;
+
+    Operon::ProbeChain original;
+    original.Add(std::move(owned));
+
+    Operon::ProbeChain moved{std::move(original)};
+    CHECK(finishCount == 0);
+
+    // The moved-from chain's entries_ is now empty, so its destructor's
+    // Finish() call has nothing to iterate - only `moved`'s Finish() should
+    // ever reach the probe.
+    moved.Finish();
+    CHECK(finishCount == 1);
 }
 
 TEST_CASE("JsonlSink writes one line per generation that ran a probe, none otherwise", "[probes]")
@@ -263,7 +311,11 @@ TEST_CASE("JsonlSink writes one line per generation that ran a probe, none other
         CHECK(line.back() == '}');
         CHECK(line.find("\"generation\"") != std::string::npos);
         CHECK(line.find("\"seen_count\"") != std::string::npos);
-        CHECK(line.find("\"readings\"") != std::string::npos);
+        CHECK(line.find("\"mean\":1.5") != std::string::npos);
+        CHECK(line.find("\"flag\":true") != std::string::npos);
+        CHECK(line.find("\"label\":\"gen\"") != std::string::npos);
+        CHECK(line.find("\"counts\":[1,2,3]") != std::string::npos);
+        CHECK(line.find("\"readings\":[1,2,3]") != std::string::npos);
     }
 }
 
@@ -280,7 +332,7 @@ TEST_CASE("JsonlSink truncates a pre-existing file rather than appending", "[pro
         record.insert_or_assign("fresh", true);
         Operon::JsonlSink sink(path.string());
         CHECK(sink.IsOpen());
-        sink.Write(0, record);
+        sink.Write(record);
     }
 
     std::ifstream in(path);
@@ -306,7 +358,7 @@ TEST_CASE("JsonlSink reports IsOpen() == false when it fails to open", "[probes]
     // Write() on a sink that failed to open must no-op, not crash.
     Operon::ResultRecord record;
     record.insert_or_assign("x", std::int64_t{1});
-    sink.Write(0, record);
+    sink.Write(record);
 }
 
 TEST_CASE("ProbeRegistry creates probes by registered type name", "[probes]")

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -336,7 +336,7 @@ TEST_CASE("ProbeRegistry factory receives its params", "[probes]")
     Operon::ProbeRegistry registry;
     registry.Register("check-params", [](Operon::ProbeParams const& params) -> std::unique_ptr<Operon::GenerationProbe> {
         REQUIRE(params.contains("path"));
-        CHECK(std::get<std::string>(params.at("path")) == "out.beve");
+        CHECK(params.at("path").Get<std::string>() == "out.beve");
         return std::make_unique<RecordingProbe>();
     });
 

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -51,9 +51,8 @@ auto MakePset() -> Operon::PrimitiveSet
     return p;
 }
 
-// Trimmed down from ga_base.cpp's GaBaseFixture: just enough wiring to get a
-// GeneticAlgorithmBase-derived object whose Parents()/Offspring() can be
-// populated via RestoreIndividuals(), which is all ProbeContext reads.
+// Trimmed down from ga_base.cpp's GaBaseFixture - just enough to populate
+// Parents()/Offspring() via RestoreIndividuals(), which is all ProbeContext reads.
 struct ProbeFixture {
     static constexpr std::size_t PopSize  = 6;
     static constexpr std::size_t PoolSize = 4;
@@ -98,10 +97,8 @@ struct ProbeFixture {
 struct RecordingProbe final : Operon::GenerationProbe {
     std::vector<std::size_t> Seen;
     int FinishCount{0};
-    // Points at a counter outliving the probe itself, for tests that need
-    // to observe Finish() calls after the owning ProbeChain (and hence this
-    // probe) has already been destroyed - reading FinishCount through a
-    // dangling `this` at that point would be a use-after-free.
+    // Outlives the probe, for tests checking Finish() after the owning
+    // ProbeChain (and thus this probe) is already destroyed.
     int* ExternalFinishCount{nullptr};
 
     auto operator()(Operon::ProbeContext& ctx) -> void override
@@ -118,10 +115,8 @@ struct RecordingProbe final : Operon::GenerationProbe {
     }
 };
 
-// Bumps Generation() on the fixture's Gp directly (no public setter exists;
-// GeneticAlgorithmBase::Generation() is a non-const-returning reference for
-// mutable callers, same as production code uses via ++Generation() in
-// source/algorithms/gp.cpp).
+// Generation() returns a mutable reference for non-const callers (same as
+// production's ++Generation() in source/algorithms/gp.cpp); no setter exists.
 auto AdvanceTo(Operon::GeneticProgrammingAlgorithm& gp, std::size_t generation) -> void
 {
     gp.Generation() = generation;

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -97,7 +97,12 @@ struct ProbeFixture {
 // so both ResultValue shapes get exercised through ProbeContext::Emit.
 struct RecordingProbe final : Operon::GenerationProbe {
     std::vector<std::size_t> Seen;
-    bool Finished{false};
+    int FinishCount{0};
+    // Points at a counter outliving the probe itself, for tests that need
+    // to observe Finish() calls after the owning ProbeChain (and hence this
+    // probe) has already been destroyed - reading FinishCount through a
+    // dangling `this` at that point would be a use-after-free.
+    int* ExternalFinishCount{nullptr};
 
     auto operator()(Operon::ProbeContext& ctx) -> void override
     {
@@ -106,7 +111,11 @@ struct RecordingProbe final : Operon::GenerationProbe {
         ctx.Emit("readings", std::vector<double>{1.0, 2.0, 3.0});
     }
 
-    auto Finish() -> void override { Finished = true; }
+    auto Finish() -> void override
+    {
+        ++FinishCount;
+        if (ExternalFinishCount != nullptr) { ++*ExternalFinishCount; }
+    }
 };
 
 // Bumps Generation() on the fixture's Gp directly (no public setter exists;
@@ -157,7 +166,38 @@ TEST_CASE("ProbeChain runs a probe every generation by default", "[probes]")
     REQUIRE(probe->Seen == std::vector<std::size_t>{0, 1, 2, 3});
 
     chain.Finish();
-    CHECK(probe->Finished);
+    CHECK(probe->FinishCount == 1);
+}
+
+TEST_CASE("ProbeChain::Finish is idempotent across explicit calls and destruction", "[probes]")
+{
+    int finishCount = 0;
+    {
+        Operon::ProbeChain chain;
+        auto owned = std::make_unique<RecordingProbe>();
+        owned->ExternalFinishCount = &finishCount;
+        chain.Add(std::move(owned));
+
+        chain.Finish();
+        chain.Finish(); // explicit double-call must not re-run probe Finish()
+        CHECK(finishCount == 1);
+    } // destructor also calls Finish() - must not run it a second time either
+
+    CHECK(finishCount == 1);
+}
+
+TEST_CASE("ProbeChain destructor runs Finish() if the caller never called it", "[probes]")
+{
+    int finishCount = 0;
+    {
+        Operon::ProbeChain chain;
+        auto owned = std::make_unique<RecordingProbe>();
+        owned->ExternalFinishCount = &finishCount;
+        chain.Add(std::move(owned));
+        CHECK(finishCount == 0);
+    } // no explicit Finish() call before scope exit
+
+    CHECK(finishCount == 1);
 }
 
 TEST_CASE("ProbeChain respects every/offset scheduling", "[probes]")
@@ -230,6 +270,48 @@ TEST_CASE("JsonlSink writes one line per generation that ran a probe, none other
         CHECK(line.find("\"seen_count\"") != std::string::npos);
         CHECK(line.find("\"readings\"") != std::string::npos);
     }
+}
+
+TEST_CASE("JsonlSink truncates a pre-existing file rather than appending", "[probes]")
+{
+    auto const path = std::filesystem::temp_directory_path() / "operon_probes_truncate_test.jsonl";
+    {
+        std::ofstream seed(path);
+        seed << "{\"stale\":true}\n{\"stale\":true}\n";
+    }
+
+    {
+        Operon::ResultRecord record;
+        record.insert_or_assign("fresh", true);
+        Operon::JsonlSink sink(path.string());
+        CHECK(sink.IsOpen());
+        sink.Write(0, record);
+    }
+
+    std::ifstream in(path);
+    std::vector<std::string> lines;
+    for (std::string line; std::getline(in, line);) {
+        if (!line.empty()) { lines.push_back(line); }
+    }
+    in.close();
+    std::filesystem::remove(path);
+
+    REQUIRE(lines.size() == 1);
+    CHECK(lines[0].find("\"stale\"") == std::string::npos);
+    CHECK(lines[0].find("\"fresh\"") != std::string::npos);
+}
+
+TEST_CASE("JsonlSink reports IsOpen() == false when it fails to open", "[probes]")
+{
+    // A path under a directory that doesn't exist can't be opened.
+    auto const path = std::filesystem::temp_directory_path() / "operon_probes_missing_dir" / "out.jsonl";
+    Operon::JsonlSink sink(path.string());
+    CHECK_FALSE(sink.IsOpen());
+
+    // Write() on a sink that failed to open must no-op, not crash.
+    Operon::ResultRecord record;
+    record.insert_or_assign("x", std::int64_t{1});
+    sink.Write(0, record);
 }
 
 TEST_CASE("ProbeRegistry creates probes by registered type name", "[probes]")

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -112,6 +112,7 @@ TEST_CASE("Zobrist - TryGet returns false on miss", "[zobrist]")
     Operon::Vector<Operon::Scalar> val;
     REQUIRE_FALSE(cache.TryGet(hash, val));
     REQUIRE(cache.Hits() == 0);
+    REQUIRE(cache.Lookups() == 1);
 }
 
 TEST_CASE("Zobrist - Insert then TryGet roundtrip", "[zobrist]")
@@ -131,6 +132,7 @@ TEST_CASE("Zobrist - Insert then TryGet roundtrip", "[zobrist]")
     Operon::Vector<Operon::Scalar> retrieved(2);
     REQUIRE(cache.TryGet(hash, retrieved));
     REQUIRE(cache.Hits() == 1);
+    REQUIRE(cache.Lookups() == 1);
     REQUIRE(retrieved[0] == stored[0]);
     REQUIRE(retrieved[1] == stored[1]);
 }
@@ -154,8 +156,34 @@ TEST_CASE("Zobrist - Clear resets table and hit counter", "[zobrist]")
     cache.Clear();
     REQUIRE(cache.Size() == 0);
     REQUIRE(cache.Hits() == 0);
+    REQUIRE(cache.Lookups() == 0);
 
     REQUIRE_FALSE(cache.TryGet(hash, tmp));
+}
+
+TEST_CASE("Zobrist - Lookups counts every TryGet call regardless of outcome", "[zobrist]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist cache(rng, MaxLength, inputs);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree1 = creator(rng, 10, 1, MaxLength);
+    auto tree2 = creator(rng, 10, 1, MaxLength);
+    auto hash1 = cache.ComputeHash(tree1);
+    auto hash2 = cache.ComputeHash(tree2);
+
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash1, val);
+
+    Operon::Vector<Operon::Scalar> tmp;
+    std::ignore = cache.TryGet(hash1, tmp); // hit
+    std::ignore = cache.TryGet(hash2, tmp); // miss (unless hash1==hash2, vanishingly unlikely here)
+    std::ignore = cache.TryGet(hash1, tmp); // hit
+
+    REQUIRE(cache.Lookups() == 3);
+    REQUIRE(cache.Hits() <= cache.Lookups());
+    REQUIRE(cache.Hits() >= 2);
 }
 
 TEST_CASE("Zobrist - duplicate inserts increment count, not entries", "[zobrist]")


### PR DESCRIPTION
## Summary

Adds a generic, pluggable mechanism for attaching per-generation instrumentation to any `GeneticAlgorithmBase`-derived algorithm (currently `GeneticProgrammingAlgorithm` and `NSGA2`), without changing either algorithm's code:

- `GenerationProbe` - one interface for a per-generation diagnostic; a probe may emit named scalar/vector values into the current generation's record, do its own bulk I/O (e.g. dump the population), or both.
- `ProbeContext` - read-only view of the running algorithm (`Parents()`, `Offspring()`, `Generation()`, `GetConfig()`, `GetProblem()`) plus a handle to emit into the shared record.
- `ProbeChain` - runs a set of probes, each on its own `every`/`offset` generation schedule, and hands the combined record to a `RecordSink`. `Finish()` is idempotent and also runs from the destructor as a safety net.
- `RecordSink` / `JsonlSink` - one JSON object per line (NDJSON), chosen because `ResultRecord` is an unordered, self-describing bag of keys that can differ from one generation to the next. Truncates by default and exposes `IsOpen()` so a caller can tell a failed sink apart from an empty run.
- `ProbeRegistry` - name -> factory registry so new probe types don't require touching config-parsing code. `ProbeParams`/`ProbeParamValue` are a plain scalar wrapper, not tied to any JSON/YAML library, keeping the format decision entirely on the (future) config-parsing side - `ProbeParamValue` also closes the classic `const char*` binding to `bool` instead of `std::string` variant trap via a deleted constructor, enforced with a `static_assert`.
- `Zobrist::Lookups()` - a new counter alongside the existing `Hits()`, so cache hit rate has an actual denominator. Both counters use relaxed atomics, since they're plain statistics on a per-individual hot path with no ordering requirement.

Deliberately not integrated with taskflow's `ObserverInterface`: that observes per-task entry/exit across worker threads and carries no domain data, whereas the existing per-generation `ReportCallback` closure already gives synchronous, generation-granular access to everything a probe needs.

This is the foundational layer only - no concrete probes (population trace, cache hit rate, structural diversity) or CLI wiring yet. Those land in follow-up PRs based on `main` once this merges.

## Test plan

- [x] `./build/test/operon_test '[probes]'` - covers `ProbeContext`, scheduling (default/every-offset/disabled), `Finish()` idempotency, `JsonlSink` output/truncation/`IsOpen()`, and `ProbeRegistry`
- [x] `./build/test/operon_test '[zobrist]'` - extended existing cases plus new cases for `Lookups()`
- [x] `./build/test/operon_test '~[performance]'` - full suite green (23411 assertions, 218 cases)