### PR TITLE
cmake: enforce -march=x86-64-v3 on x86/non-Windows without a preset

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,7 +3,9 @@
 ## Build
 
 This project doesn't require any special command-line flags to build to keep
-things simple.
+things simple. Note: on non-Windows x86-64, the build targets `-march=x86-64-v3`
+(Haswell-era, 2013+) unconditionally, so binaries built here will not run on
+older x86-64 CPUs.
 
 ### Using nix
 The recommended way to build operon is to use nix package manager.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,21 @@ else()
     target_compile_options(operon_operon PRIVATE "-fno-math-errno")
 endif()
 
+# The Eve backend's FastSinCos (include/operon/interpreter/backend/eve/
+# functions.hpp) does 3-part FMA range reduction that is only numerically
+# correct with genuine single-rounding hardware FMA, and Eve only selects
+# the FMA-capable 256-bit vector path when AVX2 is enabled. The
+# build-linux preset sets -march=x86-64-v3 (which implies both); mirror
+# that here as PUBLIC so a plain `cmake -S . -B build` (no preset) gets
+# identical codegen, and so consumers/tests that instantiate FastSinCos
+# from the public backend headers are compiled correctly too. Scoped to
+# x86_64/non-Windows (same gate as the USE_ASMJIT check above); Windows
+# gets /arch:AVX2 from the build-windows preset and clang-cl does not take
+# -march. Apple Silicon is arm64 and naturally excluded.
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i.86)$" AND NOT WIN32)
+    target_compile_options(operon_operon PUBLIC "-march=x86-64-v3")
+endif()
+
 if (HAVE_ASMJIT)
     target_link_libraries(operon_operon PUBLIC asmjit::asmjit)
     target_sources(operon_operon PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,22 +278,15 @@ else()
     target_compile_options(operon_operon PRIVATE "-fno-math-errno")
 endif()
 
-# The Eve backend's FastSinCos (include/operon/interpreter/backend/eve/
-# functions.hpp) does 3-part FMA range reduction that is only numerically
-# correct with genuine single-rounding hardware FMA, and Eve only selects
-# the FMA-capable 256-bit vector path when AVX2 is enabled. The
-# build-linux preset sets -march=x86-64-v3 (which implies both); mirror
-# that here as PUBLIC so a plain `cmake -S . -B build` (no preset) gets
-# identical codegen, and so consumers/tests that instantiate FastSinCos
-# from the public backend headers are compiled correctly too. Scoped to
-# 64-bit x86_64/non-Windows (same gate as the USE_ASMJIT check above);
-# -march=x86-64-v3 is a 64-bit-only architecture level, so 32-bit x86
-# (i386/i486/.../i686) is excluded. Windows gets /arch:AVX2 from the
-# build-windows preset and clang-cl does not take -march. Apple Silicon
-# is arm64 and naturally excluded.
+# FastSinCos's range reduction (interpreter/backend/eve/functions.hpp)
+# requires genuine hardware FMA, and Eve needs AVX2 to select that code
+# path. PUBLIC: FastSinCos is instantiated from public headers, so
+# consumers need the flag too. 64-bit x86_64/non-Windows only:
+# -march=x86-64-v3 is 64-bit-only (excludes i386/i486/.../i686); Windows
+# gets /arch:AVX2 via the build-windows preset.
 #
-# NOTE: this raises the minimum supported CPU to Haswell-era (2013+)
-# x86-64 for non-preset builds - see BUILDING.md.
+# Raises the minimum supported CPU to Haswell-era (2013+) x86-64 - see
+# BUILDING.md.
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$" AND NOT WIN32)
     target_compile_options(operon_operon PUBLIC "-march=x86-64-v3")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,10 +286,15 @@ endif()
 # that here as PUBLIC so a plain `cmake -S . -B build` (no preset) gets
 # identical codegen, and so consumers/tests that instantiate FastSinCos
 # from the public backend headers are compiled correctly too. Scoped to
-# x86_64/non-Windows (same gate as the USE_ASMJIT check above); Windows
-# gets /arch:AVX2 from the build-windows preset and clang-cl does not take
-# -march. Apple Silicon is arm64 and naturally excluded.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|i.86)$" AND NOT WIN32)
+# 64-bit x86_64/non-Windows (same gate as the USE_ASMJIT check above);
+# -march=x86-64-v3 is a 64-bit-only architecture level, so 32-bit x86
+# (i386/i486/.../i686) is excluded. Windows gets /arch:AVX2 from the
+# build-windows preset and clang-cl does not take -march. Apple Silicon
+# is arm64 and naturally excluded.
+#
+# NOTE: this raises the minimum supported CPU to Haswell-era (2013+)
+# x86-64 for non-preset builds - see BUILDING.md.
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64)$" AND NOT WIN32)
     target_compile_options(operon_operon PUBLIC "-march=x86-64-v3")
 endif()
 


### PR DESCRIPTION
## Summary

The Eve backend's `FastSinCos` (`include/operon/interpreter/backend/eve/functions.hpp`) does 3-part FMA range reduction that is only numerically correct with genuine hardware FMA. The `build-linux`/CI preset already sets `-march=x86-64-v3` (which includes FMA), but a plain non-preset `cmake -S . -B build` got no `-march`/`-mfma`/`-mavx2` at all, so it silently computed wrong `sin`/`cos` results at large `|x|` — e.g. `cos(-98.96)` off by ~196000 ULP, with no build error or warning.

This adds the same `-march=x86-64-v3` flag unconditionally (gated on x86_64/non-Windows, mirroring the existing `USE_ASMJIT` platform check) so a plain non-preset build converges with the CI-tested preset's codegen instead of silently diverging. The existing per-file `-mavx2` on `jit_compiler.cpp` is left in place as harmless defense-in-depth.

As a side effect, this also fixes the same latent bug on the `build-osx` preset, which never set `-march` at all.

## Test plan
- [x] From-scratch non-preset build (`cmake -S . -B build`, no `--preset`) now compiles with `-march=x86-64-v3`
- [x] The two previously-failing tests (`Backend transcendental ULP accuracy`, `Backend vs vdt ULP accuracy`) now pass
- [x] Full non-performance suite green (234 cases)
- [x] `build-linux` and `build-osx` presets still configure and build cleanly with the flag layered on top (no duplicate/conflicting flag issues)