### PR TITLE
core: retarget built-in dispatch chain onto BuiltinOp (generic-nodes PR 5a)

### DIFF
--- a/include/operon/core/dispatch.hpp
+++ b/include/operon/core/dispatch.hpp
@@ -54,18 +54,18 @@ auto Fill(Backend::View<T, S> view, int idx, T value) {
 } // namespace Backend
 
 // detect missing specializations for functions
-template<typename T, Operon::NodeType N = Operon::NodeTypes::NoType, bool C = false, std::size_t S = Backend::BatchSize<T>>
+template<typename T, Operon::BuiltinOp N = Operon::NoBuiltinOp, bool C = false, std::size_t S = Backend::BatchSize<T>>
 struct Func {
     auto operator()(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T, S> /*primal*/, std::integral auto /*node index*/, std::integral auto... /*child indices*/) {
-        throw std::runtime_error(fmt::format("backend error: missing specialization for function: {}\n", Operon::Node{N}.Name()));
+        throw std::runtime_error(fmt::format("backend error: missing specialization for function: {}\n", Operon::Node{Operon::NodeType::Dynamic, static_cast<Operon::Hash>(N)}.Name()));
     }
 };
 
 // detect missing specializations for function derivatives
-template<typename T, Operon::NodeType N  = Operon::NodeTypes::NoType, std::size_t S = Backend::BatchSize<T>>
+template<typename T, Operon::BuiltinOp N  = Operon::NoBuiltinOp, std::size_t S = Backend::BatchSize<T>>
 struct Diff {
     auto operator()(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> /*trace*/, std::integral auto /*node index*/, std::integral auto /*partial index*/) {
-        throw std::runtime_error(fmt::format("backend error: missing specialization for derivative: {}\n", Operon::Node{N}.Name()));
+        throw std::runtime_error(fmt::format("backend error: missing specialization for derivative: {}\n", Operon::Node{Operon::NodeType::Dynamic, static_cast<Operon::Hash>(N)}.Name()));
     }
 };
 
@@ -87,11 +87,10 @@ using CallableDiff = std::function<void(Operon::Vector<Node> const&, Backend::Vi
 // 1) improved performance: the naive method accumulates into the result for each argument, leading to unnecessary assignments
 // 2) minimizing the number of intermediate steps which might improve floating point accuracy of some operations
 //    if arity > 4, one accumulation is performed every 4 args
-template<NodeType Type, typename T, std::size_t S>
-requires Node::IsNary<Type>
+template<BuiltinOp Type, typename T, std::size_t S>
+requires Node::IsNaryOp<Type>
 static void NaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> data, size_t parentIndex, Operon::Range /*unused*/)
 {
-    static_assert(Type < NodeType::Aq);
     const auto nextArg = [&](size_t i) { return i - (nodes[i].Length + 1); };
     auto arg1 = parentIndex - 1;
     bool continued = false;
@@ -136,8 +135,8 @@ static void NaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> data, 
     }
 }
 
-template<NodeType Type, typename T, std::size_t S>
-requires Node::IsBinary<Type>
+template<BuiltinOp Type, typename T, std::size_t S>
+requires Node::IsBinaryOp<Type>
 static void BinaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> m, size_t i, Operon::Range /*unused*/)
 {
     auto j = i - 1;
@@ -145,8 +144,8 @@ static void BinaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> m, s
     Func<T, Type, false>{}(nodes, m, i, j, k);
 }
 
