### PR TITLE
Fix undefined behavior in Distance::Jaccard/SorensenDice on empty spans

### DIFF
--- a/source/core/distance.cpp
+++ b/source/core/distance.cpp
@@ -21,6 +21,13 @@ namespace Operon::Distance {
         template<typename T>
         inline auto CountIntersect(Operon::Span<T const> lhs, Operon::Span<T const> rhs) noexcept -> size_t
         {
+            // An empty span has no intersection with anything, trivially -
+            // and returning early here avoids `*(pN - 1)` below forming a
+            // pointer one element before the start of the span, which is
+            // undefined behavior when the span is empty (pN == p0 in that
+            // case), not merely a degenerate value.
+            if (lhs.empty() || rhs.empty()) { return 0; }
+
             size_t constexpr S = eve::wide<T>::size();
             T const *p0 = lhs.data();
             T const *pS = p0 + (lhs.size() & (-S));
@@ -68,6 +75,7 @@ namespace Operon::Distance {
     auto Jaccard(Operon::Vector<Operon::Hash> const& lhs, Operon::Vector<Operon::Hash> const& rhs) noexcept -> double
     {
         size_t const n = lhs.size() + rhs.size();
+        if (n == 0) { return 0.0; } // both empty -> identical by convention, not 0/0 NaN
         size_t const c = CountIntersect(lhs, rhs);
         return static_cast<double>(n - (2 * c)) / static_cast<double>(n);
     }
@@ -75,6 +83,7 @@ namespace Operon::Distance {
     auto SorensenDice(Operon::Vector<Operon::Hash> const& lhs, Operon::Vector<Operon::Hash> const& rhs) noexcept -> double
     {
         size_t const n = lhs.size() + rhs.size();
+        if (n == 0) { return 0.0; } // both empty -> identical by convention, not 0/0 NaN
         size_t const c = CountIntersect(lhs, rhs);
         return 1 - (2 * static_cast<double>(c) / static_cast<double>(n));
     }

--- a/test/source/implementation/hashing.cpp
+++ b/test/source/implementation/hashing.cpp
@@ -101,6 +101,25 @@ TEST_CASE("Hash-based distance", "[core]")
     }
 }
 
+TEST_CASE("Jaccard/SorensenDice handle empty spans without UB or NaN", "[core]")
+{
+    // CountIntersect used to dereference one element before the start of an
+    // empty span (undefined behavior, not just a 0/0 NaN) when either side
+    // was empty - both empty (n==0) additionally hit an explicit 0/0
+    // division. Convention: two empty sets are identical (distance 0); an
+    // empty set vs. a non-empty one is maximally dissimilar (distance 1).
+    Operon::Vector<Operon::Hash> const empty;
+    Operon::Vector<Operon::Hash> const nonEmpty{ 1, 2, 3 };
+
+    CHECK(Operon::Distance::Jaccard(empty, empty) == Catch::Approx(0.0));
+    CHECK(Operon::Distance::Jaccard(empty, nonEmpty) == Catch::Approx(1.0));
+    CHECK(Operon::Distance::Jaccard(nonEmpty, empty) == Catch::Approx(1.0));
+
+    CHECK(Operon::Distance::SorensenDice(empty, empty) == Catch::Approx(0.0));
+    CHECK(Operon::Distance::SorensenDice(empty, nonEmpty) == Catch::Approx(1.0));
+    CHECK(Operon::Distance::SorensenDice(nonEmpty, empty) == Catch::Approx(1.0));
+}
+
 TEST_CASE("Sorensen-Dice distance", "[core]")
 {
     auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);


### PR DESCRIPTION
## Summary

\`CountIntersect\` in \`source/core/distance.cpp\` computed \`*(pN - 1)\` unconditionally, where \`pN = p0 + span.size()\`. When either input span is empty, \`pN == p0\`, so this forms a pointer one element before the start of the span - undefined behavior, not merely a degenerate value. \`Jaccard\`/\`SorensenDice\` also divided by zero when both inputs were empty (\`0/0\` NaN).

Fixed at the source:

- \`CountIntersect\` returns 0 immediately for any empty span, before ever forming the out-of-bounds pointer.
- \`Jaccard\`/\`SorensenDice\` short-circuit to \`0.0\` when both inputs are empty (two empty sets are conventionally identical).
- An empty-vs-non-empty pair already yields the correct \`1.0\` (maximally dissimilar) once \`CountIntersect\` stops crashing - no separate special case needed there.

## Test plan

- [x] \`./build/test/operon_test '[core]'\` - new case covering all four empty/non-empty combinations for both \`Jaccard\` and \`SorensenDice\`
- [x] \`./build/test/operon_test '~[performance]'\` - full suite green (23430 assertions, 221 cases)