### PR TITLE
fix(hash): stop colliding distinct non-variable node identities in Zobrist

### DIFF
--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -5,6 +5,7 @@
 #ifndef OPERON_HASH_ZOBRIST_HPP
 #define OPERON_HASH_ZOBRIST_HPP
 
+#include <array>
 #include <atomic>
 #include <memory>
 
@@ -13,6 +14,7 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
+#include "operon/hash/hash.hpp"
 #include "operon/operon_export.hpp"
 
 namespace Operon {
@@ -90,7 +92,16 @@ class OPERON_EXPORT Zobrist {
     using Extents = std::extents<int, std::dynamic_extent, std::dynamic_extent>;
     using Table   = MDArray<Hash, Extents>;
 
+    // table_ holds one precomputed random row per variable (known and finite
+    // upfront, from variableHashes) plus one row for the Optimize marker.
+    // Non-variable node identity (built-in or user-registered function hash)
+    // is NOT table-indexed: that identity space is open-ended by design (any
+    // number of functions can be registered, at any time, not necessarily
+    // before a Zobrist is constructed), so there is no safe upper bound to
+    // size a table row-count from. Instead it's combined via seed_ below -
+    // see ComputeHash.
     Table table_;
+    Hash seed_{};
     Map<Hash, int> varIndex_;
 
     struct TranspositionTable;
@@ -120,10 +131,13 @@ public:
         if (n.IsVariable()) {
             auto const it = varIndex_.find(n.HashValue);
             ENSURE(it != varIndex_.end());
-            auto const row = static_cast<int>(NodeTypes::Count) + it->second;
-            h = table_[row, pos];
+            h = table_[it->second, pos];
         } else {
-            h = table_[NodeTypes::GetIndex(n.Type), pos];
+            // Combine the node's own identity hash with its tree position and
+            // this instance's random seed, rather than a table lookup - see
+            // the comment on table_ above for why.
+            std::array<Hash, 3> const buf{ n.HashValue, static_cast<Hash>(pos), seed_ };
+            h = Operon::Hasher{}(reinterpret_cast<uint8_t const*>(buf.data()), sizeof(buf)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         }
         if (n.Optimize) {
             h ^= table_[OptimizeRow(), pos];

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -98,10 +98,9 @@ class OPERON_EXPORT Zobrist {
     // is NOT table-indexed: that identity space is open-ended by design (any
     // number of functions can be registered, at any time, not necessarily
     // before a Zobrist is constructed), so there is no safe upper bound to
-    // size a table row-count from. Instead it's combined via seed_ below -
-    // see ComputeHash.
+    // size a table row-count from. Instead it's combined directly from the
+    // node's HashValue - see ComputeHash.
     Table table_;
-    Hash seed_{};
     Map<Hash, int> varIndex_;
 
     struct TranspositionTable;
@@ -133,10 +132,13 @@ public:
             ENSURE(it != varIndex_.end());
             h = table_[it->second, pos];
         } else {
-            // Combine the node's own identity hash with its tree position and
-            // this instance's random seed, rather than a table lookup - see
-            // the comment on table_ above for why.
-            std::array<Hash, 3> const buf{ n.HashValue, static_cast<Hash>(pos), seed_ };
+            // Combine the node's own identity hash with its tree position,
+            // rather than a table lookup - see the comment on table_ above
+            // for why. No per-instance salt is needed: nothing in this
+            // codebase compares or merges hash values across different
+            // Zobrist instances (each owns its own private cache), so there's
+            // no cross-instance independence property to preserve here.
+            std::array<Hash, 2> const buf{ n.HashValue, static_cast<Hash>(pos) };
             h = Operon::Hasher{}(reinterpret_cast<uint8_t const*>(buf.data()), sizeof(buf)); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
         }
         if (n.Optimize) {

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -14,7 +14,8 @@ struct Zobrist::TranspositionTable {
 };
 
 Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes)
-    : table_(static_cast<int>(NodeTypes::Count) + static_cast<int>(variableHashes.size()) + 1, maxLength)
+    : table_(static_cast<int>(variableHashes.size()) + 1, maxLength)
+    , seed_(rng())
     , tt_(std::make_unique<TranspositionTable>())
 {
     std::generate(table_.container().begin(), table_.container().end(), std::ref(rng));

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -15,7 +15,6 @@ struct Zobrist::TranspositionTable {
 
 Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes)
     : table_(static_cast<int>(variableHashes.size()) + 1, maxLength)
-    , seed_(rng())
     , tt_(std::make_unique<TranspositionTable>())
 {
     std::generate(table_.container().begin(), table_.container().end(), std::ref(rng));

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -204,6 +204,45 @@ TEST_CASE("Zobrist - duplicate inserts increment count, not entries", "[zobrist]
     REQUIRE(cache.Size() == 1); // only one entry
 }
 
+TEST_CASE("Zobrist - distinct built-in ops at the same position yield distinct hashes", "[zobrist]")
+{
+    // Regression test: ComputeHash used to index a table row by
+    // NodeTypes::GetIndex(n.Type) for every non-variable node, so this
+    // already held for distinct built-ins (they have distinct NodeType
+    // values) - this test pins that property now that non-variable
+    // identity is combined from n.HashValue instead of table-indexed.
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const cache(rng, MaxLength, {});
+
+    REQUIRE(cache.ComputeHash(Node(NodeType::Add), 0) != cache.ComputeHash(Node(NodeType::Mul), 0));
+    REQUIRE(cache.ComputeHash(Node(NodeType::Sin), 0) != cache.ComputeHash(Node(NodeType::Cos), 0));
+}
+
+TEST_CASE("Zobrist - distinct Dynamic-hash user functions yield distinct hashes", "[zobrist]")
+{
+    // Regression test for the actual bug this fix addresses: previously
+    // ALL NodeType::Dynamic nodes shared one table row via
+    // NodeTypes::GetIndex(NodeType::Dynamic), regardless of HashValue -
+    // meaning two different user-registered functions collided onto the
+    // same Zobrist identity and could cause a cached fitness value to be
+    // wrongly reused for a structurally different tree using a different
+    // custom function at the same position.
+    Operon::RandomGenerator rng(Seed);
+    Zobrist const cache(rng, MaxLength, {});
+
+    Operon::Hash const hashA = Operon::Hasher{}("userFunctionA");
+    Operon::Hash const hashB = Operon::Hasher{}("userFunctionB");
+    REQUIRE(hashA != hashB);
+
+    Node const nodeA(NodeType::Dynamic, hashA);
+    Node const nodeB(NodeType::Dynamic, hashB);
+
+    REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(nodeB, 0));
+
+    // Also distinct from a built-in occupying the same tree position.
+    REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(Node(NodeType::Add), 0));
+}
+
 TEST_CASE("Zobrist - different Optimize flags yield different hashes", "[zobrist]")
 {
     Operon::RandomGenerator rng(Seed);

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -241,6 +241,12 @@ TEST_CASE("Zobrist - distinct Dynamic-hash user functions yield distinct hashes"
 
     // Also distinct from a built-in occupying the same tree position.
     REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(Node(NodeType::Add), 0));
+
+    // Same Dynamic hash at two different positions must also differ - pins
+    // position-sensitivity for the non-table combine path specifically,
+    // not just (as the pre-existing "position sensitivity" test covers)
+    // for built-ins via full-tree XOR.
+    REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(nodeA, 1));
 }
 
 TEST_CASE("Zobrist - different Optimize flags yield different hashes", "[zobrist]")


### PR DESCRIPTION
## Summary

`Zobrist::ComputeHash` indexed its transposition-table row for non-variable nodes via `NodeTypes::GetIndex(n.Type)` — a function purely of `n.Type`, never `n.HashValue`. Every `NodeType::Dynamic` node therefore shared exactly one row regardless of which user-registered function it actually was: two structurally different trees using two different custom functions at the same tree position could hash identically, risking a cached fitness value from one tree being wrongly reused for the other.

This is PR 0 of a larger planned sequence (collapsing `NodeType` to `{Constant, Variable, Ref, Function}`, following #131/#132) but is a real, independently valuable bug fix on its own — it doesn't touch `NodeType`'s shape at all.

## Design

Non-variable node identity is no longer table-indexed. Instead of a bounded array lookup, `ComputeHash` combines `(n.HashValue, position)` via `Operon::Hasher` (the same XXHash-based hasher used throughout the codebase).

This was chosen over keeping a table indexed by a `PrimitiveSet`-derived dense index because the set of non-variable identities is open-ended by design (any number of functions, built-in or user-registered, at any time) — a table-based design would require every identity that could ever appear to be enumerated before `Zobrist` construction and never change afterward, an invariant that doesn't hold today (trees can be built without a populated `PrimitiveSet` at all in several existing test fixtures) and is fragile to maintain going forward. The variable dimension keeps its existing table-based approach, since that set is always small and known upfront from `variableHashes`.

Zero call-site changes were needed anywhere in the codebase — the constructor signature is unchanged.

## Test plan
- [x] All existing Zobrist tests pass unchanged (property-based, none depended on internal row counts)
- [x] New regression test: distinct built-in ops at the same tree position yield distinct hashes
- [x] New regression test: two distinct `Dynamic`-hash user functions at the same tree position yield distinct hashes (the actual bug) — and are distinct from a built-in occupying the same position
- [x] Full non-performance suite: `./build/test/operon_test '~[performance]'` — 239/239 test cases, 23799/23799 assertions green