### PR TITLE
Make runtime registration the sole DispatchTable population path

### DIFF
--- a/example/custom_primitives.cpp
+++ b/example/custom_primitives.cpp
@@ -31,7 +31,6 @@
 #include "operon/core/problem.hpp"
 #include "operon/core/symbol_library.hpp"
 #include "operon/formatter/formatter.hpp"
-#include "operon/hash/hash.hpp"
 #include "operon/operators/creator.hpp"
 #include "operon/operators/crossover.hpp"
 #include "operon/operators/evaluator.hpp"
@@ -77,23 +76,20 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
 
     // sincos(x) = sin(x) + cos(x) — explicit derivative provided
     Operon::RegisterUnaryFunction<DT, Operon::Scalar>(dtable, pset,
-        { .Hash = Operon::Hasher{}("sincos"),
-          .Name = "sincos", .Desc = "sin(x) + cos(x)",
+        { .Name = "sincos", .Desc = "sin(x) + cos(x)",
           .Arity = 1, .Frequency = 2 },
         [](auto v) -> auto { using std::sin, std::cos; return sin(v) + cos(v); },
         [](auto v) -> auto { using std::sin, std::cos; return cos(v) - sin(v); });
 
     // gaussian(x) = exp(-x²) — derivative via Jet<T,1> auto-diff
     Operon::RegisterUnaryFunction<DT, Operon::Scalar>(dtable, pset,
-        { .Hash = Operon::Hasher{}("gaussian"),
-          .Name = "gaussian", .Desc = "exp(-x * x)",
+        { .Name = "gaussian", .Desc = "exp(-x * x)",
           .Arity = 1, .Frequency = 2 },
         [](auto const& v) -> auto { using std::exp; return exp(-v * v); });
 
     // hypot(a, b) = sqrt(a² + b²) — derivative via Jet<T,1> auto-diff
     Operon::RegisterBinaryFunction<DT, Operon::Scalar>(dtable, pset,
-        { .Hash = Operon::Hasher{}("hypot"),
-          .Name = "hypot", .Desc = "sqrt(a^2 + b^2)",
+        { .Name = "hypot", .Desc = "sqrt(a^2 + b^2)",
           .Arity = 2, .Frequency = 1 },
         [](auto const& a, auto const& b) -> auto { using std::sqrt; return sqrt((a * a) + (b * b)); });
 

--- a/include/operon/core/dispatch.hpp
+++ b/include/operon/core/dispatch.hpp
@@ -18,6 +18,8 @@
 
 namespace Operon {
 
+struct StandardLibrary;
+
 namespace Backend {
 template<typename T>
 static auto constexpr BatchSize = 512UL / sizeof(T);
@@ -296,13 +298,7 @@ private:
     Map map_;
 
 public:
-    DispatchTable()
-    {
-        auto constexpr f = [](auto i) { return static_cast<NodeType>(i); };
-        [&]<auto ...I>(std::index_sequence<I...>){
-            (map_.insert({ Node(f(I)).HashValue, MakeTuple<f(I)>() }), ...);
-        }(std::make_index_sequence<NodeTypes::Count-4>{}); // exclude Dynamic, Constant, Variable, Ref
-    }
+    DispatchTable();
 
     ~DispatchTable() = default;
 
@@ -394,5 +390,7 @@ public:
 
 using ScalarDispatch = DispatchTable<Operon::Scalar>;
 } // namespace Operon
+
+#include "standard_library.hpp"
 
 #endif

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -164,8 +164,10 @@ struct Node {
         return node;
     }
 
-    [[nodiscard]] OPERON_EXPORT auto Name() const noexcept -> std::string const&;
-    [[nodiscard]] OPERON_EXPORT auto Desc() const noexcept -> std::string const&;
+    // Not noexcept: unlike the old std::string const& return, this now
+    // copies (and, on invariant violation, can throw std::out_of_range).
+    [[nodiscard]] OPERON_EXPORT auto Name() const -> std::string;
+    [[nodiscard]] OPERON_EXPORT auto Desc() const -> std::string;
 
     // Register a display name (and optional description) for a Dynamic node hash.
     // After registration, Name() and Desc() return the provided strings instead of "dyn".

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -4,6 +4,9 @@
 #ifndef OPERON_STANDARD_LIBRARY_HPP
 #define OPERON_STANDARD_LIBRARY_HPP
 
+#include <array>
+#include <string_view>
+
 #include "dispatch.hpp"
 #include "node.hpp"
 
@@ -18,15 +21,69 @@
 namespace Operon {
 
 struct StandardLibrary {
+    static void RegisterNames()
+    {
+        static auto const registered = [] {
+            for (auto const& entry : Entries) {
+                Node::RegisterName(Node(entry.Type).HashValue, std::string(entry.Name), std::string(entry.Desc));
+            }
+            return true;
+        }();
+        static_cast<void>(registered);
+    }
+
     // Register all built-in math ops (everything except Dynamic, Constant,
     // Variable, Ref) into `dt`, for every scalar type DTable supports.
     template<typename... Ts>
     static void Register(DispatchTable<Ts...>& dt)
     {
+        RegisterNames();
         RegisterAll(dt, std::make_index_sequence<NodeTypes::Count - 4>{});
     }
 
 private:
+    struct Entry {
+        NodeType Type;
+        std::string_view Name;
+        std::string_view Desc;
+    };
+
+    static constexpr std::array Entries {
+        Entry{ NodeType::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ..." },
+        Entry{ NodeType::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ..." },
+        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)" },
+        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)" },
+        Entry{ NodeType::Fmin, "fmin", "minimum function f(a,b) = min(a,b)" },
+        Entry{ NodeType::Fmax, "fmax", "maximum function f(a,b) = max(a,b)" },
+        Entry{ NodeType::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)" },
+        Entry{ NodeType::Pow, "pow", "raise to power f(a,b) = a^b" },
+        Entry{ NodeType::Powabs, "powabs", "raise absolute value to power f(a,b) = |a|^b" },
+        Entry{ NodeType::Abs, "abs", "absolute value function f(a) = abs(a)" },
+        Entry{ NodeType::Acos, "acos", "inverse cosine function f(a) = acos(a)" },
+        Entry{ NodeType::Asin, "asin", "inverse sine function f(a) = asin(a)" },
+        Entry{ NodeType::Atan, "atan", "inverse tangent function f(a) = atan(a)" },
+        Entry{ NodeType::Cbrt, "cbrt", "cube root function f(a) = cbrt(a)" },
+        Entry{ NodeType::Ceil, "ceil", "ceiling function f(a) = ceil(a)" },
+        Entry{ NodeType::Cos, "cos", "cosine function f(a) = cos(a)" },
+        Entry{ NodeType::Cosh, "cosh", "hyperbolic cosine function f(a) = cosh(a)" },
+        Entry{ NodeType::Exp, "exp", "e raised to the given power f(a) = e^a" },
+        Entry{ NodeType::Floor, "floor", "floor function f(a) = floor(a)" },
+        Entry{ NodeType::Log, "log", "natural (base e) logarithm f(a) = ln(a)" },
+        Entry{ NodeType::Logabs, "logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)" },
+        Entry{ NodeType::Log1p, "log1p", "f(a) = ln(a + 1), accurate even when a is close to zero" },
+        Entry{ NodeType::Sin, "sin", "sine function f(a) = sin(a)" },
+        Entry{ NodeType::Sinh, "sinh", "hyperbolic sine function f(a) = sinh(a)" },
+        Entry{ NodeType::Sqrt, "sqrt", "square root function f(a) = sqrt(a)" },
+        Entry{ NodeType::Sqrtabs, "sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)" },
+        Entry{ NodeType::Tan, "tan", "tangent function f(a) = tan(a)" },
+        Entry{ NodeType::Tanh, "tanh", "hyperbolic tangent function f(a) = tanh(a)" },
+        Entry{ NodeType::Square, "square", "square function f(a) = a^2" },
+        Entry{ NodeType::Dynamic, "dyn", "user-defined function" },
+        Entry{ NodeType::Constant, "constant", "a constant value" },
+        Entry{ NodeType::Variable, "variable", "a dataset input with an associated weight" },
+        Entry{ NodeType::Ref, "ref", "structural reference to another node (enables DAG sharing)" },
+    };
+
     template<typename... Ts, std::size_t... I>
     static void RegisterAll(DispatchTable<Ts...>& dt, std::index_sequence<I...> /*unused*/)
     {
@@ -41,6 +98,7 @@ private:
     }
 
     template<NodeType Type, typename T, typename... Ts>
+    requires Operon::Concepts::Arithmetic<T>
     static void RegisterForType(DispatchTable<Ts...>& dt, Operon::Hash hash)
     {
         constexpr auto S = DispatchTable<Ts...>::template BatchSize<T>;
@@ -49,8 +107,20 @@ private:
             Dispatch::MakeFunctionCall<Type, T, S>(),
             Dispatch::MakeDiffCall<Type, T, S>());
     }
+
+    template<NodeType Type, typename T, typename... Ts>
+    requires (!Operon::Concepts::Arithmetic<T>)
+    static void RegisterForType(DispatchTable<Ts...>& /*dt*/, Operon::Hash /*hash*/)
+    {
+    }
 };
 
 } // namespace Operon
+
+template<typename... Ts>
+Operon::DispatchTable<Ts...>::DispatchTable()
+{
+    Operon::StandardLibrary::Register(*this);
+}
 
 #endif

--- a/include/operon/core/symbol_library.hpp
+++ b/include/operon/core/symbol_library.hpp
@@ -5,9 +5,12 @@
 #ifndef OPERON_SYMBOL_LIBRARY_HPP
 #define OPERON_SYMBOL_LIBRARY_HPP
 
+#include <stdexcept>
+
 #include "dispatch.hpp"
 #include "node.hpp"
 #include "pset.hpp"
+#include "operon/hash/hash.hpp"
 #include "operon/interpreter/dual.hpp"
 
 // symbol_library.hpp: scalar-lambda adapters for registering user-defined
@@ -221,13 +224,34 @@ void RegisterBinary(DTable& dt, Operon::Hash hash, F primal,
 }
 
 // Bundles the metadata needed to register a user-defined function symbol.
+// Hash is derived from Name (via Operon::Hasher) rather than supplied by the
+// caller, so it can't accidentally collide with the small-integer hash range
+// reserved for built-ins (see NodeType's HashValue == static_cast<Hash>(type)).
 struct FunctionInfo {
-    Operon::Hash Hash;
-    std::string  Name;
-    std::string  Desc;
-    uint16_t     Arity;
-    size_t       Frequency{1};
+    std::string Name;
+    std::string Desc;
+    uint16_t    Arity;
+    size_t      Frequency{1};
 };
+
+namespace detail {
+    // [0, NodeTypes::Count) is reserved for built-in NodeType ordinals
+    // (Node(NodeType) ctor sets HashValue = static_cast<Hash>(type)); a
+    // name-derived hash landing there would silently overwrite a built-in's
+    // dispatch entry / name+desc. A real 64-bit XXHash of a non-empty name
+    // landing in that ~30-value range is not a plausible accident, but the
+    // check is nearly free and turns the impossible case into a clear error
+    // instead of silent corruption.
+    inline void ValidateUserHash(Operon::Hash hash, std::string_view name)
+    {
+        if (name.empty()) {
+            throw std::invalid_argument("FunctionInfo::Name must not be empty (it seeds the function's hash)");
+        }
+        if (hash < NodeTypes::Count) {
+            throw std::invalid_argument("FunctionInfo: name-derived hash falls in the range reserved for built-in NodeTypes");
+        }
+    }
+} // namespace detail
 
 // Register a unary function in the dispatch table, PrimitiveSet, and name
 // registry in a single call.  An optional explicit derivative may be supplied;
@@ -236,9 +260,11 @@ template<typename DTable, typename T, typename F, typename DF = Dispatch::Noop>
 void RegisterUnaryFunction(DTable& dt, PrimitiveSet& pset,
                            FunctionInfo const& info, F primal, DF deriv = {})
 {
-    RegisterUnary<DTable, T>(dt, info.Hash, std::move(primal), std::move(deriv));
-    pset.AddFunction(info.Hash, info.Arity, info.Frequency);
-    if (!info.Name.empty()) { Node::RegisterName(info.Hash, info.Name, info.Desc); }
+    auto const hash = Operon::Hasher{}(info.Name);
+    detail::ValidateUserHash(hash, info.Name);
+    RegisterUnary<DTable, T>(dt, hash, std::move(primal), std::move(deriv));
+    pset.AddFunction(hash, info.Arity, info.Frequency);
+    Node::RegisterName(hash, info.Name, info.Desc);
 }
 
 // Register a binary function in the dispatch table, PrimitiveSet, and name
@@ -250,10 +276,12 @@ void RegisterBinaryFunction(DTable& dt, PrimitiveSet& pset,
                             FunctionInfo const& info, F primal,
                             DFa derivA = {}, DFb derivB = {})
 {
-    RegisterBinary<DTable, T>(dt, info.Hash, std::move(primal),
+    auto const hash = Operon::Hasher{}(info.Name);
+    detail::ValidateUserHash(hash, info.Name);
+    RegisterBinary<DTable, T>(dt, hash, std::move(primal),
                               std::move(derivA), std::move(derivB));
-    pset.AddFunction(info.Hash, info.Arity, info.Frequency);
-    if (!info.Name.empty()) { Node::RegisterName(info.Hash, info.Name, info.Desc); }
+    pset.AddFunction(hash, info.Arity, info.Frequency);
+    Node::RegisterName(hash, info.Name, info.Desc);
 }
 
 } // namespace Operon

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -26,6 +26,17 @@ namespace {
     {
         return node.IsVariable() ? Node(NodeType::Variable).HashValue : node.HashValue;
     }
+
+    auto LookupDescription(Node const& node) -> pair<string, string> const&
+    {
+        auto& d = Descriptions();
+        auto const h = LookupHash(node);
+        auto const it = d.find(h);
+        if (it != d.end()) {
+            return it->second;
+        }
+        return d.at(node.IsDynamic() ? Node(NodeType::Dynamic).HashValue : h);
+    }
 } // namespace
 
     void Node::RegisterName(Operon::Hash hash, string name, string desc)
@@ -36,13 +47,13 @@ namespace {
     auto Node::Name() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
         StandardLibrary::RegisterNames();
-        return Descriptions().at(LookupHash(*this)).first;
+        return LookupDescription(*this).first;
     }
 
     auto Node::Desc() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
         StandardLibrary::RegisterNames();
-        return Descriptions().at(LookupHash(*this)).second;
+        return LookupDescription(*this).second;
     }
 
 } // namespace Operon

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -4,8 +4,10 @@
 
 #include "operon/core/node.hpp"
 
-#include <iterator>       // for pair
-#include <utility>        // for make_pair, pair
+#include <gtl/phmap.hpp>
+
+#include <stdexcept>      // for invalid_argument, out_of_range
+#include <utility>        // for make_pair, pair, move
 #include <string>         // for string
 
 #include "operon/core/standard_library.hpp"
@@ -16,9 +18,12 @@ using std::string;
 
 namespace Operon {
 namespace {
-    auto Descriptions() -> Operon::Map<Operon::Hash, pair<string, string>>&
+    // Thread-safe: Name()/Desc() are read on every tree format/print, which
+    // can happen concurrently with RegisterName() calls registering
+    // user-defined Dynamic functions during setup.
+    auto Descriptions() -> gtl::parallel_flat_hash_map_m<Operon::Hash, pair<string, string>>&
     {
-        static Operon::Map<Operon::Hash, pair<string, string>> desc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        static gtl::parallel_flat_hash_map_m<Operon::Hash, pair<string, string>> desc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
         return desc;
     }
 
@@ -27,30 +32,46 @@ namespace {
         return node.IsVariable() ? Node(NodeType::Variable).HashValue : node.HashValue;
     }
 
-    auto LookupDescription(Node const& node) -> pair<string, string> const&
+    // Returns by value: a reference into the map would not be safe to hand
+    // back once the lookup's internal lock (gtl::parallel_flat_hash_map_m
+    // shards its locking per bucket) has been released.
+    auto LookupDescription(Node const& node) -> pair<string, string>
     {
         auto& d = Descriptions();
         auto const h = LookupHash(node);
-        auto const it = d.find(h);
-        if (it != d.end()) {
-            return it->second;
+        pair<string, string> result;
+        if (d.if_contains(h, [&](auto const& kv) { result = kv.second; })) {
+            return result;
         }
-        return d.at(node.IsDynamic() ? Node(NodeType::Dynamic).HashValue : h);
+        auto const fallback = node.IsDynamic() ? Node(NodeType::Dynamic).HashValue : h;
+        if (d.if_contains(fallback, [&](auto const& kv) { result = kv.second; })) {
+            return result;
+        }
+        throw std::out_of_range("Node: no description registered for this hash");
     }
 } // namespace
 
     void Node::RegisterName(Operon::Hash hash, string name, string desc)
     {
-        Descriptions()[hash] = { std::move(name), std::move(desc) };
+        // Also used internally by StandardLibrary::RegisterNames() to seed
+        // built-in entries, whose hashes ARE in [0, NodeTypes::Count) by
+        // construction (Node(NodeType) ctor) - so this can't reject that
+        // range itself. User-facing callers (symbol_library.hpp) guard
+        // against landing in the reserved range before calling this.
+        Descriptions().lazy_emplace_l(
+            hash,
+            [&](auto& kv)         { kv.second = { std::move(name), std::move(desc) }; },
+            [&](auto const& ctor) { ctor(hash, std::make_pair(std::move(name), std::move(desc))); }
+        );
     }
 
-    auto Node::Name() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
+    auto Node::Name() const -> std::string
     {
         StandardLibrary::RegisterNames();
         return LookupDescription(*this).first;
     }
 
-    auto Node::Desc() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
+    auto Node::Desc() const -> std::string
     {
         StandardLibrary::RegisterNames();
         return LookupDescription(*this).second;

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -8,6 +8,7 @@
 #include <utility>        // for make_pair, pair
 #include <string>         // for string
 
+#include "operon/core/standard_library.hpp"
 #include "operon/core/types.hpp"
 
 using std::pair;
@@ -15,69 +16,33 @@ using std::string;
 
 namespace Operon {
 namespace {
-    Operon::Map<Operon::Hash, pair<string, string>> DynDesc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    auto Descriptions() -> Operon::Map<Operon::Hash, pair<string, string>>&
+    {
+        static Operon::Map<Operon::Hash, pair<string, string>> desc; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+        return desc;
+    }
+
+    auto LookupHash(Node const& node) -> Operon::Hash
+    {
+        return node.IsVariable() ? Node(NodeType::Variable).HashValue : node.HashValue;
+    }
 } // namespace
 
     void Node::RegisterName(Operon::Hash hash, string name, string desc)
     {
-        DynDesc[hash] = { std::move(name), std::move(desc) };
+        Descriptions()[hash] = { std::move(name), std::move(desc) };
     }
-
-    static const Operon::Map<NodeType, pair<string, string>> NodeDesc = {
-        { NodeType::Add,      std::make_pair("+", "n-ary addition f(a,b,c,...) = a + b + c + ...") },
-        { NodeType::Mul,      std::make_pair("*", "n-ary multiplication f(a,b,c,...) = a * b * c * ..." ) },
-        { NodeType::Sub,      std::make_pair("-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)" ) },
-        { NodeType::Div,      std::make_pair("/", "n-ary division f(a,b,c,..) = a / (b * c * ...)" ) },
-        { NodeType::Fmin,     std::make_pair("fmin", "minimum function f(a,b) = min(a,b)" ) },
-        { NodeType::Fmax,     std::make_pair("fmax", "maximum function f(a,b) = max(a,b)" ) },
-        { NodeType::Aq,       std::make_pair("aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)" ) },
-        { NodeType::Pow,      std::make_pair("pow", "raise to power f(a,b) = a^b" ) },
-        { NodeType::Powabs,   std::make_pair("powabs", "raise absolute value to power f(a,b) = |a|^b" ) },
-        { NodeType::Abs,      std::make_pair("abs", "absolute value function f(a) = abs(a)" ) },
-        { NodeType::Acos,     std::make_pair("acos", "inverse cosine function f(a) = acos(a)" ) },
-        { NodeType::Asin,     std::make_pair("asin", "inverse sine function f(a) = asin(a)" ) },
-        { NodeType::Atan,     std::make_pair("atan", "inverse tangent function f(a) = atan(a)" ) },
-        { NodeType::Cbrt,     std::make_pair("cbrt", "cube root function f(a) = cbrt(a)" ) },
-        { NodeType::Ceil,     std::make_pair("ceil", "ceiling function f(a) = ceil(a)" ) },
-        { NodeType::Cos,      std::make_pair("cos", "cosine function f(a) = cos(a)" ) },
-        { NodeType::Cosh,     std::make_pair("cosh", "hyperbolic cosine function f(a) = cosh(a)" ) },
-        { NodeType::Exp,      std::make_pair("exp", "e raised to the given power f(a) = e^a" ) },
-        { NodeType::Floor,    std::make_pair("floor", "floor function f(a) = floor(a)" ) },
-        { NodeType::Log,      std::make_pair("log", "natural (base e) logarithm f(a) = ln(a)" ) },
-        { NodeType::Logabs,   std::make_pair("logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)" ) },
-        { NodeType::Log1p,    std::make_pair("log1p", "f(a) = ln(a + 1), accurate even when a is close to zero" ) },
-        { NodeType::Sin,      std::make_pair("sin", "sine function f(a) = sin(a)" ) },
-        { NodeType::Sinh,     std::make_pair("sinh", "hyperbolic sine function f(a) = sinh(a)" ) },
-        { NodeType::Sqrt,     std::make_pair("sqrt", "square root function f(a) = sqrt(a)" ) },
-        { NodeType::Sqrtabs,  std::make_pair("sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)" ) },
-        { NodeType::Tan,      std::make_pair("tan", "tangent function f(a) = tan(a)" ) },
-        { NodeType::Tanh,     std::make_pair("tanh", "hyperbolic tangent function f(a) = tanh(a)" ) },
-        { NodeType::Square,   std::make_pair("square", "square function f(a) = a^2" ) },
-        { NodeType::Dynamic,  std::make_pair("dyn", "user-defined function" ) },
-        { NodeType::Constant, std::make_pair("constant", "a constant value" ) },
-        { NodeType::Variable, std::make_pair("variable", "a dataset input with an associated weight" ) },
-        { NodeType::Ref,      std::make_pair("ref", "structural reference to another node (enables DAG sharing)" ) },
-    };
 
     auto Node::Name() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
-        if (Type == NodeType::Dynamic) {
-            if (auto it = DynDesc.find(HashValue); it != DynDesc.end()) {
-                return it->second.first;
-            }
-        }
-        return NodeDesc.at(Type).first;
+        StandardLibrary::RegisterNames();
+        return Descriptions().at(LookupHash(*this)).first;
     }
 
     auto Node::Desc() const noexcept -> std::string const& // NOLINT(bugprone-exception-escape)
     {
-        if (Type == NodeType::Dynamic) {
-            if (auto it = DynDesc.find(HashValue); it != DynDesc.end()) {
-                return it->second.second;
-            }
-        }
-        return NodeDesc.at(Type).second;
+        StandardLibrary::RegisterNames();
+        return Descriptions().at(LookupHash(*this)).second;
     }
 
 } // namespace Operon
-

--- a/test/source/implementation/dispatch_table.cpp
+++ b/test/source/implementation/dispatch_table.cpp
@@ -377,12 +377,13 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
     pset.SetConfig(Operon::PrimitiveSet::Arithmetic);
 
     Operon::FunctionInfo const info{
-        .Hash      = Operon::Hasher{}("test::cube"),
         .Name      = "cube",
         .Desc      = "cube function f(x) = x^3",
         .Arity     = 1,
         .Frequency = 1
     };
+    // RegisterUnaryFunction derives the hash from info.Name the same way.
+    auto const hash = Operon::Hasher{}(info.Name);
 
     auto primal  = [](auto v) -> auto { return v * v * v; };
     auto dprimal = [](auto v) -> auto { return 3 * v * v; };
@@ -390,22 +391,22 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
     Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
 
     SECTION("Name and Desc are registered on the node") {
-        Operon::Node const dynNode(Operon::NodeType::Dynamic, info.Hash);
+        Operon::Node const dynNode(Operon::NodeType::Dynamic, hash);
         CHECK(dynNode.Name() == "cube");
         CHECK(dynNode.Desc() == "cube function f(x) = x^3");
     }
 
     SECTION("Hash is present in dispatch table and primitive set") {
-        CHECK(dt.Contains(info.Hash));
-        CHECK(pset.Contains(info.Hash));
-        CHECK(pset.MinimumArity(info.Hash) == 1);
+        CHECK(dt.Contains(hash));
+        CHECK(pset.Contains(hash));
+        CHECK(pset.MinimumArity(hash) == 1);
     }
 
     SECTION("Evaluation is correct") {
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, info.Hash);
+        Operon::Node dynNode(Operon::NodeType::Dynamic, hash);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 
@@ -423,7 +424,7 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, info.Hash);
+        Operon::Node dynNode(Operon::NodeType::Dynamic, hash);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 

--- a/test/source/implementation/dispatch_table.cpp
+++ b/test/source/implementation/dispatch_table.cpp
@@ -431,6 +431,17 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         auto formatted = InfixFormatter::Format(tree, ds);
         CHECK(formatted.find("cube") != std::string::npos);
     }
+
+    SECTION("PostfixFormatter and DotFormatter use registered built-in names") {
+        auto builtInTree = InfixParser::Parse("sin(x)");
+
+        auto postfix = PostfixFormatter::Format(builtInTree, ds);
+        CHECK(postfix == "((1.00 * x) sin) ");
+
+        auto dot = DotFormatter::Format(builtInTree, ds);
+        CHECK(dot.find("[label=\"sin\"]") != std::string::npos);
+        CHECK(dot.find("0 -> 1") != std::string::npos);
+    }
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -69,4 +69,36 @@ TEST_CASE("Mutation tree stays within bounds", "[operators]")
     }
 }
 
+TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators unchanged", "[operators]")
+{
+    auto ds = Dataset("./data/Poly-10.csv", true);
+    auto inputs = ds.VariableHashes();
+    std::erase(inputs, ds.GetVariable("Y").value().Hash);
+    auto const maxDepth{1000};
+    auto const maxLength{50};
+
+    PrimitiveSet grammar;
+    grammar.SetConfig(PrimitiveSet::Arithmetic);
+
+    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    UniformCoefficientInitializer cfi;
+
+    auto const variableHash = ds.GetVariable("X1").value().Hash;
+    Node variable(NodeType::Variable);
+    variable.HashValue = variable.CalculatedHashValue = variableHash;
+
+    Node sin(NodeType::Sin);
+    sin.Length = 1;
+
+    Tree const tree({ variable, sin });
+
+    Operon::RandomGenerator random(1234);
+    InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxLength, maxDepth);
+    auto child = mut(random, tree);
+
+    CHECK(child.Length() == tree.Length());
+    CHECK(child[child.Length() - 1].Type == NodeType::Sin);
+    CHECK(child[0].HashValue == variableHash);
+}
+
 } // namespace Operon::Test

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -6,6 +6,7 @@
 
 #include "operon/core/node.hpp"
 #include "operon/core/standard_library.hpp"
