### PR TITLE
core: BuiltinOp compile-time hash source + Is<T>() re-point (generic-nodes PR 2+3)

### DIFF
--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -56,6 +56,53 @@ enum class NodeType : uint8_t {
     Ref       // structural sharing: a backward reference to another node by index
 };
 
+// The built-in math-op subset of NodeType (Add..Square above, i.e. NodeType
+// minus the four terminal categories Dynamic/Constant/Variable/Ref), demoted
+// to a source of stable compile-time Operon::Hash constants rather than a
+// NodeType-typed value. A built-in Node's HashValue equals
+// static_cast<Hash>(its NodeType) (see Node's single-arg constructor below),
+// so these values are chosen to match NodeType's ordinals exactly — a
+// BuiltinOp::X value and the corresponding NodeType::X share the same
+// underlying number, letting call sites switch on Node::HashValue instead of
+// Node::Type without changing behavior. Carries no arity/category semantics
+// of its own; see IsNaryOp/IsBinaryOp/IsUnaryOp below for that.
+enum class BuiltinOp : Operon::Hash {
+    // n-ary symbols
+    Add = 0,
+    Mul,
+    Sub,
+    Div,
+    Fmin,
+    Fmax,
+
+    // binary symbols
+    Aq,
+    Pow,
+    Powabs,
+
+    // unary symbols
+    Abs,
+    Acos,
+    Asin,
+    Atan,
+    Cbrt,
+    Ceil,
+    Cos,
+    Cosh,
+    Exp,
+    Floor,
+    Log,
+    Logabs,
+    Log1p,
+    Sin,
+    Sinh,
+    Sqrt,
+    Sqrtabs,
+    Tan,
+    Tanh,
+    Square
+};
+
 // Arity and category (IsNary/IsBinary/IsUnary/IsNullary below, and the arity
 // inference in Node::Node) are derived from enumerator *position* in the
 // NodeType enum above, not from any per-type tag. These asserts pin the
@@ -64,6 +111,12 @@ enum class NodeType : uint8_t {
 static_assert(NodeType::Fmax < NodeType::Aq, "n-ary/binary boundary: Fmax must be the last n-ary symbol");
 static_assert(NodeType::Powabs < NodeType::Abs, "binary/unary boundary: Powabs must be the last binary symbol");
 static_assert(NodeType::Square < NodeType::Dynamic, "unary/nullary boundary: Square must be the last unary symbol");
+
+// BuiltinOp's ordinals are chosen to match NodeType's math-op subset above;
+// pin the one value shared by both enums (the last entry) so a future reorder
+// of either enum without updating the other is a compile error.
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square),
+    "BuiltinOp::Square must match NodeType::Square's ordinal");
 
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
 
@@ -210,6 +263,13 @@ struct Node {
     template <NodeType... T>
     [[nodiscard]] auto Is() const -> bool { return ((Type == T) || ...); }
 
+    // BuiltinOp overload: compares HashValue instead of Type. Equivalent to
+    // the NodeType overload above for any node constructed the ordinary way
+    // (Node(NodeType) sets HashValue = static_cast<Hash>(Type)), but usable
+    // where only a hash is in scope (e.g. dispatch keyed by HashValue).
+    template <BuiltinOp... Op>
+    [[nodiscard]] auto Is() const -> bool { return ((HashValue == static_cast<Operon::Hash>(Op)) || ...); }
+
     [[nodiscard]] auto IsConstant() const -> bool { return Is<NodeType::Constant>(); }
     [[nodiscard]] auto IsVariable() const -> bool { return Is<NodeType::Variable>(); }
     [[nodiscard]] auto IsRef()      const -> bool { return Is<NodeType::Ref>(); }
@@ -242,6 +302,19 @@ struct Node {
 
     template<NodeType Type>
     static auto constexpr IsNullary = Type > NodeType::Square; // Dynamic, Constant, Variable, Ref
+
+    // BuiltinOp counterparts of IsNary/IsBinary/IsUnary above. No IsNullary
+    // counterpart: BuiltinOp only covers the math-op subset (Add..Square),
+    // never the terminal categories (Dynamic/Constant/Variable/Ref) that
+    // IsNullary<NodeType> distinguishes.
+    template<BuiltinOp Op>
+    static auto constexpr IsNaryOp = Op <= BuiltinOp::Fmax;
+
+    template<BuiltinOp Op>
+    static auto constexpr IsBinaryOp = Op > BuiltinOp::Fmax && Op <= BuiltinOp::Powabs;
+
+    template<BuiltinOp Op>
+    static auto constexpr IsUnaryOp = Op > BuiltinOp::Powabs;
 };
 } // namespace Operon
 #endif

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -258,7 +258,7 @@ struct Node {
     }
 
     [[nodiscard]] auto IsLeaf() const noexcept -> bool { return Arity == 0; }
