### PR TITLE
core: arity/format-rule registry for StandardLibrary (generic-nodes PR 1)

### DIFF
--- a/include/operon/core/pset.hpp
+++ b/include/operon/core/pset.hpp
@@ -69,7 +69,7 @@ public:
 
     void RemovePrimitive(Operon::Hash hash) { pset_.erase(hash); }
 
-    void SetConfig(PrimitiveSetConfig config);
+    OPERON_EXPORT void SetConfig(PrimitiveSetConfig config);
 
     [[nodiscard]] auto EnabledPrimitives() const -> std::vector<Node> {
         std::vector<Node> nodes;

--- a/include/operon/core/pset.hpp
+++ b/include/operon/core/pset.hpp
@@ -69,18 +69,7 @@ public:
 
     void RemovePrimitive(Operon::Hash hash) { pset_.erase(hash); }
 
-    void SetConfig(PrimitiveSetConfig config)
-    {
-        pset_.clear();
-        for (size_t i = 0; i < Operon::NodeTypes::Count; ++i) {
-            auto t = static_cast<Operon::NodeType>(i);
-            Operon::Node n(t);
-
-            if (config.Test(i)) {
-                pset_[n.HashValue] = { n, 1, n.Arity, n.Arity };
-            }
-        }
-    }
+    void SetConfig(PrimitiveSetConfig config);
 
     [[nodiscard]] auto EnabledPrimitives() const -> std::vector<Node> {
         std::vector<Node> nodes;

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -29,8 +29,11 @@ namespace Operon {
 enum class FormatRule : uint8_t {
     GenericCall,    // name(a) / name(a, b, ...)
     Infix,          // a <op> b <op> c ...
-    PrefixNegation, // unary form renders as -a (Sub with arity 1)
-    Inversion,      // unary form renders as 1 / a (Div with arity 1)
+    PrefixNegation, // unary form renders as -a (Sub with arity 1; not
+                    // reachable via the registry below since Sub's
+                    // MinArity/MaxArity is fixed at 2 there)
+    Inversion,      // unary form renders as 1 / a (Div with arity 1; same
+                    // caveat as PrefixNegation)
     PowerNotation,  // a ^ b
     MinMaxCall,     // min(a, b) / max(a, b)
     Composite,      // bespoke multi-token expansion, e.g. log(abs(a))
@@ -83,8 +86,8 @@ private:
     static constexpr std::array Entries {
         Entry{ NodeType::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ...", 2, 2, FormatRule::Infix },
         Entry{ NodeType::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ...", 2, 2, FormatRule::Infix },
-        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)", 2, 2, FormatRule::PrefixNegation },
-        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)", 2, 2, FormatRule::Inversion },
+        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)", 2, 2, FormatRule::Infix },
+        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)", 2, 2, FormatRule::Infix },
         Entry{ NodeType::Fmin, "fmin", "minimum function f(a,b) = min(a,b)", 2, 2, FormatRule::MinMaxCall },
         Entry{ NodeType::Fmax, "fmax", "maximum function f(a,b) = max(a,b)", 2, 2, FormatRule::MinMaxCall },
         Entry{ NodeType::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)", 2, 2, FormatRule::Composite },

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -5,7 +5,9 @@
 #define OPERON_STANDARD_LIBRARY_HPP
 
 #include <array>
+#include <cstdint>
 #include <string_view>
+#include <utility>
 
 #include "dispatch.hpp"
 #include "node.hpp"
@@ -19,6 +21,20 @@
 // which path registered it.
 
 namespace Operon {
+
+// How a node's infix-notation rendering diverges from plain call syntax
+// `name(child, ...)` (GenericCall, the default). Consumed by the formatter;
+// stored here so a node's rendering rule travels with its other metadata
+// instead of living as a separate `if (s.Type == NodeType::X)` chain.
+enum class FormatRule : uint8_t {
+    GenericCall,    // name(a) / name(a, b, ...)
+    Infix,          // a <op> b <op> c ...
+    PrefixNegation, // unary form renders as -a (Sub with arity 1)
+    Inversion,      // unary form renders as 1 / a (Div with arity 1)
+    PowerNotation,  // a ^ b
+    MinMaxCall,     // min(a, b) / max(a, b)
+    Composite,      // bespoke multi-token expansion, e.g. log(abs(a))
+};
 
 struct StandardLibrary {
     static void RegisterNames()
@@ -41,47 +57,63 @@ struct StandardLibrary {
         RegisterAll(dt, std::make_index_sequence<NodeTypes::Count - 4>{});
     }
 
+    // Min/max arity for a built-in NodeType, sourced from the registry
+    // instead of Node(type).Arity's position-based inference (Node's ctor
+    // infers arity from where `type` falls relative to the Abs/Dynamic
+    // boundaries; this walks the same data the registry already carries
+    // explicitly, which is what PrimitiveSet's preset configs consume).
+    [[nodiscard]] static constexpr auto ArityLimits(NodeType type) -> std::pair<uint16_t, uint16_t>
+    {
+        for (auto const& entry : Entries) {
+            if (entry.Type == type) { return { entry.MinArity, entry.MaxArity }; }
+        }
+        return { 0, 0 };
+    }
+
 private:
     struct Entry {
         NodeType Type;
         std::string_view Name;
         std::string_view Desc;
+        uint16_t MinArity;
+        uint16_t MaxArity;
+        FormatRule Rule;
     };
 
     static constexpr std::array Entries {
-        Entry{ NodeType::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ..." },
-        Entry{ NodeType::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ..." },
-        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)" },
-        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)" },
-        Entry{ NodeType::Fmin, "fmin", "minimum function f(a,b) = min(a,b)" },
-        Entry{ NodeType::Fmax, "fmax", "maximum function f(a,b) = max(a,b)" },
-        Entry{ NodeType::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)" },
-        Entry{ NodeType::Pow, "pow", "raise to power f(a,b) = a^b" },
-        Entry{ NodeType::Powabs, "powabs", "raise absolute value to power f(a,b) = |a|^b" },
-        Entry{ NodeType::Abs, "abs", "absolute value function f(a) = abs(a)" },
-        Entry{ NodeType::Acos, "acos", "inverse cosine function f(a) = acos(a)" },
-        Entry{ NodeType::Asin, "asin", "inverse sine function f(a) = asin(a)" },
-        Entry{ NodeType::Atan, "atan", "inverse tangent function f(a) = atan(a)" },
-        Entry{ NodeType::Cbrt, "cbrt", "cube root function f(a) = cbrt(a)" },
-        Entry{ NodeType::Ceil, "ceil", "ceiling function f(a) = ceil(a)" },
-        Entry{ NodeType::Cos, "cos", "cosine function f(a) = cos(a)" },
-        Entry{ NodeType::Cosh, "cosh", "hyperbolic cosine function f(a) = cosh(a)" },
-        Entry{ NodeType::Exp, "exp", "e raised to the given power f(a) = e^a" },
-        Entry{ NodeType::Floor, "floor", "floor function f(a) = floor(a)" },
-        Entry{ NodeType::Log, "log", "natural (base e) logarithm f(a) = ln(a)" },
-        Entry{ NodeType::Logabs, "logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)" },
-        Entry{ NodeType::Log1p, "log1p", "f(a) = ln(a + 1), accurate even when a is close to zero" },
-        Entry{ NodeType::Sin, "sin", "sine function f(a) = sin(a)" },
-        Entry{ NodeType::Sinh, "sinh", "hyperbolic sine function f(a) = sinh(a)" },
-        Entry{ NodeType::Sqrt, "sqrt", "square root function f(a) = sqrt(a)" },
-        Entry{ NodeType::Sqrtabs, "sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)" },
-        Entry{ NodeType::Tan, "tan", "tangent function f(a) = tan(a)" },
-        Entry{ NodeType::Tanh, "tanh", "hyperbolic tangent function f(a) = tanh(a)" },
-        Entry{ NodeType::Square, "square", "square function f(a) = a^2" },
-        Entry{ NodeType::Dynamic, "dyn", "user-defined function" },
-        Entry{ NodeType::Constant, "constant", "a constant value" },
-        Entry{ NodeType::Variable, "variable", "a dataset input with an associated weight" },
-        Entry{ NodeType::Ref, "ref", "structural reference to another node (enables DAG sharing)" },
+        Entry{ NodeType::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ...", 2, 2, FormatRule::Infix },
+        Entry{ NodeType::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ...", 2, 2, FormatRule::Infix },
+        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)", 2, 2, FormatRule::PrefixNegation },
+        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)", 2, 2, FormatRule::Inversion },
+        Entry{ NodeType::Fmin, "fmin", "minimum function f(a,b) = min(a,b)", 2, 2, FormatRule::MinMaxCall },
+        Entry{ NodeType::Fmax, "fmax", "maximum function f(a,b) = max(a,b)", 2, 2, FormatRule::MinMaxCall },
+        Entry{ NodeType::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)", 2, 2, FormatRule::Composite },
+        Entry{ NodeType::Pow, "pow", "raise to power f(a,b) = a^b", 2, 2, FormatRule::PowerNotation },
+        Entry{ NodeType::Powabs, "powabs", "raise absolute value to power f(a,b) = |a|^b", 2, 2, FormatRule::Composite },
+        Entry{ NodeType::Abs, "abs", "absolute value function f(a) = abs(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Acos, "acos", "inverse cosine function f(a) = acos(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Asin, "asin", "inverse sine function f(a) = asin(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Atan, "atan", "inverse tangent function f(a) = atan(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Cbrt, "cbrt", "cube root function f(a) = cbrt(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Ceil, "ceil", "ceiling function f(a) = ceil(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Cos, "cos", "cosine function f(a) = cos(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Cosh, "cosh", "hyperbolic cosine function f(a) = cosh(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Exp, "exp", "e raised to the given power f(a) = e^a", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Floor, "floor", "floor function f(a) = floor(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Log, "log", "natural (base e) logarithm f(a) = ln(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Logabs, "logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)", 1, 1, FormatRule::Composite },
+        Entry{ NodeType::Log1p, "log1p", "f(a) = ln(a + 1), accurate even when a is close to zero", 1, 1, FormatRule::Composite },
+        Entry{ NodeType::Sin, "sin", "sine function f(a) = sin(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Sinh, "sinh", "hyperbolic sine function f(a) = sinh(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Sqrt, "sqrt", "square root function f(a) = sqrt(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Sqrtabs, "sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)", 1, 1, FormatRule::Composite },
+        Entry{ NodeType::Tan, "tan", "tangent function f(a) = tan(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Tanh, "tanh", "hyperbolic tangent function f(a) = tanh(a)", 1, 1, FormatRule::GenericCall },
+        Entry{ NodeType::Square, "square", "square function f(a) = a^2", 1, 1, FormatRule::PowerNotation },
+        Entry{ NodeType::Dynamic, "dyn", "user-defined function", 0, 0, FormatRule::GenericCall },
+        Entry{ NodeType::Constant, "constant", "a constant value", 0, 0, FormatRule::GenericCall },
+        Entry{ NodeType::Variable, "variable", "a dataset input with an associated weight", 0, 0, FormatRule::GenericCall },
+        Entry{ NodeType::Ref, "ref", "structural reference to another node (enables DAG sharing)", 0, 0, FormatRule::GenericCall },
     };
 
     template<typename... Ts, std::size_t... I>

--- a/include/operon/core/symbol_library.hpp
+++ b/include/operon/core/symbol_library.hpp
@@ -5,7 +5,9 @@
 #ifndef OPERON_SYMBOL_LIBRARY_HPP
 #define OPERON_SYMBOL_LIBRARY_HPP
 
+#include <algorithm>
 #include <stdexcept>
+#include <vector>
 
 #include "dispatch.hpp"
 #include "node.hpp"
@@ -177,6 +179,97 @@ auto MakeBinaryAutoDiff(F primal) -> typename DTable::template CallableDiff<T>
     };
 }
 
+// Collect the column indices of node i's children, in left-to-right tree
+// order (Nodes() stores children right-to-left of their parent).
+inline auto ChildIndices(Operon::Vector<Node> const& nodes, size_t i) -> std::vector<size_t>
+{
+    std::vector<size_t> children;
+    children.reserve(nodes[i].Arity);
+    auto j = i - 1;
+    for (auto a = 0; a < nodes[i].Arity; ++a) {
+        children.push_back(j);
+        j -= nodes[j].Length + 1;
+    }
+    std::ranges::reverse(children);
+    return children;
+}
+
+// Wrap a scalar binary reduce lambda f(acc, x) -> acc' into a batched
+// Callable<T> for n-ary (arity >= 2) functions. Children are folded
+// left-to-right: acc = f(f(c0, c1), c2, ...). Arity is read per-instance
+// from nodes[i].Arity, mirroring Dispatch::NaryOp's built-in n-ary ops.
+template<typename DTable, typename T, typename F>
+auto MakeNaryCallable(F primal) -> typename DTable::template Callable<T>
+{
+    constexpr auto S = DTable::template BatchSize<T>;
+    return [fn = std::move(primal)](
+        Operon::Vector<Node> const& nodes,
+        Backend::View<T, S>         data,
+        size_t                      i,
+        Operon::Range               /*rg*/)
+    {
+        auto const  w        = static_cast<T>(nodes[i].Value);
+        auto*       dst      = Backend::Ptr(data, i);
+        auto const  children = ChildIndices(nodes, i);
+        for (auto s = 0UL; s < S; ++s) {
+            auto acc = Backend::Ptr(data, children[0])[s];
+            for (size_t c = 1; c < children.size(); ++c) {
+                acc = fn(acc, Backend::Ptr(data, children[c])[s]);
+            }
+            dst[s] = w * acc;
+        }
+    };
+}
+
+// Generate a batched CallableDiff<T> for an n-ary reduce function using
+// forward-mode AD (ceres::Jet<T,1>): re-runs the same fold with the target
+// child (index j) seeded with unit tangent and every other child at zero
+// tangent, so a single primal lambda covers every child's partial without a
+// separate derivative rule per argument position.
+template<typename DTable, typename T, typename F>
+auto MakeNaryAutoDiff(F primal) -> typename DTable::template CallableDiff<T>
+{
+    constexpr auto S = DTable::template BatchSize<T>;
+    return [fn = std::move(primal)](
+        Operon::Vector<Node> const& nodes,
+        Backend::View<T const, S>   primal,
+        Backend::View<T>            trace,
+        int                         i,
+        int                         j)
+    {
+        using Jet = ceres::Jet<T, 1>;
+        auto const  children = ChildIndices(nodes, static_cast<size_t>(i));
+        auto*       res       = Backend::Ptr(trace, j);
+        for (auto s = 0UL; s < S; ++s) {
+            auto const seed = [&](size_t child) {
+                auto const v = Backend::Ptr(primal, children[child])[s];
+                // Jet{v, 0} seeds tangent direction 0 (the only one Jet<T,1>
+                // has) to 1; Jet{v} alone leaves the tangent at 0 (matches
+                // MakeUnaryAutoDiff's convention above).
+                return static_cast<int>(children[child]) == j ? Jet{v, 0} : Jet{v};
+            };
+            auto acc = seed(0);
+            for (size_t c = 1; c < children.size(); ++c) {
+                acc = fn(acc, seed(c));
+            }
+            res[s] = acc.v[0];
+        }
+    };
+}
+
+// Register an n-ary (arity >= 2) function from a scalar binary reduce lambda
+// f(acc, x) -> acc'. Only Jet<T,1> auto-diff is supported (no explicit
+// per-argument derivative overload, unlike RegisterUnary/RegisterBinary —
+// the fold structure means a single primal lambda already determines every
+// child's partial via MakeNaryAutoDiff).
+template<typename DTable, typename T, typename F>
+void RegisterNary(DTable& dt, Operon::Hash hash, F primal)
+{
+    dt.template RegisterFunction<T>(hash,
+        MakeNaryCallable<DTable, T>(primal),
+        MakeNaryAutoDiff<DTable, T>(std::move(primal)));
+}
+
 // Register a unary function from scalar lambdas.
 // primal:  f(x)  -> y         (required; must use auto/generic argument for
 //                               auto-diff to work)
@@ -281,6 +374,27 @@ void RegisterBinaryFunction(DTable& dt, PrimitiveSet& pset,
     RegisterBinary<DTable, T>(dt, hash, std::move(primal),
                               std::move(derivA), std::move(derivB));
     pset.AddFunction(hash, info.Arity, info.Frequency);
+    Node::RegisterName(hash, info.Name, info.Desc);
+}
+
+// Register an n-ary function in the dispatch table, PrimitiveSet, and name
+// registry in a single call. info.Arity is the minimum (and default) child
+// count; maxArity widens the PrimitiveSet entry so tree generation can
+// sample any arity in [info.Arity, maxArity] for this function, the same
+// range PrimitiveSet::SampleRandomSymbol already draws from for built-in
+// n-ary ops.
+template<typename DTable, typename T, typename F>
+void RegisterNaryFunction(DTable& dt, PrimitiveSet& pset,
+                          FunctionInfo const& info, uint16_t maxArity, F primal)
+{
+    if (maxArity < info.Arity) {
+        throw std::invalid_argument("RegisterNaryFunction: maxArity must be >= info.Arity");
+    }
+    auto const hash = Operon::Hasher{}(info.Name);
+    detail::ValidateUserHash(hash, info.Name);
+    RegisterNary<DTable, T>(dt, hash, std::move(primal));
+    pset.AddFunction(hash, info.Arity, info.Frequency);
+    if (maxArity > info.Arity) { pset.SetMaximumArity(hash, maxArity); }
     Node::RegisterName(hash, info.Name, info.Desc);
 }
 

--- a/include/operon/core/symbol_library.hpp
+++ b/include/operon/core/symbol_library.hpp
@@ -195,9 +195,13 @@ inline auto ChildIndices(Operon::Vector<Node> const& nodes, size_t i) -> std::ve
 }
 
 // Wrap a scalar binary reduce lambda f(acc, x) -> acc' into a batched
-// Callable<T> for n-ary (arity >= 2) functions. Children are folded
+// Callable<T> for n-ary (arity >= 2) functions. Children are folded strictly
 // left-to-right: acc = f(f(c0, c1), c2, ...). Arity is read per-instance
-// from nodes[i].Arity, mirroring Dispatch::NaryOp's built-in n-ary ops.
+// from nodes[i].Arity, mirroring how built-in Add/Mul accumulate. This does
+// NOT match every built-in n-ary op's semantics: Sub/Div compute
+// c0 - (c1+c2+...) / c0 / (c1*c2*...) (head vs. reduced tail), not a strict
+// left fold, so this adapter is only correct for associative reductions
+// like Add/Mul; a Sub/Div-shaped n-ary function needs a different adapter.
 template<typename DTable, typename T, typename F>
 auto MakeNaryCallable(F primal) -> typename DTable::template Callable<T>
 {

--- a/include/operon/core/symbol_library.hpp
+++ b/include/operon/core/symbol_library.hpp
@@ -387,6 +387,9 @@ template<typename DTable, typename T, typename F>
 void RegisterNaryFunction(DTable& dt, PrimitiveSet& pset,
                           FunctionInfo const& info, uint16_t maxArity, F primal)
 {
+    if (info.Arity < 2) {
+        throw std::invalid_argument("RegisterNaryFunction: info.Arity must be >= 2 (n-ary means 2 or more children)");
+    }
     if (maxArity < info.Arity) {
         throw std::invalid_argument("RegisterNaryFunction: maxArity must be >= info.Arity");
     }

--- a/source/core/pset.cpp
+++ b/source/core/pset.cpp
@@ -16,9 +16,25 @@
 #include "operon/core/pset.hpp"
 #include "operon/core/contracts.hpp"
 #include "operon/core/node.hpp"
+#include "operon/core/standard_library.hpp"
 #include "operon/core/types.hpp"
 
 namespace Operon {
+    void PrimitiveSet::SetConfig(PrimitiveSetConfig config)
+    {
+        pset_.clear();
+        for (size_t i = 0; i < Operon::NodeTypes::Count; ++i) {
+            auto t = static_cast<Operon::NodeType>(i);
+            if (!config.Test(i)) { continue; }
+
+            Operon::Node n(t);
+            auto const [minArity, maxArity] = StandardLibrary::ArityLimits(t);
+            n.Arity  = minArity;
+            n.Length = minArity;
+            pset_[n.HashValue] = { n, 1, minArity, maxArity };
+        }
+    }
+
     auto PrimitiveSet::AchievableLength(size_t targetLen) const -> size_t
     {
         if (targetLen <= 1) { return 1; }

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -215,6 +215,48 @@ TEST_CASE("RegisterNaryFunction registers a variable-arity function end-to-end",
             CHECK(jac(0, c) == Catch::Approx(1.0).epsilon(1e-5));
         }
     }
+
+    SECTION("Auto-diff seeds exactly one child per column (fn is non-linear)") {
+        // Add's fold gives every child a partial of 1 regardless of seeding
+        // correctness, so it can't tell a correct single-child seed apart
+        // from the historical bug where every non-target child was also
+        // seeded to unit tangent. A product fold can: partials differ by
+        // position, so a wrong seed produces a value that doesn't match the
+        // closed-form product-rule partial for that position.
+        DT dtProd;
+        Operon::PrimitiveSet psetProd;
+        Operon::FunctionInfo const prodInfo{
+            .Name      = "prod3",
+            .Desc      = "n-ary product",
+            .Arity     = 3,
+            .Frequency = 1
+        };
+        auto const prodHash = Operon::Hasher{}(prodInfo.Name);
+        auto prodPrimal = [](auto acc, auto x) -> auto { return acc * x; };
+        Operon::RegisterNaryFunction<DT, Scalar>(dtProd, psetProd, prodInfo, /*maxArity=*/3, prodPrimal);
+
+        Operon::Node dyn(Operon::NodeType::Dynamic, prodHash);
+        dyn.Arity    = 3;
+        dyn.Length   = 3;
+        dyn.Optimize = false;
+        Operon::Tree const tree({
+            Operon::Node::Constant(2.0),
+            Operon::Node::Constant(3.0),
+            Operon::Node::Constant(4.0),
+            dyn,
+        });
+
+        std::string const x{"x"};
+        Operon::Dataset const ds({x}, {std::vector<Scalar>{0.0}});
+        auto coeff = tree.GetCoefficients();
+        auto jac = Operon::Interpreter<Scalar, DT>(&dtProd, &ds, &tree).JacFwd(coeff, Operon::Range(0, 1));
+
+        REQUIRE(jac.rows() == 1);
+        REQUIRE(jac.cols() == 3);
+        CHECK(jac(0, 0) == Catch::Approx(12.0).epsilon(1e-5)); // d(c0*c1*c2)/dc0 = c1*c2 = 3*4
+        CHECK(jac(0, 1) == Catch::Approx(8.0).epsilon(1e-5));  // d/dc1 = c0*c2 = 2*4
+        CHECK(jac(0, 2) == Catch::Approx(6.0).epsilon(1e-5));  // d/dc2 = c0*c1 = 2*3
+    }
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -211,6 +211,7 @@ TEST_CASE("RegisterNaryFunction registers a variable-arity function end-to-end",
         auto jac = Operon::Interpreter<Scalar, DT>(&dt, &ds, &tree).JacFwd(coeff, Operon::Range(0, 1));
 
         REQUIRE(jac.rows() == 1);
+        REQUIRE(jac.cols() == 3);
         for (auto c = 0; c < jac.cols(); ++c) {
             CHECK(jac(0, c) == Catch::Approx(1.0).epsilon(1e-5));
         }

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -5,7 +5,9 @@
 #include <catch2/catch_approx.hpp>
 
 #include "operon/core/node.hpp"
+#include "operon/core/pset.hpp"
 #include "operon/core/standard_library.hpp"
+#include "operon/core/symbol_library.hpp"
 #include "operon/hash/hash.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/parser/infix.hpp"
@@ -117,6 +119,101 @@ TEST_CASE("Unregistered Dynamic nodes fall back to the generic name/desc", "[int
         Operon::Node const registeredDyn(Operon::NodeType::Dynamic, registeredHash);
         CHECK(registeredDyn.Name() == "myop");
         CHECK(registeredDyn.Desc() == "my custom op");
+    }
+}
+
+TEST_CASE("StandardLibrary::ArityLimits matches Node(type).Arity's position-based inference", "[interpreter]")
+{
+    // PR1 gives PrimitiveSet an arity source independent of Node(t).Arity;
+    // this pins that the new source agrees with the old inference for every
+    // built-in type, so decoupling the source doesn't change observed arity.
+    for (auto i = 0UL; i < Operon::NodeTypes::Count; ++i) {
+        auto const type = static_cast<Operon::NodeType>(i);
+        auto const [minArity, maxArity] = Operon::StandardLibrary::ArityLimits(type);
+        auto const expected = Operon::Node(type).Arity;
+        CHECK(minArity == expected);
+        CHECK(maxArity == expected);
+    }
+}
+
+TEST_CASE("PrimitiveSet preset configs source arity from the registry, not Node(t)", "[interpreter]")
+{
+    Operon::PrimitiveSet pset;
+    pset.SetConfig(Operon::PrimitiveSet::Full);
+
+    auto const addHash = Operon::Node(Operon::NodeType::Add).HashValue;
+    auto const sinHash = Operon::Node(Operon::NodeType::Sin).HashValue;
+    auto const constHash = Operon::Node(Operon::NodeType::Constant).HashValue;
+    auto const varHash = Operon::Node(Operon::NodeType::Variable).HashValue;
+
+    CHECK(pset.MinMaxArity(addHash) == std::tuple<size_t, size_t>{2, 2});
+    CHECK(pset.MinMaxArity(sinHash) == std::tuple<size_t, size_t>{1, 1});
+    CHECK(pset.MinMaxArity(constHash) == std::tuple<size_t, size_t>{0, 0});
+    CHECK(pset.MinMaxArity(varHash) == std::tuple<size_t, size_t>{0, 0});
+}
+
+TEST_CASE("RegisterNaryFunction registers a variable-arity function end-to-end", "[interpreter]")
+{
+    using DT = Operon::DispatchTable<Operon::Scalar>;
+    using Scalar = Operon::Scalar;
+
+    DT dt;
+    Operon::PrimitiveSet pset;
+    pset.SetConfig(Operon::PrimitiveSet::Arithmetic);
+
+    Operon::FunctionInfo const info{
+        .Name      = "sum3",
+        .Desc      = "n-ary sum",
+        .Arity     = 3,
+        .Frequency = 1
+    };
+    auto const hash = Operon::Hasher{}(info.Name);
+    auto primal = [](auto acc, auto x) -> auto { return acc + x; };
+
+    Operon::RegisterNaryFunction<DT, Scalar>(dt, pset, info, /*maxArity=*/5, primal);
+
+    auto makeTree = [&] {
+        Operon::Node dyn(Operon::NodeType::Dynamic, hash);
+        dyn.Arity    = 3;
+        dyn.Length   = 3;
+        dyn.Optimize = false; // matches AddFunction: function nodes are never coefficient-optimized
+        return Operon::Tree({
+            Operon::Node::Constant(1.0),
+            Operon::Node::Constant(2.0),
+            Operon::Node::Constant(3.0),
+            dyn,
+        });
+    };
+
+    SECTION("PrimitiveSet arity range widens to [Arity, maxArity]") {
+        CHECK(pset.MinimumArity(hash) == 3);
+        CHECK(pset.MaximumArity(hash) == 5);
+    }
+
+    SECTION("Evaluation folds children left-to-right") {
+        auto const tree = makeTree();
+
+        std::string const x{"x"};
+        Operon::Dataset const ds({x}, {std::vector<Scalar>{0.0}});
+        auto coeff = tree.GetCoefficients();
+        auto r = Operon::Interpreter<Scalar, DT>(&dt, &ds, &tree).Evaluate(coeff, Operon::Range(0, 1));
+
+        REQUIRE(std::ssize(r) == 1);
+        CHECK(r[0] == Catch::Approx(6.0).epsilon(1e-6)); // (1 + 2) + 3
+    }
+
+    SECTION("Auto-diff assigns unit partials to every child (fn is linear)") {
+        auto const tree = makeTree();
+
+        std::string const x{"x"};
+        Operon::Dataset const ds({x}, {std::vector<Scalar>{0.0}});
+        auto coeff = tree.GetCoefficients();
+        auto jac = Operon::Interpreter<Scalar, DT>(&dt, &ds, &tree).JacFwd(coeff, Operon::Range(0, 1));
+
+        REQUIRE(jac.rows() == 1);
+        for (auto c = 0; c < jac.cols(); ++c) {
+            CHECK(jac(0, c) == Catch::Approx(1.0).epsilon(1e-5));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Part of the [generic-nodes](https://github.com/heal-research/operon) NodeType-collapse plan (PR 1 of 13; PR 0 was #134). Prep work only — `NodeType` is untouched here.

- `StandardLibrary::Entry` gains `MinArity`/`MaxArity` and a `FormatRule` (how a node's infix rendering diverges from plain call syntax — `Infix`, `PrefixNegation`, `Inversion`, `PowerNotation`, `MinMaxCall`, `Composite`, or the `GenericCall` default), verified against `infix.cpp`'s actual special-casing rather than guessed.
- `StandardLibrary::ArityLimits(NodeType)` exposes that arity data; `PrimitiveSet::SetConfig` now sources preset (`Arithmetic`/`TypeCoherent`/`Full`) arity from there instead of `Node(t).Arity`'s position-based inference — the exact decoupling PR 6 will need once the enum shrinks. Values match the old inference 1:1, so this is behavior-preserving (`SetConfig` moved out-of-line into `pset.cpp` to avoid pulling `dispatch.hpp` into `pset.hpp`).
- `symbol_library.hpp` gains `RegisterNaryFunction` (fold-based `Callable` + `Jet<T,1>`-seeded `CallableDiff`, mirroring the existing Unary/Binary adapters), so user-defined n-ary functions can register the same way `Add`/`Mul`/`Sub`/`Div` will need to once they become ordinary `Function` entries in PR 6.

## Test plan
- [x] `operon_test '~[performance]'` green (242 cases) in the project's nix devShell
- [x] New tests: `ArityLimits` matches `Node(type).Arity` for every built-in; `PrimitiveSet` presets source arity from the registry; `RegisterNaryFunction` round-trips through evaluation and auto-diff (caught and fixed a real `ceres::Jet` seeding bug — `Jet{v,1}` is out-of-bounds for `Jet<T,1>`, the seeded form is `Jet{v,0}`)