### PR TITLE
Wire generation probes into the CLI via --probes-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(
     source/algorithms/enumeration.cpp
     source/algorithms/gp.cpp
     source/algorithms/nsga2.cpp
+    source/algorithms/probes/builtin.cpp
     source/algorithms/probes/chain.cpp
     source/algorithms/probes/population_trace.cpp
     source/algorithms/probes/registry.cpp

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -18,7 +18,11 @@ endif()
 
 find_package(cxxopts REQUIRED)
 find_package(scn REQUIRED)
+find_package(glaze REQUIRED)
 
+# Extra per-target sources (e.g. probes_config.cpp for operon_gp/operon_nsgp
+# only - operon_parse_model/operon_enum don't run a GeneticAlgorithmBase
+# loop, so they have nothing to wire a ProbeChain into) are passed as ARGN.
 function(add_operon_cli NAME)
     add_executable(${NAME}
         source/${NAME}.cpp
@@ -26,9 +30,10 @@ function(add_operon_cli NAME)
         source/operator_factory.cpp
         source/pareto_front.cpp
         source/util.cpp
+        ${ARGN}
     )
 
-    target_link_libraries(${NAME} PRIVATE operon::operon cxxopts::cxxopts scn::scn)
+    target_link_libraries(${NAME} PRIVATE operon::operon cxxopts::cxxopts scn::scn glaze::glaze)
     target_compile_features(${NAME} PRIVATE cxx_std_23)
     set_target_properties(${NAME} PROPERTIES
         CXX_VISIBILITY_PRESET hidden
@@ -53,7 +58,7 @@ function(add_operon_cli NAME)
         )
 endfunction()
 
-add_operon_cli(operon_gp)
-add_operon_cli(operon_nsgp)
+add_operon_cli(operon_gp source/probes_config.cpp)
+add_operon_cli(operon_nsgp source/probes_config.cpp)
 add_operon_cli(operon_parse_model)
 add_operon_cli(operon_enum)

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -30,6 +30,7 @@
 
 #include "jit_setup.hpp"
 #include "operator_factory.hpp"
+#include "probes_config.hpp"
 #include "util.hpp"
 
 
@@ -238,11 +239,14 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(evaluator.get());
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, nullptr, evaluator.get());
+        auto probes = Operon::LoadProbeConfig(result.contains("probes-config") ? result["probes-config"].as<std::string>() : std::string{});
         gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);
+            if (probes) { (*probes)(gp); }
             Operon::MaybeSaveCheckpoint(gp, random, result);
             return false;
         }, warmStart);
+        if (probes) { probes->Finish(); }
         Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();
         auto best = reporter.GetBest();

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -239,6 +239,9 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             ptr = dynamic_cast<Operon::Evaluator<decltype(dtable)> const*>(evaluator.get());
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, nullptr, evaluator.get());
+        if (warmStart && result.contains("probes-config")) {
+            fmt::print(stderr, "warning: --probes-config sinks/traces truncate on start; resuming via --resume discards prior instrumentation history at any reused output path\n");
+        }
         auto probes = Operon::LoadProbeConfig(result.contains("probes-config") ? result["probes-config"].as<std::string>() : std::string{});
         gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -36,6 +36,7 @@
 #include "jit_setup.hpp"
 #include "operator_factory.hpp"
 #include "pareto_front.hpp"
+#include "probes_config.hpp"
 #include "reporter.hpp"
 #include "util.hpp"
 
@@ -337,11 +338,14 @@ auto main(int argc, char** argv) -> int
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector), &evaluator);
         auto const warmStart = Operon::ResumeFromCheckpoint(gp, random, result);
+        auto probes = Operon::LoadProbeConfig(result.contains("probes-config") ? result["probes-config"].as<std::string>() : std::string{});
         gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);
+            if (probes) { (*probes)(gp); }
             Operon::MaybeSaveCheckpoint(gp, random, result);
             return false;
         }, warmStart);
+        if (probes) { probes->Finish(); }
         Operon::MaybeSaveCheckpoint(gp, random, result, /*force=*/true);
         jitReport();
         auto best = reporter.GetBest();

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -338,6 +338,9 @@ auto main(int argc, char** argv) -> int
         }
         Operon::Reporter<Operon::Evaluator<decltype(dtable)>> reporter(ptr, std::move(modelSelector), &evaluator);
         auto const warmStart = Operon::ResumeFromCheckpoint(gp, random, result);