-    [[nodiscard]] auto IsCommutative() const noexcept -> bool { return Is<NodeType::Add, NodeType::Mul, NodeType::Fmin, NodeType::Fmax>(); }
+    [[nodiscard]] auto IsCommutative() const noexcept -> bool { return Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>(); }
 
     template <NodeType... T>
     [[nodiscard]] auto Is() const -> bool { return ((Type == T) || ...); }
@@ -273,22 +273,22 @@ struct Node {
     [[nodiscard]] auto IsConstant() const -> bool { return Is<NodeType::Constant>(); }
     [[nodiscard]] auto IsVariable() const -> bool { return Is<NodeType::Variable>(); }
     [[nodiscard]] auto IsRef()      const -> bool { return Is<NodeType::Ref>(); }
-    [[nodiscard]] auto IsAddition() const -> bool { return Is<NodeType::Add>(); }
-    [[nodiscard]] auto IsSubtraction() const -> bool { return Is<NodeType::Sub>(); }
-    [[nodiscard]] auto IsMultiplication() const -> bool { return Is<NodeType::Mul>(); }
-    [[nodiscard]] auto IsDivision() const -> bool { return Is<NodeType::Div>(); }
-    [[nodiscard]] auto IsAq() const -> bool { return Is<NodeType::Aq>(); }
-    [[nodiscard]] auto IsPow() const -> bool { return Is<NodeType::Pow>(); }
-    [[nodiscard]] auto IsPowabs() const -> bool { return Is<NodeType::Powabs>(); }
-    [[nodiscard]] auto IsExp() const -> bool { return Is<NodeType::Exp>(); }
-    [[nodiscard]] auto IsLog() const -> bool { return Is<NodeType::Log>(); }
-    [[nodiscard]] auto IsSin() const -> bool { return Is<NodeType::Sin>(); }
-    [[nodiscard]] auto IsCos() const -> bool { return Is<NodeType::Cos>(); }
-    [[nodiscard]] auto IsTan() const -> bool { return Is<NodeType::Tan>(); }
-    [[nodiscard]] auto IsTanh() const -> bool { return Is<NodeType::Tanh>(); }
-    [[nodiscard]] auto IsSquareRoot() const -> bool { return Is<NodeType::Sqrt>(); }
-    [[nodiscard]] auto IsCubeRoot() const -> bool { return Is<NodeType::Cbrt>(); }
-    [[nodiscard]] auto IsSquare() const -> bool { return Is<NodeType::Square>(); }
+    [[nodiscard]] auto IsAddition() const -> bool { return Is<BuiltinOp::Add>(); }
+    [[nodiscard]] auto IsSubtraction() const -> bool { return Is<BuiltinOp::Sub>(); }
+    [[nodiscard]] auto IsMultiplication() const -> bool { return Is<BuiltinOp::Mul>(); }
+    [[nodiscard]] auto IsDivision() const -> bool { return Is<BuiltinOp::Div>(); }
+    [[nodiscard]] auto IsAq() const -> bool { return Is<BuiltinOp::Aq>(); }
+    [[nodiscard]] auto IsPow() const -> bool { return Is<BuiltinOp::Pow>(); }
+    [[nodiscard]] auto IsPowabs() const -> bool { return Is<BuiltinOp::Powabs>(); }
+    [[nodiscard]] auto IsExp() const -> bool { return Is<BuiltinOp::Exp>(); }
+    [[nodiscard]] auto IsLog() const -> bool { return Is<BuiltinOp::Log>(); }
+    [[nodiscard]] auto IsSin() const -> bool { return Is<BuiltinOp::Sin>(); }
+    [[nodiscard]] auto IsCos() const -> bool { return Is<BuiltinOp::Cos>(); }
+    [[nodiscard]] auto IsTan() const -> bool { return Is<BuiltinOp::Tan>(); }
+    [[nodiscard]] auto IsTanh() const -> bool { return Is<BuiltinOp::Tanh>(); }
+    [[nodiscard]] auto IsSquareRoot() const -> bool { return Is<BuiltinOp::Sqrt>(); }
+    [[nodiscard]] auto IsCubeRoot() const -> bool { return Is<BuiltinOp::Cbrt>(); }
+    [[nodiscard]] auto IsSquare() const -> bool { return Is<BuiltinOp::Square>(); }
     [[nodiscard]] auto IsDynamic() const -> bool { return Is<NodeType::Dynamic>(); }
 
     template<NodeType Type>

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -112,11 +112,40 @@ static_assert(NodeType::Fmax < NodeType::Aq, "n-ary/binary boundary: Fmax must b
 static_assert(NodeType::Powabs < NodeType::Abs, "binary/unary boundary: Powabs must be the last binary symbol");
 static_assert(NodeType::Square < NodeType::Dynamic, "unary/nullary boundary: Square must be the last unary symbol");
 
-// BuiltinOp's ordinals are chosen to match NodeType's math-op subset above;
-// pin the one value shared by both enums (the last entry) so a future reorder
-// of either enum without updating the other is a compile error.
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square),
-    "BuiltinOp::Square must match NodeType::Square's ordinal");
+// BuiltinOp's ordinals are chosen to match NodeType's math-op subset above.
+// Pin every entry individually, not just the last one — a reorder that swaps
+// two *interior* entries (leaving the enum's size and last value unchanged)
+// would slip past a boundary-only check but still silently break the
+// HashValue equivalence for those two ops.
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Add) == static_cast<Operon::Hash>(NodeType::Add));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Mul) == static_cast<Operon::Hash>(NodeType::Mul));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Sub) == static_cast<Operon::Hash>(NodeType::Sub));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Div) == static_cast<Operon::Hash>(NodeType::Div));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Fmin) == static_cast<Operon::Hash>(NodeType::Fmin));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Fmax) == static_cast<Operon::Hash>(NodeType::Fmax));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Aq) == static_cast<Operon::Hash>(NodeType::Aq));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Pow) == static_cast<Operon::Hash>(NodeType::Pow));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Powabs) == static_cast<Operon::Hash>(NodeType::Powabs));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Abs) == static_cast<Operon::Hash>(NodeType::Abs));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Acos) == static_cast<Operon::Hash>(NodeType::Acos));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Asin) == static_cast<Operon::Hash>(NodeType::Asin));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Atan) == static_cast<Operon::Hash>(NodeType::Atan));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Cbrt) == static_cast<Operon::Hash>(NodeType::Cbrt));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Ceil) == static_cast<Operon::Hash>(NodeType::Ceil));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Cos) == static_cast<Operon::Hash>(NodeType::Cos));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Cosh) == static_cast<Operon::Hash>(NodeType::Cosh));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Exp) == static_cast<Operon::Hash>(NodeType::Exp));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Floor) == static_cast<Operon::Hash>(NodeType::Floor));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Log) == static_cast<Operon::Hash>(NodeType::Log));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Logabs) == static_cast<Operon::Hash>(NodeType::Logabs));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Log1p) == static_cast<Operon::Hash>(NodeType::Log1p));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Sin) == static_cast<Operon::Hash>(NodeType::Sin));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Sinh) == static_cast<Operon::Hash>(NodeType::Sinh));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Sqrt) == static_cast<Operon::Hash>(NodeType::Sqrt));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Sqrtabs) == static_cast<Operon::Hash>(NodeType::Sqrtabs));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Tan) == static_cast<Operon::Hash>(NodeType::Tan));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Tanh) == static_cast<Operon::Hash>(NodeType::Tanh));
+static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square));
 
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
 