-template<NodeType Type, typename T, std::size_t S>
-requires Node::IsUnary<Type>
+template<BuiltinOp Type, typename T, std::size_t S>
+requires Node::IsUnaryOp<Type>
 static void UnaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> m, size_t i, Operon::Range /*unused*/)
 {
     Func<T, Type, false>{}(nodes, m, i, i-1);
@@ -157,24 +156,24 @@ struct Noop {
     void operator()(Args&&... /*unused*/) {}
 };
 
-template<NodeType Type, typename T, std::size_t S>
+template<BuiltinOp Type, typename T, std::size_t S>
 static void DiffOp(Operon::Vector<Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, int i, int j) {
     Diff<T, Type, S>{}(nodes, primal, trace, i, j);
 }
 
-template<NodeType Type, typename T, std::size_t S>
+template<BuiltinOp Type, typename T, std::size_t S>
 static constexpr auto MakeFunctionCall() -> Dispatch::Callable<T, S>
 {
-    if constexpr (Node::IsNary<Type>) {
+    if constexpr (Node::IsNaryOp<Type>) {
         return Callable<T, S>{NaryOp<Type, T, S>};
-    } else if constexpr (Node::IsBinary<Type>) {
+    } else if constexpr (Node::IsBinaryOp<Type>) {
         return Callable<T, S>{BinaryOp<Type, T, S>};
-    } else if constexpr (Node::IsUnary<Type>) {
+    } else if constexpr (Node::IsUnaryOp<Type>) {
         return Callable<T, S>{UnaryOp<Type, T, S>};
     }
 }
 
-template<NodeType Type, typename T, std::size_t S>
+template<BuiltinOp Type, typename T, std::size_t S>
 static constexpr auto MakeDiffCall() -> Dispatch::CallableDiff<T, S>
 {
     // this constexpr if here returns NOOP in case of non-arithmetic types (duals)
@@ -261,19 +260,19 @@ public:
     using CallableDiff = Dispatch::CallableDiff<T, BatchSize<T>>;
 
 private:
-    template<NodeType Type, typename T>
+    template<BuiltinOp Type, typename T>
     requires Operon::Concepts::Arithmetic<T>
     static constexpr auto MakeFunction() {
         return Dispatch::MakeFunctionCall<Type, T, BatchSize<T>>();
     }
 
-    template<NodeType Type, typename T>
+    template<BuiltinOp Type, typename T>
     requires Operon::Concepts::Arithmetic<T>
     static constexpr auto MakeDerivative() {
         return Dispatch::MakeDiffCall<Type, T, BatchSize<T>>();
     }
 
-    template<NodeType Type>
+    template<BuiltinOp Type>
     static constexpr auto MakeTuple()
     {
         return []<auto... Idx>(std::index_sequence<Idx...>){

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -148,15 +148,17 @@ static_assert(static_cast<Operon::Hash>(BuiltinOp::Tanh) == static_cast<Operon::
 static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square));
 
 // One past BuiltinOp's last value — the built-in hash range is
-// [0, BuiltinOpCount). Used below only as the sentinel default for
-// Func<T,...>/Diff<T,...>'s primary ("missing this specialization")
-// templates, mirroring NodeTypes::NoType's role for the NodeType-keyed
-// versions. Not yet used to reserve a hash range anywhere else — that's
-// symbol_library.hpp's ValidateUserHash, unchanged by this PR.
+// [0, BuiltinOpCount). Not used anywhere yet in this PR (the actual
+// reserved-hash-range check, symbol_library.hpp's ValidateUserHash, still
+// guards [0, NodeTypes::Count) unchanged); it exists for the later PR that
+// redesigns PrimitiveSetConfig around BuiltinOp instead of NodeType.
 static auto constexpr BuiltinOpCount = static_cast<Operon::Hash>(BuiltinOp::Square) + 1;
 
 // Sentinel "not a real op" value (mirrors NodeTypes::NoType), distinguishable
-// from every genuine BuiltinOp value.
+// from every genuine BuiltinOp value. Used below as the sentinel default for
+// Func<T,...>/Diff<T,...>'s primary ("missing this specialization")
+// templates, mirroring NodeTypes::NoType's role for the NodeType-keyed
+// versions.
 static auto constexpr NoBuiltinOp = static_cast<BuiltinOp>(~Operon::Hash{0});
 
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
@@ -260,13 +262,13 @@ struct Node {
 
     // The generalized "any named operation" factory: a built-in math op
     // (hash = static_cast<Hash>(some BuiltinOp)) or a user-registered
-    // function (hash = a name-derived hash outside BuiltinOpCount's range,
-    // see symbol_library.hpp's ValidateUserHash) are both represented as a
-    // Dynamic-tagged Node here — this PR doesn't touch NodeType's
-    // cardinality, so there's no dedicated Function category yet; that's
-    // introduced by the later PR that actually collapses the enum. Arity is
-    // caller-supplied rather than looked up from a registry: Node
-    // construction is the hottest path in the library (tree creators,
+    // function (hash = a name-derived hash outside symbol_library.hpp's
+    // ValidateUserHash-reserved [0, NodeTypes::Count) range) are both
+    // represented as a Dynamic-tagged Node here — this PR doesn't touch
+    // NodeType's cardinality, so there's no dedicated Function category
+    // yet; that's introduced by the later PR that actually collapses the
+    // enum. Arity is caller-supplied rather than looked up from a registry:
+    // Node construction is the hottest path in the library (tree creators,
     // crossover, mutation, Simplify's constant-folding), and every call site
     // that constructs one of these nodes already has a PrimitiveSet/
     // FunctionInfo in scope with the arity known, so a mandatory hash-map
@@ -278,15 +280,15 @@ struct Node {
     // PR) treats a Function-tagged built-in exactly like the equivalent
     // Node(NodeType::X). Several other subsystems still switch on node.Type
     // rather than HashValue and have no `case NodeType::Dynamic` for a
-    // built-in op: interval_evaluator.hpp, affine_evaluator.hpp,
-    // tree_diff.cpp's symbolic differentiation, and jit_compiler.cpp all
-    // fall through to their generic "unhandled type" default (error, zero
-    // gradient, or a zero-valued codegen stub respectively) for such a node
-    // — same as they already do for any genuine Dynamic/user-defined
-    // function today, since none of them are BuiltinOp-hash-aware yet. Do
-    // not use this factory to build a tree destined for those paths until
-    // their own retarget PRs land; it's currently safe only for the
-    // interpreter's Evaluate() path and this PR's own tests.
+    // built-in op: interval_evaluator.hpp and affine_evaluator.hpp both
+    // throw on their generic "unhandled type" default; tree_diff.cpp's
+    // symbolic differentiation returns a zero gradient; jit_compiler.cpp
+    // codegens a zero-valued stub — same as they already do for any genuine
+    // Dynamic/user-defined function today, since none of them are
+    // BuiltinOp-hash-aware yet. Do not use this factory to build a tree
+    // destined for those paths until their own retarget PRs land; it's
+    // currently safe only for the interpreter's Evaluate() path and this
+    // PR's own tests.
     static auto Function(Operon::Hash hash, uint16_t arity) noexcept
     {
         Node node(NodeType::Dynamic, hash);

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -272,6 +272,21 @@ struct Node {
     // FunctionInfo in scope with the arity known, so a mandatory hash-map
     // probe here would add cost to code that's currently a couple of integer
     // assignments.
+    //
+    // Scope note: only the core interpreter's numeric dispatch chain
+    // (DispatchTable/StandardLibrary, retargeted onto BuiltinOp/hash in this
+    // PR) treats a Function-tagged built-in exactly like the equivalent
+    // Node(NodeType::X). Several other subsystems still switch on node.Type
+    // rather than HashValue and have no `case NodeType::Dynamic` for a
+    // built-in op: interval_evaluator.hpp, affine_evaluator.hpp,
+    // tree_diff.cpp's symbolic differentiation, and jit_compiler.cpp all
+    // fall through to their generic "unhandled type" default (error, zero
+    // gradient, or a zero-valued codegen stub respectively) for such a node
+    // — same as they already do for any genuine Dynamic/user-defined
+    // function today, since none of them are BuiltinOp-hash-aware yet. Do
+    // not use this factory to build a tree destined for those paths until
+    // their own retarget PRs land; it's currently safe only for the
+    // interpreter's Evaluate() path and this PR's own tests.
     static auto Function(Operon::Hash hash, uint16_t arity) noexcept
     {
         Node node(NodeType::Dynamic, hash);

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -147,6 +147,18 @@ static_assert(static_cast<Operon::Hash>(BuiltinOp::Tan) == static_cast<Operon::H
 static_assert(static_cast<Operon::Hash>(BuiltinOp::Tanh) == static_cast<Operon::Hash>(NodeType::Tanh));
 static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square));
 
+// One past BuiltinOp's last value — the built-in hash range is
+// [0, BuiltinOpCount). Used below only as the sentinel default for
+// Func<T,...>/Diff<T,...>'s primary ("missing this specialization")
+// templates, mirroring NodeTypes::NoType's role for the NodeType-keyed
+// versions. Not yet used to reserve a hash range anywhere else — that's
+// symbol_library.hpp's ValidateUserHash, unchanged by this PR.
+static auto constexpr BuiltinOpCount = static_cast<Operon::Hash>(BuiltinOp::Square) + 1;
+
+// Sentinel "not a real op" value (mirrors NodeTypes::NoType), distinguishable
+// from every genuine BuiltinOp value.
+static auto constexpr NoBuiltinOp = static_cast<BuiltinOp>(~Operon::Hash{0});
+
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
 
 struct NodeTypes {
@@ -243,6 +255,33 @@ struct Node {
     {
         Node node(NodeType::Ref);
         node.RefTo    = target;
+        return node;
+    }
+
+    // The generalized "any named operation" factory: a built-in math op
+    // (hash = static_cast<Hash>(some BuiltinOp)) or a user-registered
+    // function (hash = a name-derived hash outside BuiltinOpCount's range,
+    // see symbol_library.hpp's ValidateUserHash) are both represented as a
+    // Dynamic-tagged Node here — this PR doesn't touch NodeType's
+    // cardinality, so there's no dedicated Function category yet; that's
+    // introduced by the later PR that actually collapses the enum. Arity is
+    // caller-supplied rather than looked up from a registry: Node
+    // construction is the hottest path in the library (tree creators,
+    // crossover, mutation, Simplify's constant-folding), and every call site
+    // that constructs one of these nodes already has a PrimitiveSet/
+    // FunctionInfo in scope with the arity known, so a mandatory hash-map
+    // probe here would add cost to code that's currently a couple of integer
+    // assignments.
+    static auto Function(Operon::Hash hash, uint16_t arity) noexcept
+    {
+        Node node(NodeType::Dynamic, hash);
+        node.Arity  = arity;
+        node.Length = arity;
+        // The two-arg ctor computes Optimize from Arity=0 (leaf) before this
+        // factory overrides Arity to the real value above - recompute
+        // explicitly rather than leave a stale true. These nodes (arity >=
+        // 1, always) are never coefficient-optimized regardless.
+        node.Optimize = false;
         return node;
     }
 

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -122,17 +122,17 @@ private:
     template<typename... Ts, std::size_t... I>
     static void RegisterAll(DispatchTable<Ts...>& dt, std::index_sequence<I...> /*unused*/)
     {
-        (RegisterOne<static_cast<NodeType>(I)>(dt), ...);
+        (RegisterOne<static_cast<BuiltinOp>(I)>(dt), ...);
     }
 
-    template<NodeType Type, typename... Ts>
+    template<BuiltinOp Type, typename... Ts>
     static void RegisterOne(DispatchTable<Ts...>& dt)
     {
-        auto const hash = Node(Type).HashValue;
+        auto const hash = static_cast<Operon::Hash>(Type);
         (RegisterForType<Type, Ts>(dt, hash), ...);
     }
 
-    template<NodeType Type, typename T, typename... Ts>
+    template<BuiltinOp Type, typename T, typename... Ts>
     requires Operon::Concepts::Arithmetic<T>
     static void RegisterForType(DispatchTable<Ts...>& dt, Operon::Hash hash)
     {
@@ -143,7 +143,7 @@ private:
             Dispatch::MakeDiffCall<Type, T, S>());
     }
 
-    template<NodeType Type, typename T, typename... Ts>
+    template<BuiltinOp Type, typename T, typename... Ts>
     requires (!Operon::Concepts::Arithmetic<T>)
     static void RegisterForType(DispatchTable<Ts...>& /*dt*/, Operon::Hash /*hash*/)
     {

--- a/include/operon/interpreter/derivatives.hpp
+++ b/include/operon/interpreter/derivatives.hpp
@@ -11,42 +11,42 @@
 namespace Operon {
     // n-ary functions
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Add, S> {
+    struct Diff<T, Operon::BuiltinOp::Add, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Add<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Sub, S> {
+    struct Diff<T, Operon::BuiltinOp::Sub, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Sub<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Mul, S> {
+    struct Diff<T, Operon::BuiltinOp::Mul, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Mul<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Div, S> {
+    struct Diff<T, Operon::BuiltinOp::Div, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Div<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Fmin, S> {
+    struct Diff<T, Operon::BuiltinOp::Fmin, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Min<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Fmax, S> {
+    struct Diff<T, Operon::BuiltinOp::Fmax, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Max<T, S>(nodes, primal, trace, i, j);
         }
@@ -54,21 +54,21 @@ namespace Operon {
 
     // binary functions
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Aq, S> {
+    struct Diff<T, Operon::BuiltinOp::Aq, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Aq<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Pow, S> {
+    struct Diff<T, Operon::BuiltinOp::Pow, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Pow<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Powabs, S> {
+    struct Diff<T, Operon::BuiltinOp::Powabs, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Powabs<T, S>(nodes, primal, trace, i, j);
         }
@@ -76,140 +76,140 @@ namespace Operon {
 
     // unary functions
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Abs, S> {
+    struct Diff<T, Operon::BuiltinOp::Abs, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Abs<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Acos, S> {
+    struct Diff<T, Operon::BuiltinOp::Acos, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Acos<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Asin, S> {
+    struct Diff<T, Operon::BuiltinOp::Asin, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Asin<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Atan, S> {
+    struct Diff<T, Operon::BuiltinOp::Atan, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Atan<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Cbrt, S> {
+    struct Diff<T, Operon::BuiltinOp::Cbrt, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Cbrt<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Ceil, S> {
+    struct Diff<T, Operon::BuiltinOp::Ceil, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Ceil<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Cos, S> {
+    struct Diff<T, Operon::BuiltinOp::Cos, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Cos<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Cosh, S> {
+    struct Diff<T, Operon::BuiltinOp::Cosh, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Cosh<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Exp, S> {
+    struct Diff<T, Operon::BuiltinOp::Exp, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Exp<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Floor, S> {
+    struct Diff<T, Operon::BuiltinOp::Floor, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Floor<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Log, S> {
+    struct Diff<T, Operon::BuiltinOp::Log, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Log<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Logabs, S> {
+    struct Diff<T, Operon::BuiltinOp::Logabs, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Logabs<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Log1p, S> {
+    struct Diff<T, Operon::BuiltinOp::Log1p, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Log1p<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Sin, S> {
+    struct Diff<T, Operon::BuiltinOp::Sin, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Sin<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Sinh, S> {
+    struct Diff<T, Operon::BuiltinOp::Sinh, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Sinh<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Sqrt, S> {
+    struct Diff<T, Operon::BuiltinOp::Sqrt, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Sqrt<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Sqrtabs, S> {
+    struct Diff<T, Operon::BuiltinOp::Sqrtabs, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Sqrtabs<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Square, S> {
+    struct Diff<T, Operon::BuiltinOp::Square, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Square<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Tan, S> {
+    struct Diff<T, Operon::BuiltinOp::Tan, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Tan<T, S>(nodes, primal, trace, i, j);
         }
     };
 
     template<typename T, std::size_t S>
-    struct Diff<T, Operon::NodeType::Tanh, S> {
+    struct Diff<T, Operon::BuiltinOp::Tanh, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
             Backend::Tanh<T, S>(nodes, primal, trace, i, j);
         }

--- a/include/operon/interpreter/functions.hpp
+++ b/include/operon/interpreter/functions.hpp
@@ -25,7 +25,7 @@ namespace Operon {
 
     // n-ary operations
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Add, C, S> {
+    struct Func<T, Operon::BuiltinOp::Add, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -37,7 +37,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Mul, C, S> {
+    struct Func<T, Operon::BuiltinOp::Mul, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -49,7 +49,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Sub, C, S> {
+    struct Func<T, Operon::BuiltinOp::Sub, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto first, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -69,7 +69,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Div, C, S> {
+    struct Func<T, Operon::BuiltinOp::Div, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto first, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -89,7 +89,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Fmin, C, S> {
+    struct Func<T, Operon::BuiltinOp::Fmin, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto first, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -109,7 +109,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Fmax, C, S> {
+    struct Func<T, Operon::BuiltinOp::Fmax, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto first, std::integral auto... args) {
             auto const w = nodes[result].Value;
             if constexpr (C) {
@@ -130,7 +130,7 @@ namespace Operon {
 
     // binary operations
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Aq, C, S> {
+    struct Func<T, Operon::BuiltinOp::Aq, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i, std::integral auto j) {
             auto const w = nodes[result].Value;
             Backend::Aq<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i), Ptr<T, S>(view, j));
@@ -138,7 +138,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Pow, C, S> {
+    struct Func<T, Operon::BuiltinOp::Pow, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i, std::integral auto j) {
             auto const w = nodes[result].Value;
             Backend::Pow<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i), Ptr<T, S>(view, j));
@@ -146,7 +146,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Powabs, C, S> {
+    struct Func<T, Operon::BuiltinOp::Powabs, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i, std::integral auto j) {
             auto const w = nodes[result].Value;
             Backend::Powabs<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i), Ptr<T, S>(view, j));
@@ -155,7 +155,7 @@ namespace Operon {
 
     // unary operations
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Abs, C, S> {
+    struct Func<T, Operon::BuiltinOp::Abs, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Abs<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -164,7 +164,7 @@ namespace Operon {
 
     // unary operations
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Square, C, S> {
+    struct Func<T, Operon::BuiltinOp::Square, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Square<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -172,7 +172,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Exp, C, S> {
+    struct Func<T, Operon::BuiltinOp::Exp, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Exp<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -180,7 +180,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Log, C, S> {
+    struct Func<T, Operon::BuiltinOp::Log, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Log<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -188,7 +188,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Logabs, C, S> {
+    struct Func<T, Operon::BuiltinOp::Logabs, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Logabs<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -196,7 +196,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Log1p, C, S> {
+    struct Func<T, Operon::BuiltinOp::Log1p, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Log1p<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -204,7 +204,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Sqrt, C, S> {
+    struct Func<T, Operon::BuiltinOp::Sqrt, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Sqrt<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -212,7 +212,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Sqrtabs, C, S> {
+    struct Func<T, Operon::BuiltinOp::Sqrtabs, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Sqrtabs<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -220,7 +220,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Cbrt, C, S> {
+    struct Func<T, Operon::BuiltinOp::Cbrt, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Cbrt<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -228,7 +228,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Ceil, C, S> {
+    struct Func<T, Operon::BuiltinOp::Ceil, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Ceil<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -236,7 +236,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Floor, C, S> {
+    struct Func<T, Operon::BuiltinOp::Floor, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Floor<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -244,7 +244,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Sin, C, S> {
+    struct Func<T, Operon::BuiltinOp::Sin, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Sin<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -252,7 +252,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Cos, C, S> {
+    struct Func<T, Operon::BuiltinOp::Cos, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Cos<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -260,7 +260,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Tan, C, S> {
+    struct Func<T, Operon::BuiltinOp::Tan, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Tan<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -268,7 +268,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Asin, C, S> {
+    struct Func<T, Operon::BuiltinOp::Asin, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Asin<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -276,7 +276,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Acos, C, S> {
+    struct Func<T, Operon::BuiltinOp::Acos, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Acos<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -284,7 +284,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Atan, C, S> {
+    struct Func<T, Operon::BuiltinOp::Atan, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Atan<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -292,7 +292,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Sinh, C, S> {
+    struct Func<T, Operon::BuiltinOp::Sinh, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Sinh<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -300,7 +300,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Cosh, C, S> {
+    struct Func<T, Operon::BuiltinOp::Cosh, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Cosh<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));
@@ -308,7 +308,7 @@ namespace Operon {
     };
 
     template<typename T, bool C, std::size_t S>
-    struct Func<T, Operon::NodeType::Tanh, C, S> {
+    struct Func<T, Operon::BuiltinOp::Tanh, C, S> {
         auto operator()(Operon::Vector<Operon::Node> const& nodes, Backend::View<T, S> view, std::integral auto result, std::integral auto i) {
             auto const w = nodes[result].Value;
             Backend::Tanh<T, S>(Ptr<T, S>(view, result), w, Ptr<T, S>(view, i));

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -3,6 +3,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "operon/core/dispatch.hpp"
 #include "operon/core/node.hpp"
 
 namespace Operon::Test {
@@ -146,6 +147,35 @@ TEST_CASE("Node::IsCommutative() agrees for every built-in op", "[core]")
     for (auto type : { NodeType::Sub, NodeType::Div, NodeType::Aq, NodeType::Pow, NodeType::Powabs,
                         NodeType::Sin, NodeType::Cos, NodeType::Square }) {
         CHECK_FALSE(Node(type).IsCommutative());
+    }
+}
+
+TEST_CASE("Node::Function() sets Type/HashValue/Arity/Length/Optimize consistently", "[core]")
+{
+    auto n = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 3);
+    CHECK(n.Type == NodeType::Dynamic);
+    CHECK(n.HashValue == static_cast<Operon::Hash>(BuiltinOp::Add));
+    CHECK(n.Arity == 3);
+    CHECK(n.Length == 3);
+    CHECK_FALSE(n.IsLeaf());
+    CHECK_FALSE(n.Optimize);
+}
+
+TEST_CASE("Node::Function() dispatches through the BuiltinOp-retargeted registry", "[core]")
+{
+    // Regression guard for the dispatch-chain retarget (functions.hpp/
+    // derivatives.hpp/dispatch.hpp/standard_library.hpp now templated on
+    // BuiltinOp instead of NodeType): every built-in op must still resolve
+    // to a registered callable by hash, independent of a Node's Type.
+    DispatchTable<Operon::Scalar> dt;
+    for (auto op : { BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div,
+                      BuiltinOp::Fmin, BuiltinOp::Fmax, BuiltinOp::Aq, BuiltinOp::Pow,
+                      BuiltinOp::Powabs, BuiltinOp::Abs, BuiltinOp::Sin, BuiltinOp::Cos,
+                      BuiltinOp::Tan, BuiltinOp::Exp, BuiltinOp::Log, BuiltinOp::Sqrt,
+                      BuiltinOp::Cbrt, BuiltinOp::Square }) {
+        auto const hash = static_cast<Operon::Hash>(op);
+        CHECK(dt.Contains(hash));
+        CHECK(dt.TryGetFunction<Operon::Scalar>(hash).has_value());
     }
 }
 

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -165,17 +165,24 @@ TEST_CASE("Node::Function() dispatches through the BuiltinOp-retargeted registry
 {
     // Regression guard for the dispatch-chain retarget (functions.hpp/
     // derivatives.hpp/dispatch.hpp/standard_library.hpp now templated on
-    // BuiltinOp instead of NodeType): every built-in op must still resolve
-    // to a registered callable by hash, independent of a Node's Type.
+    // BuiltinOp instead of NodeType): every one of the 29 built-in ops must
+    // still resolve to both a registered Callable and CallableDiff by hash,
+    // independent of a Node's Type. Covers all of BuiltinOp, not just a
+    // sample, and checks derivatives too (Diff<>/DiffOp/MakeDiffCall are
+    // retargeted by this PR just as much as Func<>/MakeFunctionCall are).
     DispatchTable<Operon::Scalar> dt;
     for (auto op : { BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div,
                       BuiltinOp::Fmin, BuiltinOp::Fmax, BuiltinOp::Aq, BuiltinOp::Pow,
-                      BuiltinOp::Powabs, BuiltinOp::Abs, BuiltinOp::Sin, BuiltinOp::Cos,
-                      BuiltinOp::Tan, BuiltinOp::Exp, BuiltinOp::Log, BuiltinOp::Sqrt,
-                      BuiltinOp::Cbrt, BuiltinOp::Square }) {
+                      BuiltinOp::Powabs, BuiltinOp::Abs, BuiltinOp::Acos, BuiltinOp::Asin,
+                      BuiltinOp::Atan, BuiltinOp::Cbrt, BuiltinOp::Ceil, BuiltinOp::Cos,
+                      BuiltinOp::Cosh, BuiltinOp::Exp, BuiltinOp::Floor, BuiltinOp::Log,
+                      BuiltinOp::Logabs, BuiltinOp::Log1p, BuiltinOp::Sin, BuiltinOp::Sinh,
+                      BuiltinOp::Sqrt, BuiltinOp::Sqrtabs, BuiltinOp::Tan, BuiltinOp::Tanh,
+                      BuiltinOp::Square }) {
         auto const hash = static_cast<Operon::Hash>(op);
         CHECK(dt.Contains(hash));
         CHECK(dt.TryGetFunction<Operon::Scalar>(hash).has_value());
+        CHECK(dt.TryGetDerivative<Operon::Scalar>(hash).has_value());
     }
 }
 


### PR DESCRIPTION
## Summary

Re-keys the built-in numeric dispatch chain from `NodeType`-templated to `BuiltinOp`-templated, without shrinking `NodeType`'s cardinality:

- `StandardLibrary::RegisterOne`/`RegisterForType`, `Dispatch::MakeFunctionCall`/`MakeDiffCall`, `NaryOp`/`BinaryOp`/`UnaryOp`/`DiffOp`, and every `Func<>`/`Diff<>` specialization in `functions.hpp`/`derivatives.hpp` now key off `BuiltinOp` instead of `NodeType`.
- Adds `Node::Function(hash, arity)`, the generalized "any named operation" factory (built via `NodeType::Dynamic` under the hood, since `NodeType` isn't shrinking in this PR) — arity is caller-supplied rather than looked up from a registry, since `Node` construction is the hottest path in the library (tree creators, crossover, mutation, `Simplify`'s constant-folding).
- Adds `BuiltinOpCount`/`NoBuiltinOp` to `node.hpp`, mirroring `NodeTypes::NoType`'s role as the `Func`/`Diff` primary templates' sentinel default.
- `StandardLibrary::Entries`/`RegisterNames`/`ArityLimits` (formatter/CLI-facing metadata) are untouched — out of scope for this dispatch-only retarget.

This is part 5a of the larger "generic nodes" `NodeType` collapse (tracking issue #136). Since `BuiltinOp` has existed since #137 and a built-in `Node(NodeType::X)`'s `HashValue` already equals `static_cast<Hash>(BuiltinOp::X)`, this PR builds and passes tests green with the old 33-value `NodeType` still in place — the actual enum collapse is a separate, later PR.

## Test plan

- [x] Static build: full non-performance suite green (24065 assertions, 249 cases)
- [x] Shared build (`-DBUILD_SHARED_LIBS=ON`): `liboperon.so` builds clean
- [x] New tests: `Node::Function()` field consistency, and a dispatch-table smoke test confirming every built-in op still resolves to a registered callable by hash after the retarget