+        if (warmStart && result.contains("probes-config")) {
+            fmt::print(stderr, "warning: --probes-config sinks/traces truncate on start; resuming via --resume discards prior instrumentation history at any reused output path\n");
+        }
         auto probes = Operon::LoadProbeConfig(result.contains("probes-config") ? result["probes-config"].as<std::string>() : std::string{});
         gp.Run(executor, random, [&]() -> bool {
             reporter(executor, gp);

--- a/cli/source/probes_config.cpp
+++ b/cli/source/probes_config.cpp
@@ -22,20 +22,20 @@ namespace {
 // that distinction for every integer field in the config.
 using Json = glz::generic_i64;
 
-auto ToParamValue(Json const& v) -> ProbeParamValue
+auto ToParamValue(Json const& v, std::string const& key) -> ProbeParamValue
 {
     if (v.is_boolean()) { return ProbeParamValue{v.get<bool>()}; }
     if (v.holds<std::int64_t>()) { return ProbeParamValue{v.get<std::int64_t>()}; }
     if (v.is_number()) { return ProbeParamValue{v.get<double>()}; }
     if (v.is_string()) { return ProbeParamValue{v.get<std::string>()}; }
-    throw std::runtime_error("probes config: probe params must be a bool, number, or string");
+    throw std::runtime_error(fmt::format("probes config: param '{}' must be a bool, number, or string", key));
 }
 
 auto ToParams(Json const& obj) -> ProbeParams
 {
     ProbeParams params;
     for (auto const& [key, value] : obj.get_object()) {
-        params.insert_or_assign(key, ToParamValue(value));
+        params.insert_or_assign(key, ToParamValue(value, key));
     }
     return params;
 }
@@ -75,7 +75,7 @@ auto LoadProbeConfig(std::string const& path) -> std::optional<ProbeChain>
 
     Json doc;
     if (auto ec = glz::read_json(doc, text); ec) {
-        throw std::runtime_error(fmt::format("probes config: {}", glz::format_error(ec, text)));
+        throw std::runtime_error(fmt::format("probes config '{}': {}", path, glz::format_error(ec, text)));
     }
 
     ProbeRegistry registry;

--- a/cli/source/probes_config.cpp
+++ b/cli/source/probes_config.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "probes_config.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+#include <fmt/format.h>
+#include <glaze/glaze.hpp>
+
+#include "operon/algorithms/probes/registry.hpp"
+
+namespace Operon {
+
+namespace {
+
+// Integers parse as int64_t, everything else (incl. non-integral numbers)
+// as double - matches ProbeParamValue's own int64_t/double split, unlike
+// glaze's default num_mode::f64 (all numbers as double) which would lose
+// that distinction for every integer field in the config.
+using Json = glz::generic_i64;
+
+auto ToParamValue(Json const& v) -> ProbeParamValue
+{
+    if (v.is_boolean()) { return ProbeParamValue{v.get<bool>()}; }
+    if (v.holds<std::int64_t>()) { return ProbeParamValue{v.get<std::int64_t>()}; }
+    if (v.is_number()) { return ProbeParamValue{v.get<double>()}; }
+    if (v.is_string()) { return ProbeParamValue{v.get<std::string>()}; }
+    throw std::runtime_error("probes config: probe params must be a bool, number, or string");
+}
+
+auto ToParams(Json const& obj) -> ProbeParams
+{
+    ProbeParams params;
+    for (auto const& [key, value] : obj.get_object()) {
+        params.insert_or_assign(key, ToParamValue(value));
+    }
+    return params;
+}
+
+// Reads a non-negative integer field, defaulting to `fallback` if absent.
+auto ToCount(Json const& entry, char const* field, std::size_t fallback) -> std::size_t
+{
+    if (!entry.contains(field)) { return fallback; }
+    auto const& v = entry.at(field);
+    if (!v.holds<std::int64_t>() || v.get<std::int64_t>() < 0) {
+        throw std::runtime_error(fmt::format("probes config: '{}' must be a non-negative integer", field));
+    }
+    return static_cast<std::size_t>(v.get<std::int64_t>());
+}
+
+auto RequireString(Json const& obj, char const* field, char const* context) -> std::string
+{
+    if (!obj.contains(field) || !obj.at(field).is_string()) {
+        throw std::runtime_error(fmt::format("probes config: {} requires a string '{}'", context, field));
+    }
+    return obj.at(field).get<std::string>();
+}
+
+} // namespace
+
+auto LoadProbeConfig(std::string const& path) -> std::optional<ProbeChain>
+{
+    if (path.empty()) { return std::nullopt; }
+
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error(fmt::format("probes config: could not open '{}'", path));
+    }
+    std::stringstream buf;
+    buf << in.rdbuf();
+    auto const text = buf.str();
+
+    Json doc;
+    if (auto ec = glz::read_json(doc, text); ec) {
+        throw std::runtime_error(fmt::format("probes config: {}", glz::format_error(ec, text)));
+    }
+
+    ProbeRegistry registry;
+    RegisterBuiltinProbes(registry);
+
+    ProbeChain chain;
+
+    if (doc.contains("probes")) {
+        for (auto const& entry : doc.at("probes").get_array()) {
+            auto const type = RequireString(entry, "type", "each probe entry");
+            auto const every = ToCount(entry, "every", 1);
+            auto const offset = ToCount(entry, "offset", 0);
+            auto const params = entry.contains("params") ? ToParams(entry.at("params")) : ProbeParams{};
+
+            auto probe = registry.Create(type, params);
+            if (!probe) {
+                throw std::runtime_error(fmt::format("probes config: unknown probe type '{}'", type));
+            }
+            chain.Add(std::move(probe), every, offset);
+        }
+    }
+
+    if (doc.contains("sink")) {
+        auto const& sink = doc.at("sink");
+        auto const sinkType = RequireString(sink, "type", "'sink'");
+        auto const sinkPath = RequireString(sink, "path", "'sink'");
+        if (sinkType != "jsonl") {
+            throw std::runtime_error(fmt::format("probes config: unknown sink type '{}' (only 'jsonl' is supported)", sinkType));
+        }
+        chain.SetSink(std::make_unique<JsonlSink>(sinkPath));
+    }
+
+    return chain;
+}
+
+} // namespace Operon

--- a/cli/source/probes_config.hpp
+++ b/cli/source/probes_config.hpp
@@ -30,6 +30,12 @@ namespace Operon {
 // "every"/"offset" default to 1/0; "params" defaults to empty; "sink" is
 // optional (a chain with no sink still runs its probes' side effects, e.g.
 // population_trace writing its own file, but nothing is recorded via Emit).
+//
+// JsonlSink and PopulationTraceProbe both truncate their output file on
+// construction (see chain.cpp/population_trace.cpp), so combining
+// --resume with a --probes-config that reuses the same output paths as
+// the resumed run discards that run's prior instrumentation history -
+// the CLI warns about this at the call site, this isn't handled here.
 auto LoadProbeConfig(std::string const& path) -> std::optional<ProbeChain>;
 
 } // namespace Operon

--- a/cli/source/probes_config.hpp
+++ b/cli/source/probes_config.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_CLI_PROBES_CONFIG_HPP
+#define OPERON_CLI_PROBES_CONFIG_HPP
+
+#include <optional>
+#include <string>
+
+#include "operon/algorithms/probes/chain.hpp"
+
+namespace Operon {
+
+// Builds a ProbeChain from a JSON config file (--probes-config). Returns
+// std::nullopt if `path` is empty (flag not given). Throws
+// std::runtime_error on a missing/unreadable file, malformed JSON, or an
+// unrecognized probe/sink type - matches this CLI's existing convention
+// (e.g. ParseEvaluator/ParseGenerator in operator_factory.cpp) of
+// surfacing config errors as exceptions caught by main()'s try/catch.
+//
+// Schema:
+//   {
+//     "probes": [
+//       { "type": "population_trace", "every": 5, "params": { "path": "pop.beve" } },
+//       { "type": "cache_hit_rate", "every": 1 },
+//       { "type": "structural_diversity", "every": 10, "params": { "hash_mode": "strict" } }
+//     ],
+//     "sink": { "type": "jsonl", "path": "metrics.jsonl" }
+//   }
+// "every"/"offset" default to 1/0; "params" defaults to empty; "sink" is
+// optional (a chain with no sink still runs its probes' side effects, e.g.
+// population_trace writing its own file, but nothing is recorded via Emit).
+auto LoadProbeConfig(std::string const& path) -> std::optional<ProbeChain>;
+
+} // namespace Operon
+
+#endif

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -187,6 +187,7 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("checkpoint-interval", "Save a checkpoint every N generations (0 = disabled)", cxxopts::value<std::size_t>()->default_value("0"))
         ("checkpoint-file", "Path for checkpoint output (BEVE binary format)", cxxopts::value<std::string>()->default_value("checkpoint.beve"))
         ("resume", "Resume a previous run from this checkpoint file", cxxopts::value<std::string>())
+        ("probes-config", R"(Path to a JSON config file describing per-generation instrumentation probes to run, e.g. {"probes":[{"type":"cache_hit_rate","every":1}],"sink":{"type":"jsonl","path":"metrics.jsonl"}})", cxxopts::value<std::string>())
         ("debug", "Debug mode (more information displayed)")
         ("help", "Print help")
         ("version", "Print version and program information");

--- a/include/operon/algorithms/probes/registry.hpp
+++ b/include/operon/algorithms/probes/registry.hpp
@@ -71,6 +71,12 @@ private:
     Operon::Map<std::string, ProbeFactory> factories_;
 };
 
+// Registers the three built-in probes ("population_trace", "cache_hit_rate",
+// "structural_diversity") by name. A plain function, not static/global
+// registration, to avoid static-init-order surprises - call it explicitly
+// on a registry before parsing config that might reference these types.
+OPERON_EXPORT auto RegisterBuiltinProbes(ProbeRegistry& registry) -> void;
+
 } // namespace Operon
 
 #endif