@@ -266,7 +295,14 @@ struct Node {
     // BuiltinOp overload: compares HashValue instead of Type. Equivalent to
     // the NodeType overload above for any node constructed the ordinary way
     // (Node(NodeType) sets HashValue = static_cast<Hash>(Type)), but usable
-    // where only a hash is in scope (e.g. dispatch keyed by HashValue).
+    // where only a hash is in scope (e.g. dispatch keyed by HashValue). Not a
+    // strict no-op vs. the NodeType overload in one theoretical edge case: a
+    // Variable node's HashValue is an unconstrained Hasher{}(name) (unlike
+    // registered functions', which ValidateUserHash keeps out of the
+    // built-in ordinal range), so a name whose hash happens to collide into
+    // [0, NodeTypes::Count) would make this overload misclassify it as a
+    // math op. Astronomically unlikely (a ~29-in-2^64 chance) and not
+    // guarded against, same as it wasn't before this overload existed.
     template <BuiltinOp... Op>
     [[nodiscard]] auto Is() const -> bool { return ((HashValue == static_cast<Operon::Hash>(Op)) || ...); }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(operon_test
     source/implementation/infix_parser.cpp
     source/implementation/initialization.cpp
     source/implementation/mutation.cpp
+    source/implementation/node.cpp
     source/implementation/node_impact.cpp
     source/implementation/nondominatedsort.cpp
     source/implementation/permutation_importance.cpp

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -99,4 +99,54 @@ TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> agree with IsNary/IsBinary/I
     static_assert(Node::IsUnaryOp<BuiltinOp::Square>);
 }
 
+TEST_CASE("Node::Is*() single-op convenience methods are re-pointed correctly", "[core]")
+{
+    // Each of these now compares HashValue via Is<BuiltinOp::X>() instead of
+    // Type via Is<NodeType::X>() (node.hpp), but must still report true only
+    // for the one op it names and false for every other built-in op.
+    CHECK(Node(NodeType::Add).IsAddition());
+    CHECK_FALSE(Node(NodeType::Mul).IsAddition());
+    CHECK(Node(NodeType::Sub).IsSubtraction());
+    CHECK_FALSE(Node(NodeType::Add).IsSubtraction());
+    CHECK(Node(NodeType::Mul).IsMultiplication());
+    CHECK_FALSE(Node(NodeType::Div).IsMultiplication());
+    CHECK(Node(NodeType::Div).IsDivision());
+    CHECK_FALSE(Node(NodeType::Mul).IsDivision());
+    CHECK(Node(NodeType::Aq).IsAq());
+    CHECK_FALSE(Node(NodeType::Pow).IsAq());
+    CHECK(Node(NodeType::Pow).IsPow());
+    CHECK_FALSE(Node(NodeType::Powabs).IsPow());
+    CHECK(Node(NodeType::Powabs).IsPowabs());
+    CHECK_FALSE(Node(NodeType::Pow).IsPowabs());
+    CHECK(Node(NodeType::Exp).IsExp());
+    CHECK_FALSE(Node(NodeType::Log).IsExp());
+    CHECK(Node(NodeType::Log).IsLog());
+    CHECK_FALSE(Node(NodeType::Exp).IsLog());
+    CHECK(Node(NodeType::Sin).IsSin());
+    CHECK_FALSE(Node(NodeType::Cos).IsSin());
+    CHECK(Node(NodeType::Cos).IsCos());
+    CHECK_FALSE(Node(NodeType::Sin).IsCos());
+    CHECK(Node(NodeType::Tan).IsTan());
+    CHECK_FALSE(Node(NodeType::Tanh).IsTan());
+    CHECK(Node(NodeType::Tanh).IsTanh());
+    CHECK_FALSE(Node(NodeType::Tan).IsTanh());
+    CHECK(Node(NodeType::Sqrt).IsSquareRoot());
+    CHECK_FALSE(Node(NodeType::Cbrt).IsSquareRoot());
+    CHECK(Node(NodeType::Cbrt).IsCubeRoot());
+    CHECK_FALSE(Node(NodeType::Sqrt).IsCubeRoot());
+    CHECK(Node(NodeType::Square).IsSquare());
+    CHECK_FALSE(Node(NodeType::Pow).IsSquare());
+}
+
+TEST_CASE("Node::IsCommutative() agrees for every built-in op", "[core]")
+{
+    for (auto type : { NodeType::Add, NodeType::Mul, NodeType::Fmin, NodeType::Fmax }) {
+        CHECK(Node(type).IsCommutative());
+    }
+    for (auto type : { NodeType::Sub, NodeType::Div, NodeType::Aq, NodeType::Pow, NodeType::Powabs,
+                        NodeType::Sin, NodeType::Cos, NodeType::Square }) {
+        CHECK_FALSE(Node(type).IsCommutative());
+    }
+}
+
 } // namespace Operon::Test

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "operon/core/node.hpp"
+
+namespace Operon::Test {
+
+TEST_CASE("BuiltinOp::X shares NodeType::X's ordinal and a built-in Node's HashValue", "[core]")
+{
+    // Node(NodeType) sets HashValue = static_cast<Hash>(Type), so for every
+    // built-in math op, Is<NodeType::X>() and Is<BuiltinOp::X>() must agree.
+    auto check = [](NodeType type, BuiltinOp op) {
+        Node const n(type);
+        CHECK(static_cast<Operon::Hash>(type) == static_cast<Operon::Hash>(op));
+        CHECK(n.HashValue == static_cast<Operon::Hash>(op));
+    };
+
+    check(NodeType::Add, BuiltinOp::Add);
+    check(NodeType::Mul, BuiltinOp::Mul);
+    check(NodeType::Sub, BuiltinOp::Sub);
+    check(NodeType::Div, BuiltinOp::Div);
+    check(NodeType::Fmin, BuiltinOp::Fmin);
+    check(NodeType::Fmax, BuiltinOp::Fmax);
+    check(NodeType::Aq, BuiltinOp::Aq);
+    check(NodeType::Pow, BuiltinOp::Pow);
+    check(NodeType::Powabs, BuiltinOp::Powabs);
+    check(NodeType::Abs, BuiltinOp::Abs);
+    check(NodeType::Acos, BuiltinOp::Acos);
+    check(NodeType::Asin, BuiltinOp::Asin);
+    check(NodeType::Atan, BuiltinOp::Atan);
+    check(NodeType::Cbrt, BuiltinOp::Cbrt);
+    check(NodeType::Ceil, BuiltinOp::Ceil);
+    check(NodeType::Cos, BuiltinOp::Cos);
+    check(NodeType::Cosh, BuiltinOp::Cosh);
+    check(NodeType::Exp, BuiltinOp::Exp);
+    check(NodeType::Floor, BuiltinOp::Floor);
+    check(NodeType::Log, BuiltinOp::Log);
+    check(NodeType::Logabs, BuiltinOp::Logabs);
+    check(NodeType::Log1p, BuiltinOp::Log1p);
+    check(NodeType::Sin, BuiltinOp::Sin);
+    check(NodeType::Sinh, BuiltinOp::Sinh);
+    check(NodeType::Sqrt, BuiltinOp::Sqrt);
+    check(NodeType::Sqrtabs, BuiltinOp::Sqrtabs);
+    check(NodeType::Tan, BuiltinOp::Tan);
+    check(NodeType::Tanh, BuiltinOp::Tanh);
+    check(NodeType::Square, BuiltinOp::Square);
+}
+
+TEST_CASE("Node::Is<BuiltinOp...>() agrees with Is<NodeType...>() for built-in nodes", "[core]")
+{
+    CHECK(Node(NodeType::Add).Is<BuiltinOp::Add>());
+    CHECK_FALSE(Node(NodeType::Add).Is<BuiltinOp::Mul>());
+    CHECK(Node(NodeType::Sin).Is<BuiltinOp::Sin>());
+    CHECK((Node(NodeType::Fmax).Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
+    CHECK_FALSE((Node(NodeType::Sub).Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
+}
+
+TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> agree with IsNary/IsBinary/IsUnary<NodeType>", "[core]")
+{
+    auto check = [](NodeType type, bool isNary, bool isBinary, bool isUnary) {
+        CHECK(Node(type).IsLeaf() == false); // sanity: all BuiltinOp-backed types are non-leaf
+        CHECK(isNary == (type == NodeType::Add || type == NodeType::Mul || type == NodeType::Sub
+            || type == NodeType::Div || type == NodeType::Fmin || type == NodeType::Fmax));
+        CHECK(isBinary == (type == NodeType::Aq || type == NodeType::Pow || type == NodeType::Powabs));
+        CHECK(isUnary == (!isNary && !isBinary));
+    };
+
+    // NodeType-keyed boundaries (existing, unchanged)
+    check(NodeType::Add, Node::IsNary<NodeType::Add>, Node::IsBinary<NodeType::Add>, Node::IsUnary<NodeType::Add>);
+    check(NodeType::Aq, Node::IsNary<NodeType::Aq>, Node::IsBinary<NodeType::Aq>, Node::IsUnary<NodeType::Aq>);
+    check(NodeType::Sin, Node::IsNary<NodeType::Sin>, Node::IsBinary<NodeType::Sin>, Node::IsUnary<NodeType::Sin>);
+
+    // BuiltinOp-keyed boundaries must classify every op identically to their
+    // NodeType counterparts.
+    CHECK(Node::IsNaryOp<BuiltinOp::Add> == Node::IsNary<NodeType::Add>);
+    CHECK(Node::IsNaryOp<BuiltinOp::Mul> == Node::IsNary<NodeType::Mul>);
+    CHECK(Node::IsNaryOp<BuiltinOp::Sub> == Node::IsNary<NodeType::Sub>);
+    CHECK(Node::IsNaryOp<BuiltinOp::Div> == Node::IsNary<NodeType::Div>);
+    CHECK(Node::IsNaryOp<BuiltinOp::Fmin> == Node::IsNary<NodeType::Fmin>);
+    CHECK(Node::IsNaryOp<BuiltinOp::Fmax> == Node::IsNary<NodeType::Fmax>);
+
+    CHECK(Node::IsBinaryOp<BuiltinOp::Aq> == Node::IsBinary<NodeType::Aq>);
+    CHECK(Node::IsBinaryOp<BuiltinOp::Pow> == Node::IsBinary<NodeType::Pow>);
+    CHECK(Node::IsBinaryOp<BuiltinOp::Powabs> == Node::IsBinary<NodeType::Powabs>);
+
+    CHECK(Node::IsUnaryOp<BuiltinOp::Abs> == Node::IsUnary<NodeType::Abs>);
+    CHECK(Node::IsUnaryOp<BuiltinOp::Sin> == Node::IsUnary<NodeType::Sin>);
+    CHECK(Node::IsUnaryOp<BuiltinOp::Square> == Node::IsUnary<NodeType::Square>);
+
+    // Boundary values specifically (most likely place for an off-by-one).
+    static_assert(Node::IsNaryOp<BuiltinOp::Fmax>);
+    static_assert(!Node::IsNaryOp<BuiltinOp::Aq>);
+    static_assert(Node::IsBinaryOp<BuiltinOp::Aq>);
+    static_assert(Node::IsBinaryOp<BuiltinOp::Powabs>);
+    static_assert(!Node::IsBinaryOp<BuiltinOp::Abs>);
+    static_assert(Node::IsUnaryOp<BuiltinOp::Abs>);
+    static_assert(Node::IsUnaryOp<BuiltinOp::Square>);
+}
+
+} // namespace Operon::Test


### PR DESCRIPTION
## Summary
Part of the [generic-nodes](https://github.com/heal-research/operon) NodeType-collapse plan (tracking: #136). Covers PR 2 + PR 3 of that sequence (reordered/rescoped from the original plan — see notes below).

- `BuiltinOp`: a new `enum class BuiltinOp : Operon::Hash` mirroring `NodeType`'s math-op subset (`Add`..`Square`), ordinals matching so `static_cast<Hash>(BuiltinOp::X) == static_cast<Hash>(NodeType::X)` == a built-in `Node`'s `HashValue` for any `Node` this codebase produces (per-entry `static_assert`s pin all 29 ordinal pairs). Purely additive: new `IsNaryOp<BuiltinOp>`/`IsBinaryOp<BuiltinOp>`/`IsUnaryOp<BuiltinOp>` and a `Node::Is<BuiltinOp...>()` overload coexist with the existing `NodeType`-keyed ones — `dispatch.hpp`/`interpreter/functions.hpp`/`interpreter/derivatives.hpp` untouched.
  - Scoped down from the original plan's "re-point `IsNary`/`IsBinary`/`IsUnary`/`IsNullary` to `BuiltinOp`": that chain is `NodeType`-templated end-to-end through per-op `Func<T, NodeType::X, ...>`/`Diff<T, NodeType::X, ...>` specializations, so a literal re-point would force retemplating the whole numeric dispatch chain now rather than when the actual collapse needs it. No `IsNullary<BuiltinOp>` counterpart: it distinguishes `Dynamic`/`Constant`/`Variable`/`Ref`, none of which are in `BuiltinOp`'s math-op-only domain.
  - One documented edge case: `Is<BuiltinOp...>()` compares `HashValue`, not `Type`. A registered function's hash can't collide into the built-in ordinal range (`ValidateUserHash` guards that), but a `Variable`'s hash is an unconstrained `Hasher{}(name)` — a name hash landing in `[0, NodeTypes::Count)` would misclassify (astronomically unlikely, ~29-in-2^64, documented at the call site).
- `Node::Is<T>()` convenience-method re-point: `IsCommutative` and the ~16 single-op methods (`IsAddition`, `IsPow`, `IsSin`, ...) now use `Is<BuiltinOp...>()`. `IsConstant`/`IsVariable`/`IsRef`/`IsDynamic` stay on `NodeType` — terminal categories, outside `BuiltinOp`'s domain. No call site changes.

## Test plan
- [x] New test `test/source/implementation/node.cpp`: pins `BuiltinOp`/`NodeType` ordinal + `HashValue` equivalence for every built-in op, `Is<BuiltinOp...>()` agreement with `Is<NodeType...>()`, `IsNaryOp`/`IsBinaryOp`/`IsUnaryOp` boundary agreement with their `NodeType` counterparts (including explicit boundary-value `static_assert`s), each re-pointed single-op convenience method directly, and `IsCommutative()` across all built-in ops.
- [x] `operon_test '~[performance]'` green (247 cases, 24015 assertions) on both a static (`BUILD_SHARED_LIBS=OFF`) and shared (`BUILD_SHARED_LIBS=ON`) build in the project's nix devShell.