+#include "operon/hash/hash.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/parser/infix.hpp"
 
@@ -92,6 +93,30 @@ TEST_CASE("StandardLibrary populates dispatch tables and node names consistently
                 CHECK(rDefault[i] == rRuntime[i]); // bit-identical: same compiled kernels
             }
         }
+    }
+}
+
+TEST_CASE("Unregistered Dynamic nodes fall back to the generic name/desc", "[interpreter]")
+{
+    Operon::StandardLibrary::RegisterNames();
+
+    Operon::Hash const unregisteredHash = Operon::Hasher{}("test::unregistered_dynamic_fallback");
+    Operon::Node const dynNode(Operon::NodeType::Dynamic, unregisteredHash);
+
+    SECTION("Name() returns the generic \"dyn\" fallback") {
+        CHECK(dynNode.Name() == "dyn");
+    }
+
+    SECTION("Desc() returns the generic \"user-defined function\" fallback") {
+        CHECK(dynNode.Desc() == "user-defined function");
+    }
+
+    SECTION("A registered Dynamic node still resolves to its specific name") {
+        Operon::Hash const registeredHash = Operon::Hasher{}("test::registered_dynamic_fallback");
+        Operon::Node::RegisterName(registeredHash, "myop", "my custom op");
+        Operon::Node const registeredDyn(Operon::NodeType::Dynamic, registeredHash);
+        CHECK(registeredDyn.Name() == "myop");
+        CHECK(registeredDyn.Desc() == "my custom op");
     }
 }
 

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -14,7 +14,7 @@
 
 namespace Operon::Test {
 
-TEST_CASE("StandardLibrary::Register matches the default DispatchTable construction", "[interpreter]") // NOLINT(readability-function-cognitive-complexity)
+TEST_CASE("StandardLibrary populates dispatch tables and node names consistently", "[interpreter]") // NOLINT(readability-function-cognitive-complexity)
 {
     using DT = Operon::DispatchTable<Operon::Scalar>;
     using Scalar = Operon::Scalar;
@@ -22,7 +22,7 @@ TEST_CASE("StandardLibrary::Register matches the default DispatchTable construct
     using FnPtr  = void (*)(Operon::Vector<Node> const&, Backend::View<Scalar, S>, size_t, Operon::Range);
     using DfPtr  = void (*)(Operon::Vector<Node> const&, Backend::View<Scalar const, S>, Backend::View<Scalar, S>, int, int);
 
-    DT const dtDefault; // populated by the existing compile-time enum loop
+    DT const dtDefault;
 
     DT dtRuntime;
     dtRuntime.GetMap().clear();
@@ -34,6 +34,13 @@ TEST_CASE("StandardLibrary::Register matches the default DispatchTable construct
             CHECK(dtDefault.Contains(h));
             CHECK(dtRuntime.Contains(h));
         }
+    }
+
+    SECTION("Built-in names and descriptions are available through the unified hash registry") {
+        CHECK(Operon::Node(Operon::NodeType::Add).Name() == "+");
+        CHECK(Operon::Node(Operon::NodeType::Add).Desc() == "n-ary addition f(a,b,c,...) = a + b + c + ...");
+        CHECK(Operon::Node(Operon::NodeType::Dynamic).Name() == "dyn");
+        CHECK(Operon::Node(Operon::NodeType::Variable).Name() == "variable");
     }
 
     SECTION("Registered callables are the identical compiled kernels (same function pointer target)") {


### PR DESCRIPTION
## Summary

Phase 2 of the generic-node-registry migration (see #131 for Phase 1's context — this PR is based on `main` directly, so its diff includes Phase 1's commit until #131 merges).

- `DispatchTable`'s default constructor now delegates to `StandardLibrary::Register(*this)` instead of its own compile-time `index_sequence` loop.
- Fixes a latent bug this exposed: `DispatchTable<Operon::Scalar, Operon::Seq<...>>` (used in the performance benchmark suite) has a trailing non-arithmetic "batch size" type parameter that the original constructor excluded via a private count; the new registration path now does the same via a `requires`/`!requires` overload split.
- Unifies `Node::Name()`/`Desc()` onto a single hash-keyed registry (folding the static `NodeDesc` table into the same mechanism used for user-registered `Dynamic` function names), preserving the existing special case where `Variable` nodes carry a per-dataset-column hash rather than their type ordinal.
- `NodeType` values and the arity-boundary invariants in `node.hpp` are untouched in this phase.

## Test plan
- [x] `./build/test/operon_test '~[performance]'` — 236 cases (234 passed, 2 pre-existing unrelated failures)
- [x] The 2 failures (`Backend vs vdt ULP accuracy`, `Backend transcendental ULP accuracy`) were independently verified via clean builds to reproduce identically on `main`, on Phase 1, and on this branch — a pre-existing floating-point precision issue in the Eve SIMD backend's large-argument `Sin`/`Cos`, unrelated to this change
- [x] Added regression coverage for postfix/dot formatter output using registered built-in names, and for the mutation arity-change gate under the new registration path