--- a/source/algorithms/probes/builtin.cpp
+++ b/source/algorithms/probes/builtin.cpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/algorithms/probes/registry.hpp"
+
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+#include "operon/algorithms/probes/cache_hit_rate.hpp"
+#include "operon/algorithms/probes/diversity.hpp"
+#include "operon/algorithms/probes/population_trace.hpp"
+#include "operon/core/constants.hpp"
+
+namespace Operon {
+
+auto RegisterBuiltinProbes(ProbeRegistry& registry) -> void
+{
+    registry.Register("population_trace", [](ProbeParams const& params) -> std::unique_ptr<GenerationProbe> {
+        if (!params.contains("path")) {
+            throw std::runtime_error("population_trace probe requires a 'path' param");
+        }
+        return std::make_unique<PopulationTraceProbe>(params.at("path").Get<std::string>());
+    });
+
+    registry.Register("cache_hit_rate", [](ProbeParams const& /*params*/) -> std::unique_ptr<GenerationProbe> {
+        return std::make_unique<CacheHitRateProbe>();
+    });
+
+    registry.Register("structural_diversity", [](ProbeParams const& params) -> std::unique_ptr<GenerationProbe> {
+        auto mode = HashMode::Strict;
+        if (params.contains("hash_mode")) {
+            auto const& m = params.at("hash_mode").Get<std::string>();
+            if (m == "relaxed") {
+                mode = HashMode::Relaxed;
+            } else if (m != "strict") {
+                throw std::runtime_error(fmt::format("structural_diversity: unknown hash_mode '{}' (expected 'strict' or 'relaxed')", m));
+            }
+        }
+        return std::make_unique<StructuralDiversityProbe>(mode);
+    });
+}
+
+} // namespace Operon

--- a/source/algorithms/probes/builtin.cpp
+++ b/source/algorithms/probes/builtin.cpp
@@ -20,6 +20,9 @@ auto RegisterBuiltinProbes(ProbeRegistry& registry) -> void
         if (!params.contains("path")) {
             throw std::runtime_error("population_trace probe requires a 'path' param");
         }
+        if (!params.at("path").Holds<std::string>()) {
+            throw std::runtime_error("population_trace probe's 'path' param must be a string");
+        }
         return std::make_unique<PopulationTraceProbe>(params.at("path").Get<std::string>());
     });
 
@@ -30,6 +33,9 @@ auto RegisterBuiltinProbes(ProbeRegistry& registry) -> void
     registry.Register("structural_diversity", [](ProbeParams const& params) -> std::unique_ptr<GenerationProbe> {
         auto mode = HashMode::Strict;
         if (params.contains("hash_mode")) {
+            if (!params.at("hash_mode").Holds<std::string>()) {
+                throw std::runtime_error("structural_diversity probe's 'hash_mode' param must be a string");
+            }
             auto const& m = params.at("hash_mode").Get<std::string>();
             if (m == "relaxed") {
                 mode = HashMode::Relaxed;

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -480,6 +480,18 @@ TEST_CASE("RegisterBuiltinProbes: population_trace requires a 'path' param", "[p
     std::filesystem::remove(path);
 }
 
+TEST_CASE("RegisterBuiltinProbes: population_trace rejects a non-string 'path' with a clear error", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    Operon::RegisterBuiltinProbes(registry);
+
+    Operon::ProbeParams params;
+    params.insert_or_assign("path", Operon::ProbeParamValue{std::int64_t{123}});
+    // Must be a descriptive std::runtime_error, not a raw std::bad_variant_access
+    // from an unchecked Get<std::string>() inside the factory.
+    CHECK_THROWS_AS(registry.Create("population_trace", params), std::runtime_error);
+}
+
 TEST_CASE("RegisterBuiltinProbes: cache_hit_rate needs no params", "[probes]")
 {
     Operon::ProbeRegistry registry;
@@ -507,6 +519,11 @@ TEST_CASE("RegisterBuiltinProbes: structural_diversity accepts strict/relaxed an
     Operon::ProbeParams bogus;
     bogus.insert_or_assign("hash_mode", Operon::ProbeParamValue{std::string{"bogus"}});
     CHECK_THROWS_AS(registry.Create("structural_diversity", bogus), std::runtime_error);
+
+    Operon::ProbeParams wrongType;
+    wrongType.insert_or_assign("hash_mode", Operon::ProbeParamValue{true});
+    // Must be a descriptive std::runtime_error, not a raw std::bad_variant_access.
+    CHECK_THROWS_AS(registry.Create("structural_diversity", wrongType), std::runtime_error);
 }
 
 TEST_CASE("PopulationTraceProbe appends framed BEVE population dumps", "[probes]")

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -477,6 +477,7 @@ TEST_CASE("RegisterBuiltinProbes: population_trace requires a 'path' param", "[p
     params.insert_or_assign("path", Operon::ProbeParamValue{path.string()});
     auto probe = registry.Create("population_trace", params);
     REQUIRE(probe != nullptr);
+    probe.reset(); // Windows can't remove a file with an open handle
     std::filesystem::remove(path);
 }
 

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -451,6 +452,61 @@ TEST_CASE("ProbeRegistry factory receives its params", "[probes]")
     params.insert_or_assign("path", Operon::ProbeParamValue{std::string{"out.beve"}});
     auto probe = registry.Create("check-params", params);
     CHECK(probe != nullptr);
+}
+
+TEST_CASE("RegisterBuiltinProbes registers exactly the three concrete probes", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    Operon::RegisterBuiltinProbes(registry);
+
+    CHECK(registry.Contains("population_trace"));
+    CHECK(registry.Contains("cache_hit_rate"));
+    CHECK(registry.Contains("structural_diversity"));
+    CHECK_FALSE(registry.Contains("not_a_real_probe"));
+}
+
+TEST_CASE("RegisterBuiltinProbes: population_trace requires a 'path' param", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    Operon::RegisterBuiltinProbes(registry);
+
+    CHECK_THROWS_AS(registry.Create("population_trace", {}), std::runtime_error);
+
+    Operon::ProbeParams params;
+    auto const path = std::filesystem::temp_directory_path() / "operon_probes_builtin_test.beve";
+    params.insert_or_assign("path", Operon::ProbeParamValue{path.string()});
+    auto probe = registry.Create("population_trace", params);
+    REQUIRE(probe != nullptr);
+    std::filesystem::remove(path);
+}
+
+TEST_CASE("RegisterBuiltinProbes: cache_hit_rate needs no params", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    Operon::RegisterBuiltinProbes(registry);
+
+    auto probe = registry.Create("cache_hit_rate", {});
+    REQUIRE(probe != nullptr);
+}
+
+TEST_CASE("RegisterBuiltinProbes: structural_diversity accepts strict/relaxed and rejects anything else", "[probes]")
+{
+    Operon::ProbeRegistry registry;
+    Operon::RegisterBuiltinProbes(registry);
+
+    CHECK(registry.Create("structural_diversity", {}) != nullptr); // defaults to strict
+
+    Operon::ProbeParams strict;
+    strict.insert_or_assign("hash_mode", Operon::ProbeParamValue{std::string{"strict"}});
+    CHECK(registry.Create("structural_diversity", strict) != nullptr);
+
+    Operon::ProbeParams relaxed;
+    relaxed.insert_or_assign("hash_mode", Operon::ProbeParamValue{std::string{"relaxed"}});
+    CHECK(registry.Create("structural_diversity", relaxed) != nullptr);
+
+    Operon::ProbeParams bogus;
+    bogus.insert_or_assign("hash_mode", Operon::ProbeParamValue{std::string{"bogus"}});
+    CHECK_THROWS_AS(registry.Create("structural_diversity", bogus), std::runtime_error);
 }
 
 TEST_CASE("PopulationTraceProbe appends framed BEVE population dumps", "[probes]")


### PR DESCRIPTION
## Summary

Final PR in the generation-probes sequence (#127 infrastructure, #128 concrete probes, #129 an upstream UB fix) - makes the probe mechanism usable from the command line.

- `RegisterBuiltinProbes(ProbeRegistry&)` - new core-library function (`operon/algorithms/probes/registry.hpp`, `source/algorithms/probes/builtin.cpp`) registering the three concrete probes by name (`population_trace`, `cache_hit_rate`, `structural_diversity`). Lives in the library, not the CLI, so it's reusable by other consumers (e.g. a future pyoperon binding) without depending on any CLI machinery.
- `LoadProbeConfig(path)` (`cli/source/probes_config.hpp/.cpp`) - parses a JSON config file into a `ProbeChain`, using `glz::generic_i64` so integer fields (`every`/`offset`) round-trip as `int64_t` rather than losing that distinction to `double`. All glaze usage stays confined to this one `.cpp`, matching `core/serialization.cpp`'s existing convention.
- `--probes-config <file>` - new flag on both `operon_gp` and `operon_nsgp`, each gaining a one-line hookup in their existing report lambda (`if (probes) (*probes)(gp);`) plus a `probes->Finish()` call after `Run()`. Config errors (bad JSON, unknown probe/sink type) surface as exceptions through the existing top-level try/catch, same as the CLI's other config-parsing paths (`ParseEvaluator`, etc.).

Config schema:

```json
{
  "probes": [
    { "type": "population_trace", "every": 5, "params": { "path": "pop.beve" } },
    { "type": "cache_hit_rate", "every": 1 },
    { "type": "structural_diversity", "every": 10, "params": { "hash_mode": "strict" } }
  ],
  "sink": { "type": "jsonl", "path": "metrics.jsonl" }
}
```

## Test plan

- [x] `./build/test/operon_test '[probes]'` - new cases for `RegisterBuiltinProbes` (registers exactly the three expected names, each factory's param validation)
- [x] `./build/test/operon_test '~[performance]'` - full suite green (23492 assertions, 233 cases)
- [x] Manual end-to-end run of `operon_gp` with a real `--probes-config` (`cache_hit_rate` + `structural_diversity` + a `jsonl` sink) against `data/Poly-10.csv` with `--transposition-cache true` - confirmed real per-generation Zobrist hit/lookup/rate/size and diversity values in the output NDJSON, correlated across generations
- [x] Manual run with a `population_trace` probe - confirmed a real, non-empty BEVE trace file gets written
- [x] Manual run with an unknown probe type in the config - confirmed a clean error message via the existing exception path, not a crash