### PR TITLE
core: collapse NodeType to Constant/Variable/Ref/Function (generic-nodes PR 5b)

### DIFF
--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -110,11 +110,11 @@ public:
             auto const sz = nodes.size();
             if (std::abs(a - Operon::Scalar{1}) > std::numeric_limits<Operon::Scalar>::epsilon()) {
                 nodes.emplace_back(Operon::Node::Constant(a));
-                nodes.emplace_back(Operon::NodeType::Mul);
+                nodes.push_back(Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Mul), 2));
             }
             if (std::abs(b) > std::numeric_limits<Operon::Scalar>::epsilon()) {
                 nodes.emplace_back(Operon::Node::Constant(b));
-                nodes.emplace_back(Operon::NodeType::Add);
+                nodes.push_back(Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Add), 2));
             }
             if (nodes.size() > sz) {
                 best_.Genotype.UpdateNodes();

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -22,43 +22,44 @@
 #include "operon/core/version.hpp"
 #include "operon/core/types.hpp"
 
+using Operon::BuiltinOp;
 using Operon::NodeType;
 
 namespace Operon {
 
-static const Operon::Map<std::string, NodeType> Primitives {
-    { "add",      NodeType::Add },
-    { "mul",      NodeType::Mul },
-    { "sub",      NodeType::Sub },
-    { "div",      NodeType::Div },
-    { "fmin",     NodeType::Fmin },
-    { "fmax",     NodeType::Fmax },
-    { "aq",       NodeType::Aq },
-    { "pow",      NodeType::Pow },
-    { "powabs",   NodeType::Powabs },
-    { "abs",      NodeType::Abs },
-    { "acos",     NodeType::Acos },
-    { "asin",     NodeType::Asin },
-    { "atan",     NodeType::Atan },
-    { "cbrt",     NodeType::Cbrt },
-    { "ceil",     NodeType::Ceil },
-    { "cos",      NodeType::Cos },
-    { "cosh",     NodeType::Cosh },
-    { "exp",      NodeType::Exp },
-    { "floor",    NodeType::Floor },
-    { "log",      NodeType::Log },
-    { "logabs",   NodeType::Logabs },
-    { "log1p",    NodeType::Log1p },
-    { "sin",      NodeType::Sin },
-    { "sinh",     NodeType::Sinh },
-    { "sqrt",     NodeType::Sqrt },
-    { "sqrtabs",  NodeType::Sqrtabs },
-    { "tan",      NodeType::Tan },
-    { "tanh",     NodeType::Tanh },
-    { "square",   NodeType::Square },
-    { "dyn",      NodeType::Dynamic },
-    { "constant", NodeType::Constant },
-    { "variable", NodeType::Variable }
+static const Operon::Map<std::string, PrimitiveSetConfig> Primitives {
+    { "add",      ToConfig(BuiltinOp::Add) },
+    { "mul",      ToConfig(BuiltinOp::Mul) },
+    { "sub",      ToConfig(BuiltinOp::Sub) },
+    { "div",      ToConfig(BuiltinOp::Div) },
+    { "fmin",     ToConfig(BuiltinOp::Fmin) },
+    { "fmax",     ToConfig(BuiltinOp::Fmax) },
+    { "aq",       ToConfig(BuiltinOp::Aq) },
+    { "pow",      ToConfig(BuiltinOp::Pow) },
+    { "powabs",   ToConfig(BuiltinOp::Powabs) },
+    { "abs",      ToConfig(BuiltinOp::Abs) },
+    { "acos",     ToConfig(BuiltinOp::Acos) },
+    { "asin",     ToConfig(BuiltinOp::Asin) },
+    { "atan",     ToConfig(BuiltinOp::Atan) },
+    { "cbrt",     ToConfig(BuiltinOp::Cbrt) },
+    { "ceil",     ToConfig(BuiltinOp::Ceil) },
+    { "cos",      ToConfig(BuiltinOp::Cos) },
+    { "cosh",     ToConfig(BuiltinOp::Cosh) },
+    { "exp",      ToConfig(BuiltinOp::Exp) },
+    { "floor",    ToConfig(BuiltinOp::Floor) },
+    { "log",      ToConfig(BuiltinOp::Log) },
+    { "logabs",   ToConfig(BuiltinOp::Logabs) },
+    { "log1p",    ToConfig(BuiltinOp::Log1p) },
+    { "sin",      ToConfig(BuiltinOp::Sin) },
+    { "sinh",     ToConfig(BuiltinOp::Sinh) },
+    { "sqrt",     ToConfig(BuiltinOp::Sqrt) },
+    { "sqrtabs",  ToConfig(BuiltinOp::Sqrtabs) },
+    { "tan",      ToConfig(BuiltinOp::Tan) },
+    { "tanh",     ToConfig(BuiltinOp::Tanh) },
+    { "square",   ToConfig(BuiltinOp::Square) },
+    { "dyn",      ToConfig(NodeType::Function) },
+    { "constant", ToConfig(NodeType::Constant) },
+    { "variable", ToConfig(NodeType::Variable) }
 };
 
 auto Split(const std::string& s, char delimiter) -> std::vector<std::string>
@@ -120,13 +121,20 @@ auto PrintPrimitives(PrimitiveSetConfig config) -> void
     tmpSet.SetConfig(config);
     fmt::print("Built-in primitives:\n");
     fmt::print("{:<8}\t{:<50}\t{:>7}\t\t{:>9}\n", "Symbol", "Description", "Enabled", "Frequency");
-    for (size_t i = 0; i < Operon::NodeTypes::Count; ++i) {
-        auto type = static_cast<NodeType>(i);
-        auto hash = Node(type).HashValue;
+
+    auto printRow = [&](Node const& node) {
+        auto hash = node.HashValue;
         auto enabled = tmpSet.Contains(hash) && tmpSet.IsEnabled(hash);
         auto freq = enabled ? tmpSet.Frequency(hash) : 0U;
-        Node const node(type);
         fmt::print("{:<8}\t{:<50}\t{:>7}\t\t{:>9}\n", node.Name(), node.Desc(), enabled, freq != 0U ? std::to_string(freq) : "-");
+    };
+
+    for (size_t i = 0; i < Operon::BuiltinOpCount; ++i) {
+        auto op = static_cast<BuiltinOp>(i);
+        printRow(Node::Function(static_cast<Operon::Hash>(op), 0)); // arity irrelevant for Name()/Desc()
+    }
+    for (auto type : { NodeType::Constant, NodeType::Variable, NodeType::Ref, NodeType::Function }) {
+        printRow(Node(type));
     }
 }
 

--- a/example/custom_primitives.cpp
+++ b/example/custom_primitives.cpp
@@ -62,12 +62,12 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
     problem.SetInputs(inputs);
 
     // Arithmetic built-ins form the structural backbone of expressions.
-    // No transcendental functions from NodeType — those come from our
+    // No transcendental functions enabled here — those come from our
     // runtime-registered callables below.
     problem.ConfigurePrimitiveSet(
         Operon::NodeType::Constant | Operon::NodeType::Variable |
-        Operon::NodeType::Add | Operon::NodeType::Sub |
-        Operon::NodeType::Mul | Operon::NodeType::Div);
+        Operon::BuiltinOp::Add | Operon::BuiltinOp::Sub |
+        Operon::BuiltinOp::Mul | Operon::BuiltinOp::Div);
 
     // register custom primitives
     using DT = Operon::ScalarDispatch;

--- a/include/operon/core/dispatch.hpp
+++ b/include/operon/core/dispatch.hpp
@@ -57,15 +57,15 @@ auto Fill(Backend::View<T, S> view, int idx, T value) {
 template<typename T, Operon::BuiltinOp N = Operon::NoBuiltinOp, bool C = false, std::size_t S = Backend::BatchSize<T>>
 struct Func {
     auto operator()(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T, S> /*primal*/, std::integral auto /*node index*/, std::integral auto... /*child indices*/) {
-        throw std::runtime_error(fmt::format("backend error: missing specialization for function: {}\n", Operon::Node{Operon::NodeType::Dynamic, static_cast<Operon::Hash>(N)}.Name()));
+        throw std::runtime_error(fmt::format("backend error: missing specialization for function with hash {}\n", static_cast<Operon::Hash>(N)));
     }
 };
 
 // detect missing specializations for function derivatives
-template<typename T, Operon::BuiltinOp N  = Operon::NoBuiltinOp, std::size_t S = Backend::BatchSize<T>>
+template<typename T, Operon::BuiltinOp N = Operon::NoBuiltinOp, std::size_t S = Backend::BatchSize<T>>
 struct Diff {
     auto operator()(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> /*primal*/, Backend::View<T> /*trace*/, std::integral auto /*node index*/, std::integral auto /*partial index*/) {
-        throw std::runtime_error(fmt::format("backend error: missing specialization for derivative: {}\n", Operon::Node{Operon::NodeType::Dynamic, static_cast<Operon::Hash>(N)}.Name()));
+        throw std::runtime_error(fmt::format("backend error: missing specialization for derivative with hash {}\n", static_cast<Operon::Hash>(N)));
     }
 };
 
@@ -87,8 +87,8 @@ using CallableDiff = std::function<void(Operon::Vector<Node> const&, Backend::Vi
 // 1) improved performance: the naive method accumulates into the result for each argument, leading to unnecessary assignments
 // 2) minimizing the number of intermediate steps which might improve floating point accuracy of some operations
 //    if arity > 4, one accumulation is performed every 4 args
-template<BuiltinOp Type, typename T, std::size_t S>
-requires Node::IsNaryOp<Type>
+template<BuiltinOp Op, typename T, std::size_t S>
+requires Node::IsNaryOp<Op>
 static void NaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> data, size_t parentIndex, Operon::Range /*unused*/)
 {
     const auto nextArg = [&](size_t i) { return i - (nodes[i].Length + 1); };
@@ -96,8 +96,8 @@ static void NaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> data, 
     bool continued = false;
 
     auto const call = [&](bool continued, int result, auto... args) {
-        if (continued) { Func<T, Type, true , S>{}(nodes, data, result, args...); }
-        else           { Func<T, Type, false, S>{}(nodes, data, result, args...); }
+        if (continued) { Func<T, Op, true , S>{}(nodes, data, result, args...); }
+        else           { Func<T, Op, false, S>{}(nodes, data, result, args...); }
     };
 
     int arity = nodes[parentIndex].Arity;
@@ -135,20 +135,20 @@ static void NaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> data, 
     }
 }
 
-template<BuiltinOp Type, typename T, std::size_t S>
-requires Node::IsBinaryOp<Type>
+template<BuiltinOp Op, typename T, std::size_t S>
+requires Node::IsBinaryOp<Op>
 static void BinaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> m, size_t i, Operon::Range /*unused*/)
 {
     auto j = i - 1;
     auto k = j - nodes[j].Length - 1;
-    Func<T, Type, false>{}(nodes, m, i, j, k);
+    Func<T, Op, false>{}(nodes, m, i, j, k);
 }
 
-template<BuiltinOp Type, typename T, std::size_t S>
-requires Node::IsUnaryOp<Type>
+template<BuiltinOp Op, typename T, std::size_t S>
+requires Node::IsUnaryOp<Op>
 static void UnaryOp(Operon::Vector<Node> const& nodes, Backend::View<T, S> m, size_t i, Operon::Range /*unused*/)
 {
-    Func<T, Type, false>{}(nodes, m, i, i-1);
+    Func<T, Op, false>{}(nodes, m, i, i-1);
 }
 
 struct Noop {
@@ -156,29 +156,29 @@ struct Noop {
     void operator()(Args&&... /*unused*/) {}
 };
 
-template<BuiltinOp Type, typename T, std::size_t S>
+template<BuiltinOp Op, typename T, std::size_t S>
 static void DiffOp(Operon::Vector<Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, int i, int j) {
-    Diff<T, Type, S>{}(nodes, primal, trace, i, j);
+    Diff<T, Op, S>{}(nodes, primal, trace, i, j);
 }
 
-template<BuiltinOp Type, typename T, std::size_t S>
+template<BuiltinOp Op, typename T, std::size_t S>
 static constexpr auto MakeFunctionCall() -> Dispatch::Callable<T, S>
 {
-    if constexpr (Node::IsNaryOp<Type>) {
-        return Callable<T, S>{NaryOp<Type, T, S>};
-    } else if constexpr (Node::IsBinaryOp<Type>) {
-        return Callable<T, S>{BinaryOp<Type, T, S>};
-    } else if constexpr (Node::IsUnaryOp<Type>) {
-        return Callable<T, S>{UnaryOp<Type, T, S>};
+    if constexpr (Node::IsNaryOp<Op>) {
+        return Callable<T, S>{NaryOp<Op, T, S>};
+    } else if constexpr (Node::IsBinaryOp<Op>) {
+        return Callable<T, S>{BinaryOp<Op, T, S>};
+    } else if constexpr (Node::IsUnaryOp<Op>) {
+        return Callable<T, S>{UnaryOp<Op, T, S>};
     }
 }
 
-template<BuiltinOp Type, typename T, std::size_t S>
+template<BuiltinOp Op, typename T, std::size_t S>
 static constexpr auto MakeDiffCall() -> Dispatch::CallableDiff<T, S>
 {
     // this constexpr if here returns NOOP in case of non-arithmetic types (duals)
     if constexpr (std::is_arithmetic_v<T>) {
-        return CallableDiff<T, S>{DiffOp<Type, T, S>};
+        return CallableDiff<T, S>{DiffOp<Op, T, S>};
     } else {
         return Dispatch::Noop{};
     }
@@ -260,29 +260,6 @@ public:
     using CallableDiff = Dispatch::CallableDiff<T, BatchSize<T>>;
 
 private:
-    template<BuiltinOp Type, typename T>
-    requires Operon::Concepts::Arithmetic<T>
-    static constexpr auto MakeFunction() {
-        return Dispatch::MakeFunctionCall<Type, T, BatchSize<T>>();
-    }
-
-    template<BuiltinOp Type, typename T>
-    requires Operon::Concepts::Arithmetic<T>
-    static constexpr auto MakeDerivative() {
-        return Dispatch::MakeDiffCall<Type, T, BatchSize<T>>();
-    }
-
-    template<BuiltinOp Type>
-    static constexpr auto MakeTuple()
-    {
-        return []<auto... Idx>(std::index_sequence<Idx...>){
-            return std::make_tuple(
-                std::make_tuple(MakeFunction<Type, std::tuple_element_t<Idx, TypeHolder>>()...),
-                std::make_tuple(MakeDerivative<Type, std::tuple_element_t<Idx, TypeHolder>>()...)
-            );
-        }(std::make_index_sequence<N>{});
-    }
-
     using TFun = decltype([]<auto... Idx>(std::index_sequence<Idx...>){
                     return std::make_tuple(Callable<std::tuple_element_t<Idx, TypeHolder>>{}...);
                  }(std::make_index_sequence<N>{}));

--- a/include/operon/core/grammar.hpp
+++ b/include/operon/core/grammar.hpp
@@ -54,10 +54,10 @@ struct GrammarSymbols {
 // enumeration engine only ever expands one level at a time, so there is no
 // need for symreg-cpp's generic grammar-string worklist machinery.
 struct Production {
-    // Operator Node appended when combining Operands. NodeTypes::NoType marks
+    // Operator Node appended when combining Operands. NoBuiltinOp marks
     // a pure coercion (e.g. Term -> RecurringFactor): the operand's tree is
     // used as-is, no new node is appended, and no complexity is added.
-    NodeType Op{NodeTypes::NoType};
+    BuiltinOp Op{NoBuiltinOp};
     // Nonterminal categories combined, in order. A self-combine (e.g.
     // {Term, Term} for Op=Mul) relies on Tree::Reduce() to flatten the
     // resulting nested Mul into one flat n-ary node, so it enumerates the
@@ -76,7 +76,7 @@ struct Production {
     // are excluded from the complexity count - see Grammar::MinComplexity).
     bool TrailingConstant{false};
 
-    [[nodiscard]] auto IsCoercion() const noexcept -> bool { return Op == NodeTypes::NoType; }
+    [[nodiscard]] auto IsCoercion() const noexcept -> bool { return Op == NoBuiltinOp; }
 };
 
 // Queryable, config/dataset-parameterized grammar for exhaustive expression

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -292,44 +292,58 @@ struct Node {
     }
 
     [[nodiscard]] auto IsLeaf() const noexcept -> bool { return Arity == 0; }
-    [[nodiscard]] auto IsCommutative() const noexcept -> bool { return Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>(); }
+    [[nodiscard]] auto IsCommutative() const noexcept -> bool { return IsOp<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>(); }
 
     template <NodeType... T>
     [[nodiscard]] auto Is() const -> bool { return ((Type == T) || ...); }
 
-    // BuiltinOp overload: compares HashValue instead of Type. Equivalent to
-    // the NodeType overload above for any node constructed the ordinary way
-    // (Node(NodeType) sets HashValue = static_cast<Hash>(Type)), but usable
-    // where only a hash is in scope (e.g. dispatch keyed by HashValue). Not a
-    // strict no-op vs. the NodeType overload in one theoretical edge case: a
-    // Variable node's HashValue is an unconstrained Hasher{}(name) (unlike
-    // registered functions', which ValidateUserHash keeps out of the
-    // built-in ordinal range), so a name whose hash happens to collide into
+    // BuiltinOp counterpart of Is<NodeType...>() above: compares HashValue
+    // instead of Type. Equivalent to the NodeType overload for any node
+    // constructed the ordinary way (Node(NodeType) sets
+    // HashValue = static_cast<Hash>(Type)), but usable where only a hash is
+    // in scope (e.g. dispatch keyed by HashValue). Not a strict no-op vs.
+    // the NodeType overload in one theoretical edge case: a Variable node's
+    // HashValue is an unconstrained Hasher{}(name) (unlike registered
+    // functions', which ValidateUserHash keeps out of the built-in ordinal
+    // range), so a name whose hash happens to collide into
     // [0, NodeTypes::Count) would make this overload misclassify it as a
     // math op. Astronomically unlikely (a ~29-in-2^64 chance) and not
     // guarded against, same as it wasn't before this overload existed.
+    //
+    // Named IsOp rather than a same-named Is<BuiltinOp...>() overload: a
+    // real clang-cl (MSVC ABI) mangling bug collapses two function templates
+    // overloaded solely by an enum-typed non-type template parameter pack
+    // into the identical mangled symbol whenever the packs' underlying
+    // integer values coincide (e.g. Is<NodeType::Ref>() [value 2] and
+    // Is<BuiltinOp::Sub>() [value 2] both mangled to
+    // `??$Is@$02@Node@Operon@@QEBA_NXZ`), causing a duplicate-definition
+    // link error — hit in practice by PR #140's Windows CI
+    // (`error: definition with same mangled name`). Distinct names sidestep
+    // the collision entirely; this is a compiler ABI limitation, not
+    // something fixable by choosing different enum values (any two enums
+    // with overlapping value ranges will eventually collide again).
     template <BuiltinOp... Op>
-    [[nodiscard]] auto Is() const -> bool { return ((HashValue == static_cast<Operon::Hash>(Op)) || ...); }
+    [[nodiscard]] auto IsOp() const -> bool { return ((HashValue == static_cast<Operon::Hash>(Op)) || ...); }
 
     [[nodiscard]] auto IsConstant() const -> bool { return Is<NodeType::Constant>(); }
     [[nodiscard]] auto IsVariable() const -> bool { return Is<NodeType::Variable>(); }
     [[nodiscard]] auto IsRef()      const -> bool { return Is<NodeType::Ref>(); }
-    [[nodiscard]] auto IsAddition() const -> bool { return Is<BuiltinOp::Add>(); }
-    [[nodiscard]] auto IsSubtraction() const -> bool { return Is<BuiltinOp::Sub>(); }
-    [[nodiscard]] auto IsMultiplication() const -> bool { return Is<BuiltinOp::Mul>(); }
-    [[nodiscard]] auto IsDivision() const -> bool { return Is<BuiltinOp::Div>(); }
-    [[nodiscard]] auto IsAq() const -> bool { return Is<BuiltinOp::Aq>(); }
-    [[nodiscard]] auto IsPow() const -> bool { return Is<BuiltinOp::Pow>(); }
-    [[nodiscard]] auto IsPowabs() const -> bool { return Is<BuiltinOp::Powabs>(); }
-    [[nodiscard]] auto IsExp() const -> bool { return Is<BuiltinOp::Exp>(); }
-    [[nodiscard]] auto IsLog() const -> bool { return Is<BuiltinOp::Log>(); }
-    [[nodiscard]] auto IsSin() const -> bool { return Is<BuiltinOp::Sin>(); }
-    [[nodiscard]] auto IsCos() const -> bool { return Is<BuiltinOp::Cos>(); }
-    [[nodiscard]] auto IsTan() const -> bool { return Is<BuiltinOp::Tan>(); }
-    [[nodiscard]] auto IsTanh() const -> bool { return Is<BuiltinOp::Tanh>(); }
-    [[nodiscard]] auto IsSquareRoot() const -> bool { return Is<BuiltinOp::Sqrt>(); }
-    [[nodiscard]] auto IsCubeRoot() const -> bool { return Is<BuiltinOp::Cbrt>(); }
-    [[nodiscard]] auto IsSquare() const -> bool { return Is<BuiltinOp::Square>(); }
+    [[nodiscard]] auto IsAddition() const -> bool { return IsOp<BuiltinOp::Add>(); }
+    [[nodiscard]] auto IsSubtraction() const -> bool { return IsOp<BuiltinOp::Sub>(); }
+    [[nodiscard]] auto IsMultiplication() const -> bool { return IsOp<BuiltinOp::Mul>(); }
+    [[nodiscard]] auto IsDivision() const -> bool { return IsOp<BuiltinOp::Div>(); }
+    [[nodiscard]] auto IsAq() const -> bool { return IsOp<BuiltinOp::Aq>(); }
+    [[nodiscard]] auto IsPow() const -> bool { return IsOp<BuiltinOp::Pow>(); }
+    [[nodiscard]] auto IsPowabs() const -> bool { return IsOp<BuiltinOp::Powabs>(); }
+    [[nodiscard]] auto IsExp() const -> bool { return IsOp<BuiltinOp::Exp>(); }
+    [[nodiscard]] auto IsLog() const -> bool { return IsOp<BuiltinOp::Log>(); }
+    [[nodiscard]] auto IsSin() const -> bool { return IsOp<BuiltinOp::Sin>(); }
+    [[nodiscard]] auto IsCos() const -> bool { return IsOp<BuiltinOp::Cos>(); }
+    [[nodiscard]] auto IsTan() const -> bool { return IsOp<BuiltinOp::Tan>(); }
+    [[nodiscard]] auto IsTanh() const -> bool { return IsOp<BuiltinOp::Tanh>(); }
+    [[nodiscard]] auto IsSquareRoot() const -> bool { return IsOp<BuiltinOp::Sqrt>(); }
+    [[nodiscard]] auto IsCubeRoot() const -> bool { return IsOp<BuiltinOp::Cbrt>(); }
+    [[nodiscard]] auto IsSquare() const -> bool { return IsOp<BuiltinOp::Square>(); }
     [[nodiscard]] auto IsFunction() const -> bool { return Is<NodeType::Function>(); }
 
     // BuiltinOp counterparts of the old NodeType-keyed IsNary/IsBinary/

--- a/include/operon/core/node.hpp
+++ b/include/operon/core/node.hpp
@@ -14,58 +14,22 @@
 
 namespace Operon {
 enum class NodeType : uint8_t {
-    // n-ary symbols
-    Add      = 0,
-    Mul,
-    Sub,
-    Div,
-    Fmin,
-    Fmax,
-
-    // binary symbols
-    Aq,
-    Pow,
-    Powabs,
-
-    // unary symbols
-    Abs,
-    Acos,
-    Asin,
-    Atan,
-    Cbrt,
-    Ceil,
-    Cos,
-    Cosh,
-    Exp,
-    Floor,
-    Log,
-    Logabs,
-    Log1p,
-    Sin,
-    Sinh,
-    Sqrt,
-    Sqrtabs,
-    Tan,
-    Tanh,
-    Square,
-
-    // nullary symbols (dynamic can be anything)
-    Dynamic,
     Constant,
     Variable,
-    Ref       // structural sharing: a backward reference to another node by index
+    Ref,      // structural sharing: a backward reference to another node by index
+    Function  // any named operation (built-in math op or user-registered), identified by HashValue
 };
 
-// The built-in math-op subset of NodeType (Add..Square above, i.e. NodeType
-// minus the four terminal categories Dynamic/Constant/Variable/Ref), demoted
-// to a source of stable compile-time Operon::Hash constants rather than a
-// NodeType-typed value. A built-in Node's HashValue equals
-// static_cast<Hash>(its NodeType) (see Node's single-arg constructor below),
-// so these values are chosen to match NodeType's ordinals exactly — a
-// BuiltinOp::X value and the corresponding NodeType::X share the same
-// underlying number, letting call sites switch on Node::HashValue instead of
-// Node::Type without changing behavior. Carries no arity/category semantics
-// of its own; see IsNaryOp/IsBinaryOp/IsUnaryOp below for that.
+// Stable compile-time Operon::Hash constants for every built-in math op.
+// A `Function`-typed Node representing a built-in op has HashValue equal to
+// static_cast<Hash>(the matching BuiltinOp) — small sequential integers,
+// chosen deliberately (not derived from anything else) so call sites can
+// `switch (n.HashValue) { case Hash(BuiltinOp::Add): ... }` with ordinary
+// compile-time case labels instead of a runtime map lookup. Carries no
+// arity/category semantics of its own; see IsNaryOp/IsBinaryOp/IsUnaryOp
+// below for that. Node::Function(hash, arity) is how a Node gets one of
+// these values as its HashValue — there is no longer a NodeType enumerator
+// per op, so nothing derives a BuiltinOp value from a Node's Type.
 enum class BuiltinOp : Operon::Hash {
     // n-ary symbols
     Add = 0,
@@ -103,69 +67,24 @@ enum class BuiltinOp : Operon::Hash {
     Square
 };
 
-// Arity and category (IsNary/IsBinary/IsUnary/IsNullary below, and the arity
-// inference in Node::Node) are derived from enumerator *position* in the
-// NodeType enum above, not from any per-type tag. These asserts pin the
-// ordering invariants that inference relies on, so a future reorder of the
-// enum is a compile error rather than a silent arity miscompute.
-static_assert(NodeType::Fmax < NodeType::Aq, "n-ary/binary boundary: Fmax must be the last n-ary symbol");
-static_assert(NodeType::Powabs < NodeType::Abs, "binary/unary boundary: Powabs must be the last binary symbol");
-static_assert(NodeType::Square < NodeType::Dynamic, "unary/nullary boundary: Square must be the last unary symbol");
-
-// BuiltinOp's ordinals are chosen to match NodeType's math-op subset above.
-// Pin every entry individually, not just the last one — a reorder that swaps
-// two *interior* entries (leaving the enum's size and last value unchanged)
-// would slip past a boundary-only check but still silently break the
-// HashValue equivalence for those two ops.
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Add) == static_cast<Operon::Hash>(NodeType::Add));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Mul) == static_cast<Operon::Hash>(NodeType::Mul));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Sub) == static_cast<Operon::Hash>(NodeType::Sub));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Div) == static_cast<Operon::Hash>(NodeType::Div));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Fmin) == static_cast<Operon::Hash>(NodeType::Fmin));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Fmax) == static_cast<Operon::Hash>(NodeType::Fmax));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Aq) == static_cast<Operon::Hash>(NodeType::Aq));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Pow) == static_cast<Operon::Hash>(NodeType::Pow));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Powabs) == static_cast<Operon::Hash>(NodeType::Powabs));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Abs) == static_cast<Operon::Hash>(NodeType::Abs));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Acos) == static_cast<Operon::Hash>(NodeType::Acos));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Asin) == static_cast<Operon::Hash>(NodeType::Asin));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Atan) == static_cast<Operon::Hash>(NodeType::Atan));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Cbrt) == static_cast<Operon::Hash>(NodeType::Cbrt));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Ceil) == static_cast<Operon::Hash>(NodeType::Ceil));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Cos) == static_cast<Operon::Hash>(NodeType::Cos));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Cosh) == static_cast<Operon::Hash>(NodeType::Cosh));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Exp) == static_cast<Operon::Hash>(NodeType::Exp));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Floor) == static_cast<Operon::Hash>(NodeType::Floor));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Log) == static_cast<Operon::Hash>(NodeType::Log));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Logabs) == static_cast<Operon::Hash>(NodeType::Logabs));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Log1p) == static_cast<Operon::Hash>(NodeType::Log1p));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Sin) == static_cast<Operon::Hash>(NodeType::Sin));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Sinh) == static_cast<Operon::Hash>(NodeType::Sinh));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Sqrt) == static_cast<Operon::Hash>(NodeType::Sqrt));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Sqrtabs) == static_cast<Operon::Hash>(NodeType::Sqrtabs));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Tan) == static_cast<Operon::Hash>(NodeType::Tan));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Tanh) == static_cast<Operon::Hash>(NodeType::Tanh));
-static_assert(static_cast<Operon::Hash>(BuiltinOp::Square) == static_cast<Operon::Hash>(NodeType::Square));
-
 // One past BuiltinOp's last value — the built-in hash range is
-// [0, BuiltinOpCount). Not used anywhere yet in this PR (the actual
-// reserved-hash-range check, symbol_library.hpp's ValidateUserHash, still
-// guards [0, NodeTypes::Count) unchanged); it exists for the later PR that
-// redesigns PrimitiveSetConfig around BuiltinOp instead of NodeType.
+// [0, BuiltinOpCount). Anything reserving "the range built-in ops occupy"
+// (see symbol_library.hpp's ValidateUserHash) should use this, not
+// NodeTypes::Count — the two are unrelated now that NodeType no longer has
+// one enumerator per math op.
 static auto constexpr BuiltinOpCount = static_cast<Operon::Hash>(BuiltinOp::Square) + 1;
 
 // Sentinel "not a real op" value (mirrors NodeTypes::NoType), distinguishable
-// from every genuine BuiltinOp value. Used below as the sentinel default for
-// Func<T,...>/Diff<T,...>'s primary ("missing this specialization")
-// templates, mirroring NodeTypes::NoType's role for the NodeType-keyed
-// versions.
+// from every genuine BuiltinOp value — used as a default template argument
+// where "no specific op" needs a nameable type, e.g. Dispatch::Func/Diff's
+// primary (unspecialized, "missing this specialization") templates.
 static auto constexpr NoBuiltinOp = static_cast<BuiltinOp>(~Operon::Hash{0});
 
 using UnderlyingNodeType = std::underlying_type_t<NodeType>;
 
 struct NodeTypes {
     // total number of distinct node types
-    static auto constexpr Count = static_cast<std::size_t>(NodeType::Ref) + 1UL;
+    static auto constexpr Count = static_cast<std::size_t>(NodeType::Function) + 1UL;
 
     // returns the index of the given type in the NodeType enum
     static constexpr auto GetIndex(NodeType type) -> size_t
@@ -176,30 +95,60 @@ struct NodeTypes {
     static auto constexpr NoType{static_cast<NodeType>(0xFFU)};
 };
 
-// A bitset over all node types, used to represent primitive set configurations.
-using PrimitiveSetConfig = Bitset<NodeTypes::Count>;
+// A bitset over "which built-in ops / terminal categories are enabled",
+// used by PrimitiveSet::SetConfig. [0, BuiltinOpCount) map to BuiltinOp
+// ordinals directly; the next NodeTypes::Count (4) slots map to
+// Constant/Variable/Ref and a shared "any Function present" slot — the
+// latter mirrors the pre-collapse Dynamic slot, since individual
+// user-registered functions (whose HashValue lands outside
+// [0, BuiltinOpCount)) were never individually representable in this
+// bitset either; only PrimitiveSet's own per-hash Enable/Disable does that.
+// Same total bit count as the pre-collapse 33-value NodeType bitset
+// (BuiltinOpCount=29 + NodeTypes::Count=4), just re-derived from two
+// smaller enums instead of one that no longer exists.
+using PrimitiveSetConfig = Bitset<BuiltinOpCount + NodeTypes::Count>;
 
-// Build a PrimitiveSetConfig from two individual NodeType values.
-constexpr auto operator|(NodeType lhs, NodeType rhs) -> PrimitiveSetConfig
+constexpr auto ToConfig(BuiltinOp op) -> PrimitiveSetConfig
 {
     PrimitiveSetConfig c{};
-    c.Set(NodeTypes::GetIndex(lhs));
-    c.Set(NodeTypes::GetIndex(rhs));
+    c.Set(static_cast<std::size_t>(op));
     return c;
 }
 
-// Extend a PrimitiveSetConfig with one more NodeType.
-constexpr auto operator|(PrimitiveSetConfig lhs, NodeType rhs) -> PrimitiveSetConfig
+constexpr auto ToConfig(NodeType type) -> PrimitiveSetConfig
 {
-    lhs.Set(NodeTypes::GetIndex(rhs));
-    return lhs;
+    PrimitiveSetConfig c{};
+    c.Set(BuiltinOpCount + NodeTypes::GetIndex(type));
+    return c;
 }
 
-constexpr auto operator|=(PrimitiveSetConfig& lhs, NodeType rhs) -> PrimitiveSetConfig&
+// The PrimitiveSetConfig bit index for a given (Type, HashValue) pair, e.g.
+// from an existing Node: a built-in op (Type == Function, HashValue in
+// [0, BuiltinOpCount)) maps to that BuiltinOp's own index; any other
+// Function node (a user-registered function) maps to the shared "any
+// Function present" slot (see the PrimitiveSetConfig comment above);
+// Constant/Variable/Ref map to their own slot.
+constexpr auto ConfigIndex(NodeType type, Operon::Hash hash) -> std::size_t
 {
-    lhs.Set(NodeTypes::GetIndex(rhs));
-    return lhs;
+    if (type == NodeType::Function && hash < BuiltinOpCount) {
+        return hash;
+    }
+    return BuiltinOpCount + NodeTypes::GetIndex(type);
 }
+
+// Combine a BuiltinOp/NodeType (any order/mix) into a PrimitiveSetConfig —
+// e.g. `NodeType::Constant | NodeType::Variable | BuiltinOp::Add | BuiltinOp::Sub`.
+constexpr auto operator|(BuiltinOp lhs, BuiltinOp rhs) -> PrimitiveSetConfig { return ToConfig(lhs) | ToConfig(rhs); }
+constexpr auto operator|(NodeType lhs, NodeType rhs) -> PrimitiveSetConfig { return ToConfig(lhs) | ToConfig(rhs); }
+constexpr auto operator|(NodeType lhs, BuiltinOp rhs) -> PrimitiveSetConfig { return ToConfig(lhs) | ToConfig(rhs); }
+constexpr auto operator|(BuiltinOp lhs, NodeType rhs) -> PrimitiveSetConfig { return ToConfig(lhs) | ToConfig(rhs); }
+
+// Extend a PrimitiveSetConfig with one more BuiltinOp/NodeType.
+constexpr auto operator|(PrimitiveSetConfig lhs, BuiltinOp rhs) -> PrimitiveSetConfig { return lhs | ToConfig(rhs); }
+constexpr auto operator|(PrimitiveSetConfig lhs, NodeType rhs) -> PrimitiveSetConfig { return lhs | ToConfig(rhs); }
+
+constexpr auto operator|=(PrimitiveSetConfig& lhs, BuiltinOp rhs) -> PrimitiveSetConfig& { lhs = lhs | rhs; return lhs; }
+constexpr auto operator|=(PrimitiveSetConfig& lhs, NodeType rhs) -> PrimitiveSetConfig& { lhs = lhs | rhs; return lhs; }
 
 struct Node {
     Operon::Hash HashValue; // needs to be unique for each node type
@@ -217,8 +166,34 @@ struct Node {
 
     Node() = default;
 
+    // Fixed sentinel hashes for the terminal categories' default (no
+    // explicit hash given) construction. Deliberately arbitrary constants
+    // far outside BuiltinOpCount's occupied range, rather than
+    // static_cast<Hash>(type) (what pre-collapse code did): basing a
+    // terminal's default hash on its own small NodeType ordinal would make
+    // "terminal hashes never collide with a built-in op's HashValue"
+    // depend on remembering to keep NodeType's terminal enumerators
+    // numbered after every BuiltinOp value — true by construction once,
+    // silently breakable by a later edit to either enum. These values have
+    // no such dependency: they're simply nowhere near [0, BuiltinOpCount).
+    // Function has no meaningful default — every real Function node is
+    // built via Node::Function(hash, arity) with a caller-supplied hash —
+    // but it still gets a distinct, non-colliding sentinel so the plain
+    // Node(NodeType::Function) path is inert rather than dangerous if
+    // something calls it by mistake.
+    static auto constexpr DefaultHash(NodeType type) noexcept -> Operon::Hash
+    {
+        switch (type) {
+        case NodeType::Constant: return Operon::Hash{0x00000000434F4E53ULL}; // "CONS"
+        case NodeType::Variable: return Operon::Hash{0x0000000056415249ULL}; // "VARI"
+        case NodeType::Ref:      return Operon::Hash{0x0000000000524546ULL}; // "REF"
+        case NodeType::Function: return Operon::Hash{0x0000000046554E43ULL}; // "FUNC"
+        }
+        return Operon::Hash{0};
+    }
+
     explicit Node(NodeType type) noexcept
-        : Node(type, static_cast<Operon::Hash>(type))
+        : Node(type, DefaultHash(type))
     {
     }
 
@@ -233,14 +208,6 @@ struct Node {
         , Type(type)
         , RefTo(0)
     {
-        if (Type < NodeType::Abs) // Add, Mul, Sub, Div, Fmin, Fmax, Aq, Pow, Powabs
-        {
-            Arity = 2;
-        } else if (Type < NodeType::Dynamic) // Abs through Square (unary)
-        {
-            Arity = 1;
-        }
-        Length = Arity;
         IsEnabled = true;
         Optimize = IsLeaf() && !IsRef();
         Value = 1.;
@@ -262,42 +229,24 @@ struct Node {
 
     // The generalized "any named operation" factory: a built-in math op
     // (hash = static_cast<Hash>(some BuiltinOp)) or a user-registered
-    // function (hash = a name-derived hash outside symbol_library.hpp's
-    // ValidateUserHash-reserved [0, NodeTypes::Count) range) are both
-    // represented as a Dynamic-tagged Node here — this PR doesn't touch
-    // NodeType's cardinality, so there's no dedicated Function category
-    // yet; that's introduced by the later PR that actually collapses the
-    // enum. Arity is caller-supplied rather than looked up from a registry:
-    // Node construction is the hottest path in the library (tree creators,
-    // crossover, mutation, Simplify's constant-folding), and every call site
-    // that constructs one of these nodes already has a PrimitiveSet/
-    // FunctionInfo in scope with the arity known, so a mandatory hash-map
-    // probe here would add cost to code that's currently a couple of integer
-    // assignments.
-    //
-    // Scope note: only the core interpreter's numeric dispatch chain
-    // (DispatchTable/StandardLibrary, retargeted onto BuiltinOp/hash in this
-    // PR) treats a Function-tagged built-in exactly like the equivalent
-    // Node(NodeType::X). Several other subsystems still switch on node.Type
-    // rather than HashValue and have no `case NodeType::Dynamic` for a
-    // built-in op: interval_evaluator.hpp and affine_evaluator.hpp both
-    // throw on their generic "unhandled type" default; tree_diff.cpp's
-    // symbolic differentiation returns a zero gradient; jit_compiler.cpp
-    // codegens a zero-valued stub — same as they already do for any genuine
-    // Dynamic/user-defined function today, since none of them are
-    // BuiltinOp-hash-aware yet. Do not use this factory to build a tree
-    // destined for those paths until their own retarget PRs land; it's
-    // currently safe only for the interpreter's Evaluate() path and this
-    // PR's own tests.
+    // function (hash = a name-derived hash outside BuiltinOpCount's range,
+    // see symbol_library.hpp's ValidateUserHash) are both just Function
+    // nodes now, distinguished only by HashValue. Arity is caller-supplied
+    // rather than looked up from a registry: Node construction is the
+    // hottest path in the library (tree creators, crossover, mutation,
+    // Simplify's constant-folding), and every call site already has a
+    // PrimitiveSet/FunctionInfo in scope with the arity known, so a
+    // mandatory hash-map probe here would add cost to code that's
+    // currently a couple of integer assignments.
     static auto Function(Operon::Hash hash, uint16_t arity) noexcept
     {
-        Node node(NodeType::Dynamic, hash);
+        Node node(NodeType::Function, hash);
         node.Arity  = arity;
         node.Length = arity;
-        // The two-arg ctor computes Optimize from Arity=0 (leaf) before this
-        // factory overrides Arity to the real value above - recompute
-        // explicitly rather than leave a stale true. These nodes (arity >=
-        // 1, always) are never coefficient-optimized regardless.
+        // The two-arg ctor computes Optimize from Arity=0 (leaf) before
+        // this factory overrides Arity to the real value above - recompute
+        // explicitly rather than leave a stale true. Function nodes (arity
+        // >= 1, always) are never coefficient-optimized regardless.
         node.Optimize = false;
         return node;
     }
@@ -381,24 +330,14 @@ struct Node {
     [[nodiscard]] auto IsSquareRoot() const -> bool { return Is<BuiltinOp::Sqrt>(); }
     [[nodiscard]] auto IsCubeRoot() const -> bool { return Is<BuiltinOp::Cbrt>(); }
     [[nodiscard]] auto IsSquare() const -> bool { return Is<BuiltinOp::Square>(); }
-    [[nodiscard]] auto IsDynamic() const -> bool { return Is<NodeType::Dynamic>(); }
+    [[nodiscard]] auto IsFunction() const -> bool { return Is<NodeType::Function>(); }
 
-    template<NodeType Type>
-    static auto constexpr IsNary = Type < NodeType::Aq;
-
-    template<NodeType Type>
-    static auto constexpr IsBinary = Type > NodeType::Fmax && Type < NodeType::Abs;
-
-    template<NodeType Type>
-    static auto constexpr IsUnary = Type > NodeType::Powabs && Type < NodeType::Dynamic;
-
-    template<NodeType Type>
-    static auto constexpr IsNullary = Type > NodeType::Square; // Dynamic, Constant, Variable, Ref
-
-    // BuiltinOp counterparts of IsNary/IsBinary/IsUnary above. No IsNullary
-    // counterpart: BuiltinOp only covers the math-op subset (Add..Square),
-    // never the terminal categories (Dynamic/Constant/Variable/Ref) that
-    // IsNullary<NodeType> distinguishes.
+    // BuiltinOp counterparts of the old NodeType-keyed IsNary/IsBinary/
+    // IsUnary/IsNullary, which no longer type-check (NodeType has no
+    // per-op enumerators left to compare against). No IsNullary
+    // counterpart: BuiltinOp only covers the math-op subset, never the
+    // terminal categories (Constant/Variable/Ref) that IsNullary used to
+    // distinguish — use `!Is<NodeType::Function>()` for that instead.
     template<BuiltinOp Op>
     static auto constexpr IsNaryOp = Op <= BuiltinOp::Fmax;
 

--- a/include/operon/core/pset.hpp
+++ b/include/operon/core/pset.hpp
@@ -34,9 +34,9 @@ class PrimitiveSet {
     }
 
 public:
-    static constexpr PrimitiveSetConfig Arithmetic = NodeType::Constant | NodeType::Variable | NodeType::Add | NodeType::Sub | NodeType::Mul | NodeType::Div;
-    static constexpr PrimitiveSetConfig TypeCoherent = Arithmetic | NodeType::Pow | NodeType::Exp | NodeType::Log | NodeType::Sin | NodeType::Cos | NodeType::Square;
-    static constexpr PrimitiveSetConfig Full = TypeCoherent | NodeType::Aq | NodeType::Tan | NodeType::Tanh | NodeType::Sqrt | NodeType::Cbrt;
+    static constexpr PrimitiveSetConfig Arithmetic = NodeType::Constant | NodeType::Variable | BuiltinOp::Add | BuiltinOp::Sub | BuiltinOp::Mul | BuiltinOp::Div;
+    static constexpr PrimitiveSetConfig TypeCoherent = Arithmetic | BuiltinOp::Pow | BuiltinOp::Exp | BuiltinOp::Log | BuiltinOp::Sin | BuiltinOp::Cos | BuiltinOp::Square;
+    static constexpr PrimitiveSetConfig Full = TypeCoherent | BuiltinOp::Aq | BuiltinOp::Tan | BuiltinOp::Tanh | BuiltinOp::Sqrt | BuiltinOp::Cbrt;
 
 
     PrimitiveSet() = default;
@@ -58,11 +58,7 @@ public:
     // arity must match what the registered callable in the DispatchTable expects.
     auto AddFunction(Operon::Hash hash, uint16_t arity, size_t frequency = 1) -> bool
     {
-        Node node(NodeType::Dynamic, hash);
-        node.Arity    = arity;
-        node.Length   = arity;
-        node.Optimize = false; // function nodes are never coefficient-optimized
-        return AddPrimitive(node, frequency, arity, arity);
+        return AddPrimitive(Node::Function(hash, arity), frequency, arity, arity);
     }
 
     void RemovePrimitive(Operon::Node node) { pset_.erase(node.HashValue); }
@@ -88,7 +84,7 @@ public:
         for (auto [k, v] : pset_) {
             auto const& [node, freq, min_arity, max_arity] = v;
             if (node.IsEnabled && freq > 0) {
-                conf.Set(static_cast<std::size_t>(node.Type));
+                conf.Set(ConfigIndex(node.Type, node.HashValue));
             }
         }
         return conf;

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -43,39 +43,44 @@ struct StandardLibrary {
     static void RegisterNames()
     {
         static auto const registered = [] {
-            for (auto const& entry : Entries) {
-                Node::RegisterName(Node(entry.Type).HashValue, std::string(entry.Name), std::string(entry.Desc));
+            for (auto const& entry : BuiltinEntries) {
+                Node::RegisterName(static_cast<Operon::Hash>(entry.Op), std::string(entry.Name), std::string(entry.Desc));
+            }
+            for (auto const& entry : TerminalEntries) {
+                Node::RegisterName(Node::DefaultHash(entry.Type), std::string(entry.Name), std::string(entry.Desc));
             }
             return true;
         }();
         static_cast<void>(registered);
     }
 
-    // Register all built-in math ops (everything except Dynamic, Constant,
-    // Variable, Ref) into `dt`, for every scalar type DTable supports.
+    // Register all built-in math ops into `dt`, for every scalar type
+    // DTable supports. Constant/Variable/Ref/(the generic "dyn" Function
+    // fallback) have no numeric Callable/CallableDiff to register - they're
+    // terminals, not evaluated via the dispatch table.
     template<typename... Ts>
     static void Register(DispatchTable<Ts...>& dt)
     {
         RegisterNames();
-        RegisterAll(dt, std::make_index_sequence<NodeTypes::Count - 4>{});
+        RegisterAll(dt, std::make_index_sequence<BuiltinEntries.size()>{});
     }
 
-    // Min/max arity for a built-in NodeType, sourced from the registry
-    // instead of Node(type).Arity's position-based inference (Node's ctor
-    // infers arity from where `type` falls relative to the Abs/Dynamic
-    // boundaries; this walks the same data the registry already carries
-    // explicitly, which is what PrimitiveSet's preset configs consume).
-    [[nodiscard]] static constexpr auto ArityLimits(NodeType type) -> std::pair<uint16_t, uint16_t>
+    // Min/max arity for a built-in op, sourced from the registry instead of
+    // position-based inference (removed along with NodeType's old
+    // math-op enumerators; this walks the same data the registry already
+    // carries explicitly, which is what PrimitiveSet's preset configs
+    // consume).
+    [[nodiscard]] static constexpr auto ArityLimits(BuiltinOp op) -> std::pair<uint16_t, uint16_t>
     {
-        for (auto const& entry : Entries) {
-            if (entry.Type == type) { return { entry.MinArity, entry.MaxArity }; }
+        for (auto const& entry : BuiltinEntries) {
+            if (entry.Op == op) { return { entry.MinArity, entry.MaxArity }; }
         }
         return { 0, 0 };
     }
 
 private:
-    struct Entry {
-        NodeType Type;
+    struct BuiltinEntry {
+        BuiltinOp Op;
         std::string_view Name;
         std::string_view Desc;
         uint16_t MinArity;
@@ -83,40 +88,55 @@ private:
         FormatRule Rule;
     };
 
-    static constexpr std::array Entries {
-        Entry{ NodeType::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ...", 2, 2, FormatRule::Infix },
-        Entry{ NodeType::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ...", 2, 2, FormatRule::Infix },
-        Entry{ NodeType::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)", 2, 2, FormatRule::Infix },
-        Entry{ NodeType::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)", 2, 2, FormatRule::Infix },
-        Entry{ NodeType::Fmin, "fmin", "minimum function f(a,b) = min(a,b)", 2, 2, FormatRule::MinMaxCall },
-        Entry{ NodeType::Fmax, "fmax", "maximum function f(a,b) = max(a,b)", 2, 2, FormatRule::MinMaxCall },
-        Entry{ NodeType::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)", 2, 2, FormatRule::Composite },
-        Entry{ NodeType::Pow, "pow", "raise to power f(a,b) = a^b", 2, 2, FormatRule::PowerNotation },
-        Entry{ NodeType::Powabs, "powabs", "raise absolute value to power f(a,b) = |a|^b", 2, 2, FormatRule::Composite },
-        Entry{ NodeType::Abs, "abs", "absolute value function f(a) = abs(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Acos, "acos", "inverse cosine function f(a) = acos(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Asin, "asin", "inverse sine function f(a) = asin(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Atan, "atan", "inverse tangent function f(a) = atan(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Cbrt, "cbrt", "cube root function f(a) = cbrt(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Ceil, "ceil", "ceiling function f(a) = ceil(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Cos, "cos", "cosine function f(a) = cos(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Cosh, "cosh", "hyperbolic cosine function f(a) = cosh(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Exp, "exp", "e raised to the given power f(a) = e^a", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Floor, "floor", "floor function f(a) = floor(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Log, "log", "natural (base e) logarithm f(a) = ln(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Logabs, "logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)", 1, 1, FormatRule::Composite },
-        Entry{ NodeType::Log1p, "log1p", "f(a) = ln(a + 1), accurate even when a is close to zero", 1, 1, FormatRule::Composite },
-        Entry{ NodeType::Sin, "sin", "sine function f(a) = sin(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Sinh, "sinh", "hyperbolic sine function f(a) = sinh(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Sqrt, "sqrt", "square root function f(a) = sqrt(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Sqrtabs, "sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)", 1, 1, FormatRule::Composite },
-        Entry{ NodeType::Tan, "tan", "tangent function f(a) = tan(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Tanh, "tanh", "hyperbolic tangent function f(a) = tanh(a)", 1, 1, FormatRule::GenericCall },
-        Entry{ NodeType::Square, "square", "square function f(a) = a^2", 1, 1, FormatRule::PowerNotation },
-        Entry{ NodeType::Dynamic, "dyn", "user-defined function", 0, 0, FormatRule::GenericCall },
-        Entry{ NodeType::Constant, "constant", "a constant value", 0, 0, FormatRule::GenericCall },
-        Entry{ NodeType::Variable, "variable", "a dataset input with an associated weight", 0, 0, FormatRule::GenericCall },
-        Entry{ NodeType::Ref, "ref", "structural reference to another node (enables DAG sharing)", 0, 0, FormatRule::GenericCall },
+    // Ordered to match BuiltinOp's own enumerator order exactly - RegisterAll
+    // below relies on index I mapping directly to static_cast<BuiltinOp>(I).
+    static constexpr std::array BuiltinEntries {
+        BuiltinEntry{ BuiltinOp::Add, "+", "n-ary addition f(a,b,c,...) = a + b + c + ...", 2, 2, FormatRule::Infix },
+        BuiltinEntry{ BuiltinOp::Mul, "*", "n-ary multiplication f(a,b,c,...) = a * b * c * ...", 2, 2, FormatRule::Infix },
+        BuiltinEntry{ BuiltinOp::Sub, "-", "n-ary subtraction f(a,b,c,...) = a - (b + c + ...)", 2, 2, FormatRule::Infix },
+        BuiltinEntry{ BuiltinOp::Div, "/", "n-ary division f(a,b,c,..) = a / (b * c * ...)", 2, 2, FormatRule::Infix },
+        BuiltinEntry{ BuiltinOp::Fmin, "fmin", "minimum function f(a,b) = min(a,b)", 2, 2, FormatRule::MinMaxCall },
+        BuiltinEntry{ BuiltinOp::Fmax, "fmax", "maximum function f(a,b) = max(a,b)", 2, 2, FormatRule::MinMaxCall },
+        BuiltinEntry{ BuiltinOp::Aq, "aq", "analytical quotient f(a,b) = a / sqrt(1 + b^2)", 2, 2, FormatRule::Composite },
+        BuiltinEntry{ BuiltinOp::Pow, "pow", "raise to power f(a,b) = a^b", 2, 2, FormatRule::PowerNotation },
+        BuiltinEntry{ BuiltinOp::Powabs, "powabs", "raise absolute value to power f(a,b) = |a|^b", 2, 2, FormatRule::Composite },
+        BuiltinEntry{ BuiltinOp::Abs, "abs", "absolute value function f(a) = abs(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Acos, "acos", "inverse cosine function f(a) = acos(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Asin, "asin", "inverse sine function f(a) = asin(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Atan, "atan", "inverse tangent function f(a) = atan(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Cbrt, "cbrt", "cube root function f(a) = cbrt(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Ceil, "ceil", "ceiling function f(a) = ceil(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Cos, "cos", "cosine function f(a) = cos(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Cosh, "cosh", "hyperbolic cosine function f(a) = cosh(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Exp, "exp", "e raised to the given power f(a) = e^a", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Floor, "floor", "floor function f(a) = floor(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Log, "log", "natural (base e) logarithm f(a) = ln(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Logabs, "logabs", "natural (base e) logarithm of absolute value f(a) = ln(|a|)", 1, 1, FormatRule::Composite },
+        BuiltinEntry{ BuiltinOp::Log1p, "log1p", "f(a) = ln(a + 1), accurate even when a is close to zero", 1, 1, FormatRule::Composite },
+        BuiltinEntry{ BuiltinOp::Sin, "sin", "sine function f(a) = sin(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Sinh, "sinh", "hyperbolic sine function f(a) = sinh(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Sqrt, "sqrt", "square root function f(a) = sqrt(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Sqrtabs, "sqrtabs", "square root of absolute value function f(a) = sqrt(|a|)", 1, 1, FormatRule::Composite },
+        BuiltinEntry{ BuiltinOp::Tan, "tan", "tangent function f(a) = tan(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Tanh, "tanh", "hyperbolic tangent function f(a) = tanh(a)", 1, 1, FormatRule::GenericCall },
+        BuiltinEntry{ BuiltinOp::Square, "square", "square function f(a) = a^2", 1, 1, FormatRule::PowerNotation },
+    };
+
+    struct TerminalEntry {
+        NodeType Type;
+        std::string_view Name;
+        std::string_view Desc;
+    };
+
+    // Function's entry is the generic fallback name/desc for an
+    // unregistered user function (mirrors the old Dynamic entry) - a
+    // registered user function's own name/desc (via Node::RegisterName)
+    // takes precedence, this is only reached when that lookup misses.
+    static constexpr std::array TerminalEntries {
+        TerminalEntry{ NodeType::Function, "dyn", "user-defined function" },
+        TerminalEntry{ NodeType::Constant, "constant", "a constant value" },
+        TerminalEntry{ NodeType::Variable, "variable", "a dataset input with an associated weight" },
+        TerminalEntry{ NodeType::Ref, "ref", "structural reference to another node (enables DAG sharing)" },
     };
 
     template<typename... Ts, std::size_t... I>
@@ -125,25 +145,25 @@ private:
         (RegisterOne<static_cast<BuiltinOp>(I)>(dt), ...);
     }
 
-    template<BuiltinOp Type, typename... Ts>
+    template<BuiltinOp Op, typename... Ts>
     static void RegisterOne(DispatchTable<Ts...>& dt)
     {
-        auto const hash = static_cast<Operon::Hash>(Type);
-        (RegisterForType<Type, Ts>(dt, hash), ...);
+        auto const hash = static_cast<Operon::Hash>(Op);
+        (RegisterForType<Op, Ts>(dt, hash), ...);
     }
 
-    template<BuiltinOp Type, typename T, typename... Ts>
+    template<BuiltinOp Op, typename T, typename... Ts>
     requires Operon::Concepts::Arithmetic<T>
     static void RegisterForType(DispatchTable<Ts...>& dt, Operon::Hash hash)
     {
         constexpr auto S = DispatchTable<Ts...>::template BatchSize<T>;
         dt.template RegisterFunction<T>(
             hash,
-            Dispatch::MakeFunctionCall<Type, T, S>(),
-            Dispatch::MakeDiffCall<Type, T, S>());
+            Dispatch::MakeFunctionCall<Op, T, S>(),
+            Dispatch::MakeDiffCall<Op, T, S>());
     }
 
-    template<BuiltinOp Type, typename T, typename... Ts>
+    template<BuiltinOp Op, typename T, typename... Ts>
     requires (!Operon::Concepts::Arithmetic<T>)
     static void RegisterForType(DispatchTable<Ts...>& /*dt*/, Operon::Hash /*hash*/)
     {

--- a/include/operon/core/symbol_library.hpp
+++ b/include/operon/core/symbol_library.hpp
@@ -323,7 +323,7 @@ void RegisterBinary(DTable& dt, Operon::Hash hash, F primal,
 // Bundles the metadata needed to register a user-defined function symbol.
 // Hash is derived from Name (via Operon::Hasher) rather than supplied by the
 // caller, so it can't accidentally collide with the small-integer hash range
-// reserved for built-ins (see NodeType's HashValue == static_cast<Hash>(type)).
+// reserved for built-ins (see BuiltinOp's HashValue == static_cast<Hash>(op)).
 struct FunctionInfo {
     std::string Name;
     std::string Desc;
@@ -332,20 +332,20 @@ struct FunctionInfo {
 };
 
 namespace detail {
-    // [0, NodeTypes::Count) is reserved for built-in NodeType ordinals
-    // (Node(NodeType) ctor sets HashValue = static_cast<Hash>(type)); a
-    // name-derived hash landing there would silently overwrite a built-in's
-    // dispatch entry / name+desc. A real 64-bit XXHash of a non-empty name
-    // landing in that ~30-value range is not a plausible accident, but the
-    // check is nearly free and turns the impossible case into a clear error
-    // instead of silent corruption.
+    // [0, BuiltinOpCount) is reserved for built-in ops (a Function node's
+    // HashValue == static_cast<Hash>(some BuiltinOp)); a name-derived hash
+    // landing there would silently overwrite a built-in's dispatch entry /
+    // name+desc. A real 64-bit XXHash of a non-empty name landing in that
+    // ~30-value range is not a plausible accident, but the check is nearly
+    // free and turns the impossible case into a clear error instead of
+    // silent corruption.
     inline void ValidateUserHash(Operon::Hash hash, std::string_view name)
     {
         if (name.empty()) {
             throw std::invalid_argument("FunctionInfo::Name must not be empty (it seeds the function's hash)");
         }
-        if (hash < NodeTypes::Count) {
-            throw std::invalid_argument("FunctionInfo: name-derived hash falls in the range reserved for built-in NodeTypes");
+        if (hash < BuiltinOpCount) {
+            throw std::invalid_argument("FunctionInfo: name-derived hash falls in the range reserved for built-in ops");
         }
     }
 } // namespace detail

--- a/include/operon/information_criteria/weighted_complexity.hpp
+++ b/include/operon/information_criteria/weighted_complexity.hpp
@@ -23,7 +23,7 @@ namespace Operon {
 // fComplexity = k * log(q), q = number of unique symbol types.
 inline auto WeightedComplexity(Tree const& tree) -> std::pair<double, double>
 {
-    static auto const MulHash   = Node{NodeType::Mul}.HashValue;
+    static auto const MulHash   = static_cast<Operon::Hash>(BuiltinOp::Mul);
     static auto const ParamHash = Node{NodeType::Constant}.HashValue;
     Operon::Set<Operon::Hash> uniqueSymbols;
     auto k = 0.0;

--- a/include/operon/interpreter/affine_evaluator.hpp
+++ b/include/operon/interpreter/affine_evaluator.hpp
@@ -133,8 +133,8 @@ public:
             EXPECT(acc.has_value()); // arity > 0 — malformed tree otherwise
             return std::move(*acc);
         };
-        // Fmin/Fmax are n-ary (NodeType::IsNary covers Add..Fmax). Fold all
-        // children — do NOT hardcode binary j/k indexing.
+        // Fmin/Fmax are n-ary (Node::IsNaryOp<BuiltinOp> covers Add..Fmax). Fold
+        // all children — do NOT hardcode binary j/k indexing.
         auto const minFold = [&](std::size_t i) {
             std::optional<Affine> acc;
             for (auto j : Tree::Indices(nodes, i)) {
@@ -164,11 +164,9 @@ public:
                 v = static_cast<Scalar>(node.Value);
             }
 
-            switch (node.Type) {
-            case NodeType::Constant:
+            if (node.Type == NodeType::Constant) {
                 primal_.push_back(pappus::ops::constant<Scalar>(ctx_, v));
-                break;
-            case NodeType::Variable: {
+            } else if (node.Type == NodeType::Variable) {
                 auto it = domains_.find(node.HashValue);
                 if (it == domains_.end()) {
                     throw std::runtime_error(fmt::format(
@@ -177,119 +175,119 @@ public:
                 }
                 auto const& [lo, hi] = it->second;
                 primal_.push_back(pappus::ops::variable<Scalar>(ctx_, lo, hi) * v);
-                break;
-            }
-            case NodeType::Ref:
+            } else if (node.Type == NodeType::Ref) {
                 EXPECT(static_cast<std::size_t>(node.RefTo) < primal_.size());
                 primal_.push_back(primal_[node.RefTo]);
-                break;
-            case NodeType::Add:
-                primal_.push_back(addFold(i) * v);
-                break;
-            case NodeType::Mul:
-                primal_.push_back(mulFold(i) * v);
-                break;
-            case NodeType::Sub:
-                primal_.push_back((node.Arity == 1 ? pappus::ops::neg<Scalar>(primal_[i - 1])
-                                                  : subFold(i)) * v);
-                break;
-            case NodeType::Div:
-                // May throw if the denominator form contains zero (affine inv
-                // is stricter than interval inv).
-                primal_.push_back((node.Arity == 1 ? pappus::ops::inv<Scalar>(ctx_, primal_[i - 1])
-                                                  : divFold(i)) * v);
-                break;
-            case NodeType::Square:
-                primal_.push_back(pappus::ops::square<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Sqrt:
-                primal_.push_back(pappus::ops::sqrt<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Exp:
-                primal_.push_back(pappus::ops::exp<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Log:
-                primal_.push_back(pappus::ops::log<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Sin:
-                primal_.push_back(pappus::ops::sin<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Cos:
-                primal_.push_back(pappus::ops::cos<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Tan:
-                primal_.push_back(pappus::ops::tan<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Asin:
-                primal_.push_back(pappus::ops::asin<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Acos:
-                primal_.push_back(pappus::ops::acos<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Atan:
-                primal_.push_back(pappus::ops::atan<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Sinh:
-                primal_.push_back(pappus::ops::sinh<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Cosh:
-                primal_.push_back(pappus::ops::cosh<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Tanh:
-                primal_.push_back(pappus::ops::tanh<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Pow: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                primal_.push_back(pappus::ops::pow<Scalar>(ctx_, primal_[j], primal_[k]) * v);
-                break;
-            }
-            case NodeType::Aq: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                primal_.push_back(pappus::ops::aq<Scalar>(ctx_, primal_[j], primal_[k]) * v);
-                break;
-            }
-            case NodeType::Abs:
-                // May throw if the domain crosses zero (requires Chebyshev V-shape).
-                primal_.push_back(pappus::ops::abs<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Sqrtabs:
-                primal_.push_back(pappus::ops::sqrtabs<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Logabs:
-                primal_.push_back(pappus::ops::logabs<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Powabs: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                auto absBase = pappus::ops::abs<Scalar>(ctx_, primal_[j]);
-                primal_.push_back(pappus::ops::pow<Scalar>(ctx_, absBase, primal_[k]) * v);
-                break;
-            }
-            case NodeType::Fmin:
-                primal_.push_back(minFold(i) * v);
-                break;
-            case NodeType::Fmax:
-                primal_.push_back(maxFold(i) * v);
-                break;
-            case NodeType::Cbrt:
-                primal_.push_back(pappus::ops::cbrt<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Log1p:
-                // May throw if the domain includes values <= -1.
-                primal_.push_back(pappus::ops::log1p<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Floor:
-                primal_.push_back(pappus::ops::floor<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            case NodeType::Ceil:
-                primal_.push_back(pappus::ops::ceil<Scalar>(ctx_, primal_[i - 1]) * v);
-                break;
-            default:
-                throw std::runtime_error(fmt::format(
-                    "AffineEvaluator: node kind `{}` not yet mapped",
-                    node.Name()));
+            } else {
+                switch (node.HashValue) {
+                case Operon::Hash(BuiltinOp::Add):
+                    primal_.push_back(addFold(i) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Mul):
+                    primal_.push_back(mulFold(i) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Sub):
+                    primal_.push_back((node.Arity == 1 ? pappus::ops::neg<Scalar>(primal_[i - 1])
+                                                      : subFold(i)) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Div):
+                    // May throw if the denominator form contains zero (affine inv
+                    // is stricter than interval inv).
+                    primal_.push_back((node.Arity == 1 ? pappus::ops::inv<Scalar>(ctx_, primal_[i - 1])
+                                                      : divFold(i)) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Square):
+                    primal_.push_back(pappus::ops::square<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Sqrt):
+                    primal_.push_back(pappus::ops::sqrt<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Exp):
+                    primal_.push_back(pappus::ops::exp<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Log):
+                    primal_.push_back(pappus::ops::log<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Sin):
+                    primal_.push_back(pappus::ops::sin<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Cos):
+                    primal_.push_back(pappus::ops::cos<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Tan):
+                    primal_.push_back(pappus::ops::tan<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Asin):
+                    primal_.push_back(pappus::ops::asin<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Acos):
+                    primal_.push_back(pappus::ops::acos<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Atan):
+                    primal_.push_back(pappus::ops::atan<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Sinh):
+                    primal_.push_back(pappus::ops::sinh<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Cosh):
+                    primal_.push_back(pappus::ops::cosh<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Tanh):
+                    primal_.push_back(pappus::ops::tanh<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Pow): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    primal_.push_back(pappus::ops::pow<Scalar>(ctx_, primal_[j], primal_[k]) * v);
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Aq): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    primal_.push_back(pappus::ops::aq<Scalar>(ctx_, primal_[j], primal_[k]) * v);
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Abs):
+                    // May throw if the domain crosses zero (requires Chebyshev V-shape).
+                    primal_.push_back(pappus::ops::abs<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Sqrtabs):
+                    primal_.push_back(pappus::ops::sqrtabs<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Logabs):
+                    primal_.push_back(pappus::ops::logabs<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Powabs): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    auto absBase = pappus::ops::abs<Scalar>(ctx_, primal_[j]);
+                    primal_.push_back(pappus::ops::pow<Scalar>(ctx_, absBase, primal_[k]) * v);
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Fmin):
+                    primal_.push_back(minFold(i) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Fmax):
+                    primal_.push_back(maxFold(i) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Cbrt):
+                    primal_.push_back(pappus::ops::cbrt<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Log1p):
+                    // May throw if the domain includes values <= -1.
+                    primal_.push_back(pappus::ops::log1p<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Floor):
+                    primal_.push_back(pappus::ops::floor<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                case Operon::Hash(BuiltinOp::Ceil):
+                    primal_.push_back(pappus::ops::ceil<Scalar>(ctx_, primal_[i - 1]) * v);
+                    break;
+                default:
+                    throw std::runtime_error(fmt::format(
+                        "AffineEvaluator: node kind `{}` not yet mapped",
+                        node.Name()));
+                }
             }
         }
         return primal_.back();

--- a/include/operon/interpreter/interval_evaluator.hpp
+++ b/include/operon/interpreter/interval_evaluator.hpp
@@ -154,11 +154,9 @@ public:
                 v = static_cast<Scalar>(node.Value);
             }
 
-            switch (node.Type) {
-            case NodeType::Constant:
+            if (node.Type == NodeType::Constant) {
                 primal_[i] = pappus::ops::constant<Scalar>(v);
-                break;
-            case NodeType::Variable: {
+            } else if (node.Type == NodeType::Variable) {
                 auto it = domains_.find(node.HashValue);
                 if (it == domains_.end()) {
                     throw std::runtime_error(fmt::format(
@@ -167,114 +165,114 @@ public:
                 }
                 auto const& [lo, hi] = it->second;
                 primal_[i] = pappus::ops::variable<Scalar>(lo, hi) * v;
-                break;
-            }
-            case NodeType::Ref:
+            } else if (node.Type == NodeType::Ref) {
                 EXPECT(static_cast<std::size_t>(node.RefTo) < i);
                 primal_[i] = primal_[node.RefTo];
-                break;
-            case NodeType::Add:
-                primal_[i] = addFold(i) * v;
-                break;
-            case NodeType::Mul:
-                primal_[i] = mulFold(i) * v;
-                break;
-            case NodeType::Sub:
-                primal_[i] = (node.Arity == 1 ? pappus::ops::neg<Scalar>(primal_[i - 1])
-                                              : subFold(i)) * v;
-                break;
-            case NodeType::Div:
-                primal_[i] = (node.Arity == 1 ? pappus::ops::inv<Scalar>(primal_[i - 1])
-                                              : divFold(i)) * v;
-                break;
-            case NodeType::Square:
-                primal_[i] = pappus::ops::square<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Sqrt:
-                primal_[i] = pappus::ops::sqrt<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Exp:
-                primal_[i] = pappus::ops::exp<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Log:
-                primal_[i] = pappus::ops::log<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Sin:
-                primal_[i] = pappus::ops::sin<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Cos:
-                primal_[i] = pappus::ops::cos<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Tan:
-                primal_[i] = pappus::ops::tan<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Asin:
-                primal_[i] = pappus::ops::asin<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Acos:
-                primal_[i] = pappus::ops::acos<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Atan:
-                primal_[i] = pappus::ops::atan<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Sinh:
-                primal_[i] = pappus::ops::sinh<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Cosh:
-                primal_[i] = pappus::ops::cosh<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Tanh:
-                primal_[i] = pappus::ops::tanh<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Pow: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                primal_[i] = pappus::ops::pow<Scalar>(primal_[j], primal_[k]) * v;
-                break;
-            }
-            case NodeType::Abs:
-                primal_[i] = pappus::ops::abs<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Sqrtabs:
-                primal_[i] = pappus::ops::sqrtabs<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Logabs:
-                primal_[i] = pappus::ops::logabs<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Powabs: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                primal_[i] = pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(primal_[j]), primal_[k]) * v;
-                break;
-            }
-            case NodeType::Aq: {
-                auto const j = static_cast<std::size_t>(i - 1);
-                auto const k = j - (nodes[j].Length + 1);
-                primal_[i] = pappus::ops::aq<Scalar>(primal_[j], primal_[k]) * v;
-                break;
-            }
-            case NodeType::Fmin:
-                primal_[i] = minFold(i) * v;
-                break;
-            case NodeType::Fmax:
-                primal_[i] = maxFold(i) * v;
-                break;
-            case NodeType::Cbrt:
-                primal_[i] = pappus::ops::cbrt<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Log1p:
-                primal_[i] = pappus::ops::log1p<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Floor:
-                primal_[i] = pappus::ops::floor<Scalar>(primal_[i - 1]) * v;
-                break;
-            case NodeType::Ceil:
-                primal_[i] = pappus::ops::ceil<Scalar>(primal_[i - 1]) * v;
-                break;
-            default:
-                throw std::runtime_error(fmt::format(
-                    "IntervalEvaluator: node kind `{}` not yet mapped",
-                    node.Name()));
+            } else {
+                switch (node.HashValue) {
+                case Operon::Hash(BuiltinOp::Add):
+                    primal_[i] = addFold(i) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Mul):
+                    primal_[i] = mulFold(i) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Sub):
+                    primal_[i] = (node.Arity == 1 ? pappus::ops::neg<Scalar>(primal_[i - 1])
+                                                  : subFold(i)) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Div):
+                    primal_[i] = (node.Arity == 1 ? pappus::ops::inv<Scalar>(primal_[i - 1])
+                                                  : divFold(i)) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Square):
+                    primal_[i] = pappus::ops::square<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Sqrt):
+                    primal_[i] = pappus::ops::sqrt<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Exp):
+                    primal_[i] = pappus::ops::exp<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Log):
+                    primal_[i] = pappus::ops::log<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Sin):
+                    primal_[i] = pappus::ops::sin<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Cos):
+                    primal_[i] = pappus::ops::cos<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Tan):
+                    primal_[i] = pappus::ops::tan<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Asin):
+                    primal_[i] = pappus::ops::asin<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Acos):
+                    primal_[i] = pappus::ops::acos<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Atan):
+                    primal_[i] = pappus::ops::atan<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Sinh):
+                    primal_[i] = pappus::ops::sinh<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Cosh):
+                    primal_[i] = pappus::ops::cosh<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Tanh):
+                    primal_[i] = pappus::ops::tanh<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Pow): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    primal_[i] = pappus::ops::pow<Scalar>(primal_[j], primal_[k]) * v;
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Abs):
+                    primal_[i] = pappus::ops::abs<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Sqrtabs):
+                    primal_[i] = pappus::ops::sqrtabs<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Logabs):
+                    primal_[i] = pappus::ops::logabs<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Powabs): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    primal_[i] = pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(primal_[j]), primal_[k]) * v;
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Aq): {
+                    auto const j = static_cast<std::size_t>(i - 1);
+                    auto const k = j - (nodes[j].Length + 1);
+                    primal_[i] = pappus::ops::aq<Scalar>(primal_[j], primal_[k]) * v;
+                    break;
+                }
+                case Operon::Hash(BuiltinOp::Fmin):
+                    primal_[i] = minFold(i) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Fmax):
+                    primal_[i] = maxFold(i) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Cbrt):
+                    primal_[i] = pappus::ops::cbrt<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Log1p):
+                    primal_[i] = pappus::ops::log1p<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Floor):
+                    primal_[i] = pappus::ops::floor<Scalar>(primal_[i - 1]) * v;
+                    break;
+                case Operon::Hash(BuiltinOp::Ceil):
+                    primal_[i] = pappus::ops::ceil<Scalar>(primal_[i - 1]) * v;
+                    break;
+                default:
+                    throw std::runtime_error(fmt::format(
+                        "IntervalEvaluator: node kind `{}` not yet mapped",
+                        node.Name()));
+                }
             }
         }
         return primal_.back();

--- a/source/algorithms/enumeration.cpp
+++ b/source/algorithms/enumeration.cpp
@@ -148,9 +148,11 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
                 Operon::Vector<Node> nodes;
                 if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(WeightPlaceholder)); }
                 AppendNodes(nodes, t.Nodes());
-                if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
+                if (p.WeightFirstOperand) { nodes.push_back(Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2)); }
                 if (p.TrailingConstant) { nodes.push_back(Node::Constant(BiasPlaceholder)); }
-                nodes.push_back(Node(p.Op));
+                // Op's direct children: the (possibly Mul-wrapped) operand, plus
+                // one more if TrailingConstant appended a Bias sibling.
+                nodes.push_back(Node::Function(static_cast<Hash>(p.Op), p.TrailingConstant ? 2 : 1));
                 TryInsert(nt, Tree(std::move(nodes)).UpdateNodes());
             }
         } else {
@@ -188,9 +190,12 @@ void EnumerationEngine::ProcessNonterminal(GrammarSymbol nt, std::size_t budget)
                         Operon::Vector<Node> nodes;
                         if (p.WeightFirstOperand) { nodes.push_back(Node::Constant(WeightPlaceholder)); }
                         AppendNodes(nodes, t0.Nodes());
-                        if (p.WeightFirstOperand) { nodes.push_back(Node(NodeType::Mul)); }
+                        if (p.WeightFirstOperand) { nodes.push_back(Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2)); }
                         AppendNodes(nodes, t1.Nodes());
-                        nodes.push_back(Node(p.Op));
+                        // Op's direct children: the (possibly Mul-wrapped) first
+                        // operand, plus the second operand - always 2 today (this
+                        // branch handles exactly Operands.size()==2 productions).
+                        nodes.push_back(Node::Function(static_cast<Hash>(p.Op), static_cast<uint16_t>(p.Operands.size())));
                         TryInsert(nt, Tree(std::move(nodes)).UpdateNodes());
                     }
                 }

--- a/source/core/grammar.cpp
+++ b/source/core/grammar.cpp
@@ -9,12 +9,12 @@
 namespace Operon {
 
 namespace {
-    // Unary NodeTypes that may wrap a SimpleExpr as a RecurringFactor, gated
+    // Unary ops that may wrap a SimpleExpr as a RecurringFactor, gated
     // by whether each is enabled in the configured PrimitiveSetConfig.
     // Mirrors symreg-cpp's grammar.cpp (LogFactor/ExpFactor/SinFactor/
     // SqrtFactor/CbrtFactor); InvFactor is intentionally not reproduced (see
     // grammar.hpp's GrammarSymbol comment).
-    constexpr std::array UnaryWraps { NodeType::Log, NodeType::Exp, NodeType::Sin, NodeType::Sqrt, NodeType::Cbrt };
+    constexpr std::array UnaryWraps { BuiltinOp::Log, BuiltinOp::Exp, BuiltinOp::Sin, BuiltinOp::Sqrt, BuiltinOp::Cbrt };
 } // namespace
 
 Grammar::Grammar(PrimitiveSetConfig enabledFunctions, std::vector<Operon::Hash> variableHashes)
@@ -44,28 +44,28 @@ void Grammar::Rebuild()
 
     auto& recurringFactor = rules_[GrammarSymbols::GetIndex(GrammarSymbol::RecurringFactor)];
     for (auto op : UnaryWraps) {
-        if (config_.Test(NodeTypes::GetIndex(op))) {
+        if (config_.Test(static_cast<std::size_t>(op))) {
             recurringFactor.push_back(Production{ .Op = op, .Operands = { GrammarSymbol::SimpleExpr } });
         }
     }
 
     rules_[GrammarSymbols::GetIndex(GrammarSymbol::Term)] = {
-        Production{ .Op = NodeTypes::NoType, .Operands = { GrammarSymbol::RecurringFactor } }, // coercion
-        Production{ .Op = NodeType::Mul, .Operands = { GrammarSymbol::Term, GrammarSymbol::Term } },
+        Production{ .Op = NoBuiltinOp, .Operands = { GrammarSymbol::RecurringFactor } }, // coercion
+        Production{ .Op = BuiltinOp::Mul, .Operands = { GrammarSymbol::Term, GrammarSymbol::Term } },
     };
 
     rules_[GrammarSymbols::GetIndex(GrammarSymbol::SimpleTerm)] = {
-        Production{ .Op = NodeType::Mul, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleTerm } },
+        Production{ .Op = BuiltinOp::Mul, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleTerm } },
     };
 
     rules_[GrammarSymbols::GetIndex(GrammarSymbol::Expression)] = {
-        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::Term }, .WeightFirstOperand = true, .TrailingConstant = true },
-        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::Term, GrammarSymbol::Expression }, .WeightFirstOperand = true, .TrailingConstant = false },
+        Production{ .Op = BuiltinOp::Add, .Operands = { GrammarSymbol::Term }, .WeightFirstOperand = true, .TrailingConstant = true },
+        Production{ .Op = BuiltinOp::Add, .Operands = { GrammarSymbol::Term, GrammarSymbol::Expression }, .WeightFirstOperand = true, .TrailingConstant = false },
     };
 
     rules_[GrammarSymbols::GetIndex(GrammarSymbol::SimpleExpr)] = {
-        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::SimpleTerm }, .WeightFirstOperand = true, .TrailingConstant = true },
-        Production{ .Op = NodeType::Add, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleExpr }, .WeightFirstOperand = true, .TrailingConstant = false },
+        Production{ .Op = BuiltinOp::Add, .Operands = { GrammarSymbol::SimpleTerm }, .WeightFirstOperand = true, .TrailingConstant = true },
+        Production{ .Op = BuiltinOp::Add, .Operands = { GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleExpr }, .WeightFirstOperand = true, .TrailingConstant = false },
     };
 
     // Fixed-point over the production table for MinComplexity. Complexity

--- a/source/core/node.cpp
+++ b/source/core/node.cpp
@@ -43,7 +43,13 @@ namespace {
         if (d.if_contains(h, [&](auto const& kv) { result = kv.second; })) {
             return result;
         }
-        auto const fallback = node.IsDynamic() ? Node(NodeType::Dynamic).HashValue : h;
+        // Every built-in BuiltinOp hash is registered by the unconditional
+        // StandardLibrary::RegisterNames() call in Name()/Desc() below, so
+        // reaching this fallback means `node` is either a genuinely
+        // unregistered user function or a malformed hash - either way, the
+        // generic "user-defined function" entry (registered under this same
+        // sentinel by StandardLibrary, see standard_library.hpp) is correct.
+        auto const fallback = node.IsFunction() ? Node::DefaultHash(NodeType::Function) : h;
         if (d.if_contains(fallback, [&](auto const& kv) { result = kv.second; })) {
             return result;
         }
@@ -54,10 +60,10 @@ namespace {
     void Node::RegisterName(Operon::Hash hash, string name, string desc)
     {
         // Also used internally by StandardLibrary::RegisterNames() to seed
-        // built-in entries, whose hashes ARE in [0, NodeTypes::Count) by
-        // construction (Node(NodeType) ctor) - so this can't reject that
-        // range itself. User-facing callers (symbol_library.hpp) guard
-        // against landing in the reserved range before calling this.
+        // built-in entries, whose hashes ARE in [0, BuiltinOpCount) by
+        // construction (static_cast<Hash>(some BuiltinOp)) - so this can't
+        // reject that range itself. User-facing callers (symbol_library.hpp)
+        // guard against landing in the reserved range before calling this.
         Descriptions().lazy_emplace_l(
             hash,
             [&](auto& kv)         { kv.second = { std::move(name), std::move(desc) }; },

--- a/source/core/pset.cpp
+++ b/source/core/pset.cpp
@@ -23,16 +23,28 @@ namespace Operon {
     void PrimitiveSet::SetConfig(PrimitiveSetConfig config)
     {
         pset_.clear();
-        for (size_t i = 0; i < Operon::NodeTypes::Count; ++i) {
-            auto t = static_cast<Operon::NodeType>(i);
-            if (!config.Test(i)) { continue; }
 
-            Operon::Node n(t);
-            auto const [minArity, maxArity] = StandardLibrary::ArityLimits(t);
-            n.Arity  = minArity;
-            n.Length = minArity;
+        for (size_t i = 0; i < Operon::BuiltinOpCount; ++i) {
+            if (!config.Test(i)) { continue; }
+            auto const op = static_cast<Operon::BuiltinOp>(i);
+            auto const [minArity, maxArity] = StandardLibrary::ArityLimits(op);
+            auto n = Operon::Node::Function(static_cast<Operon::Hash>(op), minArity);
             pset_[n.HashValue] = { n, 1, minArity, maxArity };
         }
+
+        for (auto type : { Operon::NodeType::Constant, Operon::NodeType::Variable, Operon::NodeType::Ref }) {
+            if (!config.Test(Operon::BuiltinOpCount + Operon::NodeTypes::GetIndex(type))) { continue; }
+            Operon::Node n(type);
+            pset_[n.HashValue] = { n, 1, 0, 0 }; // terminals are leaves: arity 0
+        }
+
+        // The shared "any Function present" bit (BuiltinOpCount +
+        // NodeTypes::GetIndex(NodeType::Function)) is intentionally not
+        // actionable here - unlike a BuiltinOp or Constant/Variable/Ref, it
+        // has no single real hash/arity to construct a primitive from
+        // (AddFunction handles that, for a specific user function). It only
+        // exists so Config() can report "a user function is present"
+        // symmetrically with the pre-collapse Dynamic slot.
     }
 
     auto PrimitiveSet::AchievableLength(size_t targetLen) const -> size_t

--- a/source/core/serialization.cpp
+++ b/source/core/serialization.cpp
@@ -13,46 +13,38 @@
 #include <glaze/glaze.hpp>
 
 // Ensure the enumerate below stays in sync with NodeType additions.
-static_assert(Operon::NodeTypes::Count == 33,
+static_assert(Operon::NodeTypes::Count == 4,
               "NodeType count changed — update glz::meta<Operon::NodeType>");
 
 // glz::meta specializations — all glaze details stay in this translation unit.
+//
+// BACKWARD-COMPATIBILITY WARNING: this enumerate shrank from 33 entries
+// (one per built-in math op, plus Dynamic/Constant/Variable/Ref) to 4
+// (Constant/Variable/Ref/Function) as part of the NodeType collapse. A
+// built-in math op is now a Function-typed Node distinguished by HashValue
+// (see BuiltinOp in node.hpp), not by a NodeType enumerator - a Function
+// node's specific op is NOT reconstructible from NodeProxy::Type alone.
+//
+// Verified against glaze 7.8.3's BEVE codec (beve/read.hpp, beve/write.hpp):
+// glaze_enum_t types are NOT written by name in BEVE (unlike JSON) - the
+// raw underlying integer ordinal is written/read directly, with no
+// validation on read that the value is a member of the enumerate list.
+// A pre-collapse BEVE Tree/Individual export's old NodeType ordinal
+// (e.g. Sin=22) would decode as `static_cast<NodeType>(22)`, a garbage
+// out-of-range value - CheckpointProxy's Magic/Version fields (bumped
+// below) guard checkpoint loads against this, but ToBeve(Tree)/
+// ToBeve(Individual) exports have no equivalent guard, before or after
+// this change. Do not attempt to load a pre-collapse .beve Tree/Individual
+// export against this code; a dedicated versioned legacy reader (translating
+// old ordinals to the new BuiltinOp/Function representation) would be
+// needed to do so safely - not implemented here.
 template <>
 struct glz::meta<Operon::NodeType> {
     static constexpr auto value = glz::enumerate(
-        "Add",      Operon::NodeType::Add,
-        "Mul",      Operon::NodeType::Mul,
-        "Sub",      Operon::NodeType::Sub,
-        "Div",      Operon::NodeType::Div,
-        "Fmin",     Operon::NodeType::Fmin,
-        "Fmax",     Operon::NodeType::Fmax,
-        "Aq",       Operon::NodeType::Aq,
-        "Pow",      Operon::NodeType::Pow,
-        "Powabs",   Operon::NodeType::Powabs,
-        "Abs",      Operon::NodeType::Abs,
-        "Acos",     Operon::NodeType::Acos,
-        "Asin",     Operon::NodeType::Asin,
-        "Atan",     Operon::NodeType::Atan,
-        "Cbrt",     Operon::NodeType::Cbrt,
-        "Ceil",     Operon::NodeType::Ceil,
-        "Cos",      Operon::NodeType::Cos,
-        "Cosh",     Operon::NodeType::Cosh,
-        "Exp",      Operon::NodeType::Exp,
-        "Floor",    Operon::NodeType::Floor,
-        "Log",      Operon::NodeType::Log,
-        "Logabs",   Operon::NodeType::Logabs,
-        "Log1p",    Operon::NodeType::Log1p,
-        "Sin",      Operon::NodeType::Sin,
-        "Sinh",     Operon::NodeType::Sinh,
-        "Sqrt",     Operon::NodeType::Sqrt,
-        "Sqrtabs",  Operon::NodeType::Sqrtabs,
-        "Tan",      Operon::NodeType::Tan,
-        "Tanh",     Operon::NodeType::Tanh,
-        "Square",   Operon::NodeType::Square,
-        "Dynamic",  Operon::NodeType::Dynamic,
         "Constant", Operon::NodeType::Constant,
         "Variable", Operon::NodeType::Variable,
-        "Ref",      Operon::NodeType::Ref
+        "Ref",      Operon::NodeType::Ref,
+        "Function", Operon::NodeType::Function
     );
 };
 
@@ -63,17 +55,25 @@ struct NodeProxy {
     Operon::NodeType Type{};
     Operon::Hash     HashValue{};
     Operon::Scalar   Value{};
+    // Explicit as of the NodeType collapse: Node's two-arg constructor no
+    // longer infers Arity from Type's position in the enum (there is no
+    // longer a position to infer from - every Function node has the same
+    // Type). Without this field every deserialized Function node would get
+    // Arity=0, silently corrupting the tree structure.
+    uint16_t         Arity{0};
     bool             IsEnabled{true};
     bool             Optimize{false};
     uint16_t         RefTo{0};
 
     static auto FromNode(Operon::Node const& n) noexcept -> NodeProxy {
-        return { n.Type, n.HashValue, n.Value, n.IsEnabled, n.Optimize, n.RefTo };
+        return { n.Type, n.HashValue, n.Value, n.Arity, n.IsEnabled, n.Optimize, n.RefTo };
     }
 
     auto ToNode() const noexcept -> Operon::Node {
         Operon::Node n(Type, HashValue);
         n.Value     = Value;
+        n.Arity     = Arity;
+        n.Length    = Arity; // leaf-level Length; Tree::UpdateNodes() (called by ProxiesToTree) recomputes the real subtree Length
         n.IsEnabled = IsEnabled;
         n.Optimize  = Optimize;
         n.RefTo     = RefTo;
@@ -94,7 +94,13 @@ struct IndividualProxy {
 
 // Bump Version whenever the on-disk layout changes in a backwards-incompatible way.
 constexpr uint32_t CheckpointMagic   = 0x4F50434BU; // "OPCK"
-constexpr uint32_t CheckpointVersion = 1U;
+// Bumped: NodeType collapse (glz::meta<NodeType> shrank from 33 to 4
+// entries, NodeProxy gained an explicit Arity field) is a breaking,
+// silently-misdecodable format change for BEVE - see the warning above
+// glz::meta<Operon::NodeType>. A version-1 checkpoint will now be cleanly
+// rejected by FromProxy's Magic/Version check below, rather than partially
+// decoding into corrupted trees.
+constexpr uint32_t CheckpointVersion = 2U;
 
 struct CheckpointProxy {
     uint32_t                                 Magic{CheckpointMagic};
@@ -145,6 +151,7 @@ struct glz::meta<NodeProxy> {
         "type",     &T::Type,
         "hash",     &T::HashValue,
         "value",    &T::Value,
+        "arity",    &T::Arity,
         "enabled",  &T::IsEnabled,
         "optimize", &T::Optimize,
         "ref_to",   &T::RefTo

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -206,7 +206,6 @@ auto Tree::Hash(Operon::HashMode mode) const -> Tree const&
 }
 
 auto Tree::Simplify() -> Tree& {
-    using NT = NodeType;
     using BO = BuiltinOp;
     using S  = Operon::Scalar;
 
@@ -374,13 +373,11 @@ auto Tree::Simplify() -> Tree& {
                         changed = true;
                     } else if (nodes_[expIdx].Value == S{2}) {
                         nodes_[expIdx].IsEnabled = false;  // Pow(x,2) → Square(x)
-                        n.Type = NT::Square;
-                        n.HashValue = Operon::Hash(BO::Square);
+                        n.HashValue = Operon::Hash(BO::Square); // Type stays Function - only HashValue distinguishes ops now
                         n.Arity = 1;
                         changed = true;
                     } else if (nodes_[expIdx].Value == S{0.5}) {
                         nodes_[expIdx].IsEnabled = false;  // Pow(x,0.5) → Sqrt(x)
-                        n.Type = NT::Sqrt;
                         n.HashValue = Operon::Hash(BO::Sqrt);
                         n.Arity = 1;
                         changed = true;
@@ -414,8 +411,7 @@ auto Tree::Simplify() -> Tree& {
                 // sqrt(x^2) = |x|;  sqrt(|x^2|) = |x|
                 if (ch.size() == 1 && nodes_[ch[0]].Is<BO::Square>()) {
                     nodes_[ch[0]].IsEnabled = false;
-                    n.Type = NT::Abs;
-                    n.HashValue = Operon::Hash(BO::Abs);
+                    n.HashValue = Operon::Hash(BO::Abs); // Type stays Function
                     n.Arity = 1; // Sqrt/Sqrtabs and Abs are both unary; explicit for symmetry with the Pow retargets above
                     changed = true;
                 }

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -399,7 +399,7 @@ auto Tree::Simplify() -> Tree& {
             case Operon::Hash(BO::Log):
             case Operon::Hash(BO::Logabs): {
                 // log(exp(x)) = x for all x; log|exp(x)| = x likewise.
-                if (ch.size() == 1 && nodes_[ch[0]].Is<BO::Exp>()) {
+                if (ch.size() == 1 && nodes_[ch[0]].IsOp<BO::Exp>()) {
                     n.IsEnabled = false;
                     nodes_[ch[0]].IsEnabled = false;
                     changed = true;
@@ -409,7 +409,7 @@ auto Tree::Simplify() -> Tree& {
             case Operon::Hash(BO::Sqrt):
             case Operon::Hash(BO::Sqrtabs): {
                 // sqrt(x^2) = |x|;  sqrt(|x^2|) = |x|
-                if (ch.size() == 1 && nodes_[ch[0]].Is<BO::Square>()) {
+                if (ch.size() == 1 && nodes_[ch[0]].IsOp<BO::Square>()) {
                     nodes_[ch[0]].IsEnabled = false;
                     n.HashValue = Operon::Hash(BO::Abs); // Type stays Function
                     n.Arity = 1; // Sqrt/Sqrtabs and Abs are both unary; explicit for symmetry with the Pow retargets above

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -72,12 +72,11 @@ auto GetConst(Nodes& dag, Memo& memo, Hashes& h, Scalar val) -> std::size_t {
 // Layout appended: [Ref(a), UnaryOp]
 // Hash-consed so that identical expressions share a single node.
 auto MakeUnary(Nodes& dag, Memo& memo, Hashes& h,
-               NodeType op, std::size_t a) -> std::size_t {
+               BuiltinOp op, std::size_t a) -> std::size_t {
     auto opHash = Mix(static_cast<uint64_t>(op), h[a]);
     if (auto it = memo.find(opHash); it != memo.end()) { return it->second; }
     AppendRef(dag, h, a);
-    Node n{op};
-    n.Length = 1; // one Ref child with Length=0
+    auto n = Node::Function(static_cast<Operon::Hash>(op), 1); // sets Arity=Length=1
     auto idx = dag.size();
     Push(dag, h, n, opHash);
     memo.insert_or_assign(opHash, idx);
@@ -91,14 +90,12 @@ auto MakeUnary(Nodes& dag, Memo& memo, Hashes& h,
 // Hash-consed; note that Mul(a,b) and Mul(b,a) get different hash keys
 // (less deduplication but no correctness issue).
 auto MakeBinary(Nodes& dag, Memo& memo, Hashes& h,
-                NodeType op, std::size_t a, std::size_t b) -> std::size_t {
+                BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t {
     auto opHash = Mix(Mix(static_cast<uint64_t>(op), h[a]), h[b]);
     if (auto it = memo.find(opHash); it != memo.end()) { return it->second; }
     AppendRef(dag, h, b); // farther child first
     AppendRef(dag, h, a); // nearer child second
-    Node n{op};
-    n.Arity  = 2;
-    n.Length = 2; // two Ref children, each Length=0
+    auto n = Node::Function(static_cast<Operon::Hash>(op), 2); // sets Arity=Length=2
     auto idx = dag.size();
     Push(dag, h, n, opHash);
     memo.insert_or_assign(opHash, idx);
@@ -111,7 +108,7 @@ auto AddTerms(Nodes& dag, Memo& memo, Hashes& h,
     if (terms.empty()) { return Zero; }
     auto result = terms[0];
     for (std::size_t k = 1; k < terms.size(); ++k) {
-        result = MakeBinary(dag, memo, h, NodeType::Add, result, terms[k]);
+        result = MakeBinary(dag, memo, h, BuiltinOp::Add, result, terms[k]);
     }
     return result;
 }
@@ -176,9 +173,9 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
                 if (l == m) { continue; }
                 prod = (prod == Zero)
                     ? children[l]
-                    : MakeBinary(dag, memo, h, NodeType::Mul, prod, children[l]);
+                    : MakeBinary(dag, memo, h, BuiltinOp::Mul, prod, children[l]);
             }
-            terms.push_back((prod == Zero) ? dm : MakeBinary(dag, memo, h, NodeType::Mul, dm, prod));
+            terms.push_back((prod == Zero) ? dm : MakeBinary(dag, memo, h, BuiltinOp::Mul, dm, prod));
         }
         return AddTerms(dag, memo, h, terms);
     }
@@ -190,7 +187,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             // Unary minus: -a. d(-a)/dc = -da
             if (dj == Zero) { return Zero; }
             auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-            return MakeBinary(dag, memo, h, NodeType::Mul, neg1, dj);
+            return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj);
         }
         if (arity == 2) {
             auto dk = Deriv(orig, dag, memo, h, children[1], targetC);
@@ -198,9 +195,9 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             if (dk == Zero) { return dj; }
             if (dj == Zero) {
                 auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-                return MakeBinary(dag, memo, h, NodeType::Mul, neg1, dk);
+                return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dk);
             }
-            return MakeBinary(dag, memo, h, NodeType::Sub, dj, dk);
+            return MakeBinary(dag, memo, h, BuiltinOp::Sub, dj, dk);
         }
         // arity > 2: treat as +first - rest
         Operon::Vector<std::size_t> pos;
@@ -216,9 +213,9 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         if (q == Zero) { return p; }
         if (p == Zero) {
             auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-            return MakeBinary(dag, memo, h, NodeType::Mul, neg1, q);
+            return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, q);
         }
-        return MakeBinary(dag, memo, h, NodeType::Sub, p, q);
+        return MakeBinary(dag, memo, h, BuiltinOp::Sub, p, q);
     }
 
     // --- Div ---
@@ -228,10 +225,10 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             auto dj = Deriv(orig, dag, memo, h, children[0], targetC);
             if (dj == Zero) { return Zero; }
             auto j      = children[0];
-            auto j2     = MakeBinary(dag, memo, h, NodeType::Mul, j, j);
+            auto j2     = MakeBinary(dag, memo, h, BuiltinOp::Mul, j, j);
             auto neg1   = GetConst(dag, memo, h, Scalar{-1});
-            auto negDj = MakeBinary(dag, memo, h, NodeType::Mul, neg1, dj);
-            return MakeBinary(dag, memo, h, NodeType::Div, negDj, j2);
+            auto negDj = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj);
+            return MakeBinary(dag, memo, h, BuiltinOp::Div, negDj, j2);
         }
         if (arity == 2) {
             // a/b: d = (da*b - a*db) / b^2
@@ -243,23 +240,23 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             // When only the numerator depends on x, simplify da/b directly.
             // Avoids (da*b)/b^2 which produces 0*Inf=NaN when b=Inf.
             if (dk == Zero) {
-                return MakeBinary(dag, memo, h, NodeType::Div, dj, k);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, dj, k);
             }
-            auto k2 = MakeBinary(dag, memo, h, NodeType::Mul, k, k);
+            auto k2 = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, k);
             std::size_t num = Zero;
             if (dj != Zero) {
-                num = MakeBinary(dag, memo, h, NodeType::Mul, dj, k);
+                num = MakeBinary(dag, memo, h, BuiltinOp::Mul, dj, k);
             }
             {
-                auto term = MakeBinary(dag, memo, h, NodeType::Mul, j, dk);
+                auto term = MakeBinary(dag, memo, h, BuiltinOp::Mul, j, dk);
                 if (num == Zero) {
                     auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-                    num = MakeBinary(dag, memo, h, NodeType::Mul, neg1, term);
+                    num = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, term);
                 } else {
-                    num = MakeBinary(dag, memo, h, NodeType::Sub, num, term);
+                    num = MakeBinary(dag, memo, h, BuiltinOp::Sub, num, term);
                 }
             }
-            return MakeBinary(dag, memo, h, NodeType::Div, num, k2);
+            return MakeBinary(dag, memo, h, BuiltinOp::Div, num, k2);
         }
         return Zero; // arity > 2 not yet supported
     }
@@ -274,21 +271,21 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         Operon::Vector<std::size_t> terms;
         if (dj != Zero) {
             // d/dj: k * j^k / j = k * result / j
-            auto ki   = MakeBinary(dag, memo, h, NodeType::Mul, k, i); // k * result
-            auto term = MakeBinary(dag, memo, h, NodeType::Div, ki, j);
-            terms.push_back(MakeBinary(dag, memo, h, NodeType::Mul, dj, term));
+            auto ki   = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, i); // k * result
+            auto term = MakeBinary(dag, memo, h, BuiltinOp::Div, ki, j);
+            terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dj, term));
         }
         if (dk != Zero) {
             // d/dk: j^k * ln(j) = result * log(j)
-            auto logJ = MakeUnary(dag, memo, h, NodeType::Log, j);
-            auto t     = MakeBinary(dag, memo, h, NodeType::Mul, i, logJ);
-            terms.push_back(MakeBinary(dag, memo, h, NodeType::Mul, dk, t));
+            auto logJ = MakeUnary(dag, memo, h, BuiltinOp::Log, j);
+            auto t     = MakeBinary(dag, memo, h, BuiltinOp::Mul, i, logJ);
+            terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dk, t));
         }
         return AddTerms(dag, memo, h, terms);
     }
 
     // --- Aq, Powabs, Fmin, Fmax: not yet differentiated ---
-    if (n.IsAq() || n.IsPowabs() || n.Is<NodeType::Fmin, NodeType::Fmax>()) {
+    if (n.IsAq() || n.IsPowabs() || n.Is<BuiltinOp::Fmin, BuiltinOp::Fmax>()) {
         return Zero;
     }
 
@@ -300,132 +297,132 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
 
         std::size_t fp = Zero; // symbolic f'(j)
 
-        switch (n.Type) {
-        case NodeType::Exp:
+        switch (n.HashValue) {
+        case Operon::Hash(BuiltinOp::Exp):
             // d exp(j)/dj = exp(j) = result
             fp = i;
             break;
 
-        case NodeType::Log:
-        case NodeType::Logabs: {
+        case Operon::Hash(BuiltinOp::Log):
+        case Operon::Hash(BuiltinOp::Logabs): {
             // d log(j)/dj = 1/j
             auto c1 = GetConst(dag, memo, h, Scalar{1});
-            fp = MakeBinary(dag, memo, h, NodeType::Div, c1, j);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, j);
             break;
         }
 
-        case NodeType::Log1p: {
+        case Operon::Hash(BuiltinOp::Log1p): {
             // d log(1+j)/dj = 1/(1+j)
             auto c1 = GetConst(dag, memo, h, Scalar{1});
-            auto onePlusJ = MakeBinary(dag, memo, h, NodeType::Add, c1, j);
-            fp = MakeBinary(dag, memo, h, NodeType::Div, c1, onePlusJ);
+            auto onePlusJ = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, j);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, onePlusJ);
             break;
         }
 
-        case NodeType::Sin:
+        case Operon::Hash(BuiltinOp::Sin):
             // d sin(j)/dj = cos(j)
-            fp = MakeUnary(dag, memo, h, NodeType::Cos, j);
+            fp = MakeUnary(dag, memo, h, BuiltinOp::Cos, j);
             break;
 
-        case NodeType::Cos: {
+        case Operon::Hash(BuiltinOp::Cos): {
             // d cos(j)/dj = -sin(j)
-            auto sinJ = MakeUnary(dag, memo, h, NodeType::Sin, j);
+            auto sinJ = MakeUnary(dag, memo, h, BuiltinOp::Sin, j);
             auto neg1  = GetConst(dag, memo, h, Scalar{-1});
-            fp = MakeBinary(dag, memo, h, NodeType::Mul, neg1, sinJ);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, sinJ);
             break;
         }
 
-        case NodeType::Tan: {
+        case Operon::Hash(BuiltinOp::Tan): {
             // d tan(j)/dj = 1 + tan^2(j) = 1 + result^2
             auto c1   = GetConst(dag, memo, h, Scalar{1});
-            auto sqI = MakeUnary(dag, memo, h, NodeType::Square, i);
-            fp = MakeBinary(dag, memo, h, NodeType::Add, c1, sqI);
+            auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqI);
             break;
         }
 
-        case NodeType::Acos: {
+        case Operon::Hash(BuiltinOp::Acos): {
             // d acos(j)/dj = -1/sqrt(1 - j^2)
             auto c1     = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ   = MakeUnary(dag, memo, h, NodeType::Square, j);
-            auto denom  = MakeBinary(dag, memo, h, NodeType::Sub, c1, sqJ);
-            auto sqD   = MakeUnary(dag, memo, h, NodeType::Sqrt, denom);
-            auto recip  = MakeBinary(dag, memo, h, NodeType::Div, c1, sqD);
+            auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+            auto denom  = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
+            auto sqD   = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
+            auto recip  = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
             auto neg1   = GetConst(dag, memo, h, Scalar{-1});
-            fp = MakeBinary(dag, memo, h, NodeType::Mul, neg1, recip);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, recip);
             break;
         }
 
-        case NodeType::Asin: {
+        case Operon::Hash(BuiltinOp::Asin): {
             // d asin(j)/dj = 1/sqrt(1 - j^2)
             auto c1    = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ  = MakeUnary(dag, memo, h, NodeType::Square, j);
-            auto denom = MakeBinary(dag, memo, h, NodeType::Sub, c1, sqJ);
-            auto sqD  = MakeUnary(dag, memo, h, NodeType::Sqrt, denom);
-            fp = MakeBinary(dag, memo, h, NodeType::Div, c1, sqD);
+            auto sqJ  = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+            auto denom = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
+            auto sqD  = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
             break;
         }
 
-        case NodeType::Atan: {
+        case Operon::Hash(BuiltinOp::Atan): {
             // d atan(j)/dj = 1/(1 + j^2)
             auto c1    = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ  = MakeUnary(dag, memo, h, NodeType::Square, j);
-            auto denom = MakeBinary(dag, memo, h, NodeType::Add, c1, sqJ);
-            fp = MakeBinary(dag, memo, h, NodeType::Div, c1, denom);
+            auto sqJ  = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+            auto denom = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqJ);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, denom);
             break;
         }
 
-        case NodeType::Sinh:
+        case Operon::Hash(BuiltinOp::Sinh):
             // d sinh(j)/dj = cosh(j)
-            fp = MakeUnary(dag, memo, h, NodeType::Cosh, j);
+            fp = MakeUnary(dag, memo, h, BuiltinOp::Cosh, j);
             break;
 
-        case NodeType::Cosh:
+        case Operon::Hash(BuiltinOp::Cosh):
             // d cosh(j)/dj = sinh(j)
-            fp = MakeUnary(dag, memo, h, NodeType::Sinh, j);
+            fp = MakeUnary(dag, memo, h, BuiltinOp::Sinh, j);
             break;
 
-        case NodeType::Tanh: {
+        case Operon::Hash(BuiltinOp::Tanh): {
             // d tanh(j)/dj = 1 - tanh^2(j) = 1 - result^2
             auto c1   = GetConst(dag, memo, h, Scalar{1});
-            auto sqI = MakeUnary(dag, memo, h, NodeType::Square, i);
-            fp = MakeBinary(dag, memo, h, NodeType::Sub, c1, sqI);
+            auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqI);
             break;
         }
 
-        case NodeType::Sqrt: {
+        case Operon::Hash(BuiltinOp::Sqrt): {
             // d sqrt(j)/dj = result / (2 * j)
             auto c2   = GetConst(dag, memo, h, Scalar{2});
-            auto twoJ = MakeBinary(dag, memo, h, NodeType::Mul, c2, j);
-            fp = MakeBinary(dag, memo, h, NodeType::Div, i, twoJ);
+            auto twoJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, i, twoJ);
             break;
         }
 
-        case NodeType::Cbrt: {
+        case Operon::Hash(BuiltinOp::Cbrt): {
             // d cbrt(j)/dj = result / (3 * j)
             auto c3    = GetConst(dag, memo, h, Scalar{3});
-            auto threeJ = MakeBinary(dag, memo, h, NodeType::Mul, c3, j);
-            fp = MakeBinary(dag, memo, h, NodeType::Div, i, threeJ);
+            auto threeJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, j);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, i, threeJ);
             break;
         }
 
-        case NodeType::Square: {
+        case Operon::Hash(BuiltinOp::Square): {
             // d j^2/dj = 2 * j
             auto c2 = GetConst(dag, memo, h, Scalar{2});
-            fp = MakeBinary(dag, memo, h, NodeType::Mul, c2, j);
+            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
             break;
         }
 
         // Non-smooth or not-yet-implemented: return zero gradient.
-        case NodeType::Abs:
-        case NodeType::Sqrtabs:
-        case NodeType::Floor:
-        case NodeType::Ceil:
+        case Operon::Hash(BuiltinOp::Abs):
+        case Operon::Hash(BuiltinOp::Sqrtabs):
+        case Operon::Hash(BuiltinOp::Floor):
+        case Operon::Hash(BuiltinOp::Ceil):
         default:
             return Zero;
         }
 
         if (fp == Zero) { return Zero; }
-        return MakeBinary(dag, memo, h, NodeType::Mul, fp, dj);
+        return MakeBinary(dag, memo, h, BuiltinOp::Mul, fp, dj);
     }
 
     return Zero;

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -285,7 +285,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
     }
 
     // --- Aq, Powabs, Fmin, Fmax: not yet differentiated ---
-    if (n.IsAq() || n.IsPowabs() || n.Is<BuiltinOp::Fmin, BuiltinOp::Fmax>()) {
+    if (n.IsAq() || n.IsPowabs() || n.IsOp<BuiltinOp::Fmin, BuiltinOp::Fmax>()) {
         return Zero;
     }
 

--- a/source/formatter/infix.cpp
+++ b/source/formatter/infix.cpp
@@ -36,22 +36,22 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
         {
             fmt::format_to(std::back_inserter(current), "(");
             if (s.Arity == 1) {
-                if (s.Is<BuiltinOp::Sub>()) {
+                if (s.IsOp<BuiltinOp::Sub>()) {
                     // subtraction with a single argument is a negation -x
                     fmt::format_to(std::back_inserter(current), "-");
-                } else if (s.Is<BuiltinOp::Div>()) {
+                } else if (s.IsOp<BuiltinOp::Div>()) {
                     // division with a single argument is an inversion 1/x
                     fmt::format_to(std::back_inserter(current), "1 / ");
                 }
                 FormatNode(tree, variableNames, i-1, current, decimalPrecision);
-            } else if (s.Is<BuiltinOp::Pow>()) {
+            } else if (s.IsOp<BuiltinOp::Pow>()) {
                 // format pow(a,b) as a^b
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 FormatNode(tree, variableNames, j, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.Is<BuiltinOp::Powabs>()) {
+            } else if (s.IsOp<BuiltinOp::Powabs>()) {
                 // format powabs(a,b) as abs(a)^b
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
@@ -59,7 +59,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 FormatNode(tree, variableNames, j, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), ") ^ ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.Is<BuiltinOp::Aq>()) {
+            } else if (s.IsOp<BuiltinOp::Aq>()) {
                 // format aq(a,b) as a / (1 + b^2)
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
@@ -67,7 +67,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 fmt::format_to(std::back_inserter(current), " / (sqrt(1 + ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ 2))");
-            } else if (s.Is<BuiltinOp::Fmin>()) {
+            } else if (s.IsOp<BuiltinOp::Fmin>()) {
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 fmt::format_to(std::back_inserter(current), "min(");
@@ -75,7 +75,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 fmt::format_to(std::back_inserter(current), ", ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), ")");
-            } else if (s.Is<BuiltinOp::Fmax>()) {
+            } else if (s.IsOp<BuiltinOp::Fmax>()) {
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 fmt::format_to(std::back_inserter(current), "max(");
@@ -94,22 +94,22 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
             }
             fmt::format_to(std::back_inserter(current), ")");
         } else { // unary operators abs, asin, ... log, exp, sin, etc.
-            if (s.Is<BuiltinOp::Square>()) {
+            if (s.IsOp<BuiltinOp::Square>()) {
                 // format square(a) as a ^ 2
                 fmt::format_to(std::back_inserter(current), "(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ 2)");
-            } else if (s.Is<BuiltinOp::Logabs>()) {
+            } else if (s.IsOp<BuiltinOp::Logabs>()) {
                 // format logabs(a) as log(abs(a))
                 fmt::format_to(std::back_inserter(current), "log(abs(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), "))");
-            } else if (s.Is<BuiltinOp::Log1p>()) {
+            } else if (s.IsOp<BuiltinOp::Log1p>()) {
                 // format log1p(a) as log(a+1)
                 fmt::format_to(std::back_inserter(current), "log(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), "+1)");
-            } else if (s.Is<BuiltinOp::Sqrtabs>()) {
+            } else if (s.IsOp<BuiltinOp::Sqrtabs>()) {
                 // format sqrtabs(a) as sqrt(abs(a))
                 fmt::format_to(std::back_inserter(current), "sqrt(abs(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);

--- a/source/formatter/infix.cpp
+++ b/source/formatter/infix.cpp
@@ -29,26 +29,29 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
             fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
             fmt::format_to(std::back_inserter(current), " * ");
         }
-        if (s.Type < NodeType::Abs) // add, sub, mul, div, aq, fmax, fmin, pow
+        // BuiltinOp's ordinals preserve the same relative order the old
+        // NodeType math-op subset had, so this boundary (Add..Powabs vs.
+        // Abs onward) is still exactly `< Hash(BuiltinOp::Abs)`.
+        if (s.HashValue < Operon::Hash(BuiltinOp::Abs)) // add, sub, mul, div, aq, fmax, fmin, pow
         {
             fmt::format_to(std::back_inserter(current), "(");
             if (s.Arity == 1) {
-                if (s.Type == NodeType::Sub) {
+                if (s.Is<BuiltinOp::Sub>()) {
                     // subtraction with a single argument is a negation -x
                     fmt::format_to(std::back_inserter(current), "-");
-                } else if (s.Type == NodeType::Div) {
+                } else if (s.Is<BuiltinOp::Div>()) {
                     // division with a single argument is an inversion 1/x
                     fmt::format_to(std::back_inserter(current), "1 / ");
                 }
                 FormatNode(tree, variableNames, i-1, current, decimalPrecision);
-            } else if (s.Type == NodeType::Pow) {
+            } else if (s.Is<BuiltinOp::Pow>()) {
                 // format pow(a,b) as a^b
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 FormatNode(tree, variableNames, j, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.Type == NodeType::Powabs) {
+            } else if (s.Is<BuiltinOp::Powabs>()) {
                 // format powabs(a,b) as abs(a)^b
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
@@ -56,7 +59,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 FormatNode(tree, variableNames, j, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), ") ^ ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.Type == NodeType::Aq) {
+            } else if (s.Is<BuiltinOp::Aq>()) {
                 // format aq(a,b) as a / (1 + b^2)
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
@@ -64,7 +67,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 fmt::format_to(std::back_inserter(current), " / (sqrt(1 + ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ 2))");
-            } else if (s.Type == NodeType::Fmin) {
+            } else if (s.Is<BuiltinOp::Fmin>()) {
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 fmt::format_to(std::back_inserter(current), "min(");
@@ -72,7 +75,7 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 fmt::format_to(std::back_inserter(current), ", ");
                 FormatNode(tree, variableNames, k, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), ")");
-            } else if (s.Type == NodeType::Fmax) {
+            } else if (s.Is<BuiltinOp::Fmax>()) {
                 auto j = i - 1;
                 auto k = j - tree[j].Length - 1;
                 fmt::format_to(std::back_inserter(current), "max(");
@@ -91,22 +94,22 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
             }
             fmt::format_to(std::back_inserter(current), ")");
         } else { // unary operators abs, asin, ... log, exp, sin, etc.
-            if (s.Type == NodeType::Square) {
+            if (s.Is<BuiltinOp::Square>()) {
                 // format square(a) as a ^ 2
                 fmt::format_to(std::back_inserter(current), "(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), " ^ 2)");
-            } else if (s.Type == NodeType::Logabs) {
+            } else if (s.Is<BuiltinOp::Logabs>()) {
                 // format logabs(a) as log(abs(a))
                 fmt::format_to(std::back_inserter(current), "log(abs(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), "))");
-            } else if (s.Type == NodeType::Log1p) {
+            } else if (s.Is<BuiltinOp::Log1p>()) {
                 // format log1p(a) as log(a+1)
                 fmt::format_to(std::back_inserter(current), "log(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), "+1)");
-            } else if (s.Type == NodeType::Sqrtabs) {
+            } else if (s.Is<BuiltinOp::Sqrtabs>()) {
                 // format sqrtabs(a) as sqrt(abs(a))
                 fmt::format_to(std::back_inserter(current), "sqrt(abs(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -11,11 +11,13 @@
 // Must be included AFTER eve headers so the templates can instantiate.
 #include "operon/interpreter/backend/eve/functions.hpp"
 
+#include <fmt/format.h>
 #include <immintrin.h>
 
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -186,8 +188,8 @@ namespace {
             }
 
             Vec res;
-            switch (n.Type) {
-            case NodeType::Add: {
+            switch (n.HashValue) {
+            case Operon::Hash(Operon::BuiltinOp::Add): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_xmm_ss();
@@ -196,7 +198,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Mul: {
+            case Operon::Hash(Operon::BuiltinOp::Mul): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_xmm_ss();
@@ -205,7 +207,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Sub: {
+            case Operon::Hash(Operon::BuiltinOp::Sub): {
                 if (arity == 1) {
                     Vec const zero = LoadFloat(cc, 0.0F);
                     res = cc.new_xmm_ss();
@@ -221,7 +223,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Div: {
+            case Operon::Hash(Operon::BuiltinOp::Div): {
                 if (arity == 1) {
                     Vec const one = LoadFloat(cc, 1.0F);
                     res = cc.new_xmm_ss();
@@ -237,7 +239,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Fmin: {
+            case Operon::Hash(Operon::BuiltinOp::Fmin): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_xmm_ss();
@@ -246,7 +248,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Fmax: {
+            case Operon::Hash(Operon::BuiltinOp::Fmax): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_xmm_ss();
@@ -255,7 +257,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Aq: {
+            case Operon::Hash(Operon::BuiltinOp::Aq): {
                 Vec const b2 = cc.new_xmm_ss();
                 cc.vmulss(b2, args[1], args[1]);
                 Vec const one = LoadFloat(cc, 1.0F);
@@ -267,107 +269,105 @@ namespace {
                 cc.vdivss(res, args[0], sq);
                 break;
             }
-            case NodeType::Pow: {
+            case Operon::Hash(Operon::BuiltinOp::Pow): {
                 res = InvokePowf(cc, args[0], args[1]);
                 break;
             }
-            case NodeType::Powabs: {
+            case Operon::Hash(Operon::BuiltinOp::Powabs): {
                 Vec const absA = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
                 res = InvokePowf(cc, absA, args[1]);
                 break;
             }
-            case NodeType::Abs: {
+            case Operon::Hash(Operon::BuiltinOp::Abs): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
                 break;
             }
-            case NodeType::Acos: {
+            case Operon::Hash(Operon::BuiltinOp::Acos): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAcos), args[0]);
                 break;
             }
-            case NodeType::Asin: {
+            case Operon::Hash(Operon::BuiltinOp::Asin): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAsin), args[0]);
                 break;
             }
-            case NodeType::Atan: {
+            case Operon::Hash(Operon::BuiltinOp::Atan): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAtan), args[0]);
                 break;
             }
-            case NodeType::Cbrt: {
+            case Operon::Hash(Operon::BuiltinOp::Cbrt): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCbrt), args[0]);
                 break;
             }
-            case NodeType::Ceil: {
+            case Operon::Hash(Operon::BuiltinOp::Ceil): {
                 res = cc.new_xmm_ss();
                 cc.vroundss(res, args[0], args[0],
                     Imm(static_cast<uint8_t>(RoundImm::kUp) | static_cast<uint8_t>(RoundImm::kSuppress)));
                 break;
             }
-            case NodeType::Cos: {
+            case Operon::Hash(Operon::BuiltinOp::Cos): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCos), args[0]);
                 break;
             }
-            case NodeType::Cosh: {
+            case Operon::Hash(Operon::BuiltinOp::Cosh): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCosh), args[0]);
                 break;
             }
-            case NodeType::Exp: {
+            case Operon::Hash(Operon::BuiltinOp::Exp): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarExp), args[0]);
                 break;
             }
-            case NodeType::Floor: {
+            case Operon::Hash(Operon::BuiltinOp::Floor): {
                 res = cc.new_xmm_ss();
                 cc.vroundss(res, args[0], args[0],
                     Imm(static_cast<uint8_t>(RoundImm::kDown) | static_cast<uint8_t>(RoundImm::kSuppress)));
                 break;
             }
-            case NodeType::Log: {
+            case Operon::Hash(Operon::BuiltinOp::Log): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLog), args[0]);
                 break;
             }
-            case NodeType::Logabs: {
+            case Operon::Hash(Operon::BuiltinOp::Logabs): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLogabs), args[0]);
                 break;
             }
-            case NodeType::Log1p: {
+            case Operon::Hash(Operon::BuiltinOp::Log1p): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLog1p), args[0]);
                 break;
             }
-            case NodeType::Sin: {
+            case Operon::Hash(Operon::BuiltinOp::Sin): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarSin), args[0]);
                 break;
             }
-            case NodeType::Sinh: {
+            case Operon::Hash(Operon::BuiltinOp::Sinh): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarSinh), args[0]);
                 break;
             }
-            case NodeType::Sqrt: {
+            case Operon::Hash(Operon::BuiltinOp::Sqrt): {
                 res = cc.new_xmm_ss();
                 cc.vsqrtss(res, args[0], args[0]);
                 break;
             }
-            case NodeType::Sqrtabs: {
+            case Operon::Hash(Operon::BuiltinOp::Sqrtabs): {
                 Vec const absVal = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
                 res = cc.new_xmm_ss();
                 cc.vsqrtss(res, absVal, absVal);
                 break;
             }
-            case NodeType::Tan: {
+            case Operon::Hash(Operon::BuiltinOp::Tan): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarTan), args[0]);
                 break;
             }
-            case NodeType::Tanh: {
+            case Operon::Hash(Operon::BuiltinOp::Tanh): {
                 res = InvokeF1(cc, reinterpret_cast<void*>(ScalarTanh), args[0]);
                 break;
             }
-            case NodeType::Square: {
+            case Operon::Hash(Operon::BuiltinOp::Square): {
                 res = cc.new_xmm_ss();
                 cc.vmulss(res, args[0], args[0]);
                 break;
             }
-            default: {
-                res = LoadFloat(cc, 0.0F);
-                break;
-            }
+            default:
+                throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
             }
 
             nodeVecs[ii] = res;
@@ -604,8 +604,8 @@ namespace {
             }
 
             Vec res;
-            switch (n.Type) {
-            case NodeType::Add: {
+            switch (n.HashValue) {
+            case Operon::Hash(Operon::BuiltinOp::Add): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_ymm_ps();
@@ -614,7 +614,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Mul: {
+            case Operon::Hash(Operon::BuiltinOp::Mul): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_ymm_ps();
@@ -623,7 +623,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Sub: {
+            case Operon::Hash(Operon::BuiltinOp::Sub): {
                 if (arity == 1) {
                     Vec const zero = BroadcastFloat(cc, 0.0F);
                     res = cc.new_ymm_ps();
@@ -639,7 +639,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Div: {
+            case Operon::Hash(Operon::BuiltinOp::Div): {
                 if (arity == 1) {
                     Vec const one = BroadcastFloat(cc, 1.0F);
                     res = cc.new_ymm_ps();
@@ -655,7 +655,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Fmin: {
+            case Operon::Hash(Operon::BuiltinOp::Fmin): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_ymm_ps();
@@ -664,7 +664,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Fmax: {
+            case Operon::Hash(Operon::BuiltinOp::Fmax): {
                 res = args[0];
                 for (int k = 1; std::cmp_less(k, arity); ++k) {
                     Vec const tmp = cc.new_ymm_ps();
@@ -673,7 +673,7 @@ namespace {
                 }
                 break;
             }
-            case NodeType::Aq: {
+            case Operon::Hash(Operon::BuiltinOp::Aq): {
                 Vec const b2 = cc.new_ymm_ps();
                 cc.vmulps(b2, args[1], args[1]);
                 Vec const one = BroadcastFloat(cc, 1.0F);
@@ -685,107 +685,105 @@ namespace {
                 cc.vdivps(res, args[0], sq);
                 break;
             }
-            case NodeType::Pow: {
+            case Operon::Hash(Operon::BuiltinOp::Pow): {
                 res = InvokePowfPs(cc, args[0], args[1]);
                 break;
             }
-            case NodeType::Powabs: {
+            case Operon::Hash(Operon::BuiltinOp::Powabs): {
                 Vec const absA = InvokeF1Ps(cc, VecFabsf, args[0]);
                 res = InvokePowfPs(cc, absA, args[1]);
                 break;
             }
-            case NodeType::Abs: {
+            case Operon::Hash(Operon::BuiltinOp::Abs): {
                 res = InvokeF1Ps(cc, VecFabsf, args[0]);
                 break;
             }
-            case NodeType::Acos: {
+            case Operon::Hash(Operon::BuiltinOp::Acos): {
                 res = InvokeF1Ps(cc, VecAcosf, args[0]);
                 break;
             }
-            case NodeType::Asin: {
+            case Operon::Hash(Operon::BuiltinOp::Asin): {
                 res = InvokeF1Ps(cc, VecAsinf, args[0]);
                 break;
             }
-            case NodeType::Atan: {
+            case Operon::Hash(Operon::BuiltinOp::Atan): {
                 res = InvokeF1Ps(cc, VecAtanf, args[0]);
                 break;
             }
-            case NodeType::Cbrt: {
+            case Operon::Hash(Operon::BuiltinOp::Cbrt): {
                 res = InvokeF1Ps(cc, VecCbrtf, args[0]);
                 break;
             }
-            case NodeType::Ceil: {
+            case Operon::Hash(Operon::BuiltinOp::Ceil): {
                 res = cc.new_ymm_ps();
                 cc.vroundps(res, args[0],
                     Imm(static_cast<uint8_t>(RoundImm::kUp) | static_cast<uint8_t>(RoundImm::kSuppress)));
                 break;
             }
-            case NodeType::Cos: {
+            case Operon::Hash(Operon::BuiltinOp::Cos): {
                 res = InvokeF1Ps(cc, VecCosf, args[0]);
                 break;
             }
-            case NodeType::Cosh: {
+            case Operon::Hash(Operon::BuiltinOp::Cosh): {
                 res = InvokeF1Ps(cc, VecCoshf, args[0]);
                 break;
             }
-            case NodeType::Exp: {
+            case Operon::Hash(Operon::BuiltinOp::Exp): {
                 res = InvokeF1Ps(cc, VecExpf, args[0]);
                 break;
             }
-            case NodeType::Floor: {
+            case Operon::Hash(Operon::BuiltinOp::Floor): {
                 res = cc.new_ymm_ps();
                 cc.vroundps(res, args[0],
                     Imm(static_cast<uint8_t>(RoundImm::kDown) | static_cast<uint8_t>(RoundImm::kSuppress)));
                 break;
             }
-            case NodeType::Log: {
+            case Operon::Hash(Operon::BuiltinOp::Log): {
                 res = InvokeF1Ps(cc, VecLogf, args[0]);
                 break;
             }
-            case NodeType::Logabs: {
+            case Operon::Hash(Operon::BuiltinOp::Logabs): {
                 res = InvokeF1Ps(cc, VecLogabsf, args[0]);
                 break;
             }
-            case NodeType::Log1p: {
+            case Operon::Hash(Operon::BuiltinOp::Log1p): {
                 res = InvokeF1Ps(cc, VecLog1pf, args[0]);
                 break;
             }
-            case NodeType::Sin: {
+            case Operon::Hash(Operon::BuiltinOp::Sin): {
                 res = InvokeF1Ps(cc, VecSinf, args[0]);
                 break;
             }
-            case NodeType::Sinh: {
+            case Operon::Hash(Operon::BuiltinOp::Sinh): {
                 res = InvokeF1Ps(cc, VecSinhf, args[0]);
                 break;
             }
-            case NodeType::Sqrt: {
+            case Operon::Hash(Operon::BuiltinOp::Sqrt): {
                 res = cc.new_ymm_ps();
                 cc.vsqrtps(res, args[0]);
                 break;
             }
-            case NodeType::Sqrtabs: {
+            case Operon::Hash(Operon::BuiltinOp::Sqrtabs): {
                 Vec const absVal = InvokeF1Ps(cc, VecFabsf, args[0]);
                 res = cc.new_ymm_ps();
                 cc.vsqrtps(res, absVal);
                 break;
             }
-            case NodeType::Tan: {
+            case Operon::Hash(Operon::BuiltinOp::Tan): {
                 res = InvokeF1Ps(cc, VecTanf, args[0]);
                 break;
             }
-            case NodeType::Tanh: {
+            case Operon::Hash(Operon::BuiltinOp::Tanh): {
                 res = InvokeF1Ps(cc, VecTanhf, args[0]);
                 break;
             }
-            case NodeType::Square: {
+            case Operon::Hash(Operon::BuiltinOp::Square): {
                 res = cc.new_ymm_ps();
                 cc.vmulps(res, args[0], args[0]);
                 break;
             }
-            default: {
-                res = BroadcastFloat(cc, 0.0F);
-                break;
-            }
+            default:
+                throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
             }
 
             nodeVecs[ii] = res;

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -144,7 +144,7 @@ auto InsertSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
     auto const* pset = creator_->GetPrimitiveSet();
 
     auto test = [&](auto const& node) -> auto {
-        return node.template Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div>() && (node.Arity < pset->MaximumArity(node.HashValue));
+        return node.template IsOp<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div>() && (node.Arity < pset->MaximumArity(node.HashValue));
     };
 
     auto n = std::count_if(nodes.begin(), nodes.end(), test);

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -144,7 +144,7 @@ auto InsertSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
     auto const* pset = creator_->GetPrimitiveSet();
 
     auto test = [&](auto const& node) -> auto {
-        return node.template Is<NodeType::Add, NodeType::Mul, NodeType::Sub, NodeType::Div>() && (node.Arity < pset->MaximumArity(node.HashValue));
+        return node.template Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div>() && (node.Arity < pset->MaximumArity(node.HashValue));
     };
 
     auto n = std::count_if(nodes.begin(), nodes.end(), test);

--- a/source/parser/infix.cpp
+++ b/source/parser/infix.cpp
@@ -19,46 +19,47 @@
 
 namespace {
 
-// Build a compile-time lookup table from infix_parser::node_type to Operon::NodeType.
-// Entries without an Operon equivalent are set to the NoType sentinel.
-constexpr auto MakeNodeTypeMap()
+// Build a compile-time lookup table from infix_parser::node_type to
+// Operon::BuiltinOp. Entries without an Operon equivalent are set to the
+// NoBuiltinOp sentinel.
+constexpr auto MakeBuiltinOpMap()
 {
     constexpr auto count = static_cast<std::size_t>(infix_parser::node_type::count);
-    std::array<Operon::NodeType, count> map{};
-    map.fill(Operon::NodeTypes::NoType);
+    std::array<Operon::BuiltinOp, count> map{};
+    map.fill(Operon::NoBuiltinOp);
 
-    map[static_cast<std::size_t>(infix_parser::node_type::add)]      = Operon::NodeType::Add;
-    map[static_cast<std::size_t>(infix_parser::node_type::sub)]      = Operon::NodeType::Sub;
-    map[static_cast<std::size_t>(infix_parser::node_type::mul)]      = Operon::NodeType::Mul;
-    map[static_cast<std::size_t>(infix_parser::node_type::div)]      = Operon::NodeType::Div;
-    map[static_cast<std::size_t>(infix_parser::node_type::pow)]      = Operon::NodeType::Pow;
-    map[static_cast<std::size_t>(infix_parser::node_type::abs)]      = Operon::NodeType::Abs;
-    map[static_cast<std::size_t>(infix_parser::node_type::square)]   = Operon::NodeType::Square;
-    map[static_cast<std::size_t>(infix_parser::node_type::exp)]      = Operon::NodeType::Exp;
-    map[static_cast<std::size_t>(infix_parser::node_type::log)]      = Operon::NodeType::Log;
-    map[static_cast<std::size_t>(infix_parser::node_type::sin)]      = Operon::NodeType::Sin;
-    map[static_cast<std::size_t>(infix_parser::node_type::cos)]      = Operon::NodeType::Cos;
-    map[static_cast<std::size_t>(infix_parser::node_type::tan)]      = Operon::NodeType::Tan;
-    map[static_cast<std::size_t>(infix_parser::node_type::asin)]     = Operon::NodeType::Asin;
-    map[static_cast<std::size_t>(infix_parser::node_type::acos)]     = Operon::NodeType::Acos;
-    map[static_cast<std::size_t>(infix_parser::node_type::atan)]     = Operon::NodeType::Atan;
-    map[static_cast<std::size_t>(infix_parser::node_type::sinh)]     = Operon::NodeType::Sinh;
-    map[static_cast<std::size_t>(infix_parser::node_type::cosh)]     = Operon::NodeType::Cosh;
-    map[static_cast<std::size_t>(infix_parser::node_type::tanh)]     = Operon::NodeType::Tanh;
-    map[static_cast<std::size_t>(infix_parser::node_type::sqrt)]     = Operon::NodeType::Sqrt;
-    map[static_cast<std::size_t>(infix_parser::node_type::cbrt)]     = Operon::NodeType::Cbrt;
-    map[static_cast<std::size_t>(infix_parser::node_type::log1p)]    = Operon::NodeType::Log1p;
-    map[static_cast<std::size_t>(infix_parser::node_type::logabs)]   = Operon::NodeType::Logabs;
-    map[static_cast<std::size_t>(infix_parser::node_type::sqrtabs)]  = Operon::NodeType::Sqrtabs;
-    map[static_cast<std::size_t>(infix_parser::node_type::aq)]       = Operon::NodeType::Aq;
-    map[static_cast<std::size_t>(infix_parser::node_type::fmin)]     = Operon::NodeType::Fmin;
-    map[static_cast<std::size_t>(infix_parser::node_type::fmax)]     = Operon::NodeType::Fmax;
-    map[static_cast<std::size_t>(infix_parser::node_type::powabs)]   = Operon::NodeType::Powabs;
+    map[static_cast<std::size_t>(infix_parser::node_type::add)]      = Operon::BuiltinOp::Add;
+    map[static_cast<std::size_t>(infix_parser::node_type::sub)]      = Operon::BuiltinOp::Sub;
+    map[static_cast<std::size_t>(infix_parser::node_type::mul)]      = Operon::BuiltinOp::Mul;
+    map[static_cast<std::size_t>(infix_parser::node_type::div)]      = Operon::BuiltinOp::Div;
+    map[static_cast<std::size_t>(infix_parser::node_type::pow)]      = Operon::BuiltinOp::Pow;
+    map[static_cast<std::size_t>(infix_parser::node_type::abs)]      = Operon::BuiltinOp::Abs;
+    map[static_cast<std::size_t>(infix_parser::node_type::square)]   = Operon::BuiltinOp::Square;
+    map[static_cast<std::size_t>(infix_parser::node_type::exp)]      = Operon::BuiltinOp::Exp;
+    map[static_cast<std::size_t>(infix_parser::node_type::log)]      = Operon::BuiltinOp::Log;
+    map[static_cast<std::size_t>(infix_parser::node_type::sin)]      = Operon::BuiltinOp::Sin;
+    map[static_cast<std::size_t>(infix_parser::node_type::cos)]      = Operon::BuiltinOp::Cos;
+    map[static_cast<std::size_t>(infix_parser::node_type::tan)]      = Operon::BuiltinOp::Tan;
+    map[static_cast<std::size_t>(infix_parser::node_type::asin)]     = Operon::BuiltinOp::Asin;
+    map[static_cast<std::size_t>(infix_parser::node_type::acos)]     = Operon::BuiltinOp::Acos;
+    map[static_cast<std::size_t>(infix_parser::node_type::atan)]     = Operon::BuiltinOp::Atan;
+    map[static_cast<std::size_t>(infix_parser::node_type::sinh)]     = Operon::BuiltinOp::Sinh;
+    map[static_cast<std::size_t>(infix_parser::node_type::cosh)]     = Operon::BuiltinOp::Cosh;
+    map[static_cast<std::size_t>(infix_parser::node_type::tanh)]     = Operon::BuiltinOp::Tanh;
+    map[static_cast<std::size_t>(infix_parser::node_type::sqrt)]     = Operon::BuiltinOp::Sqrt;
+    map[static_cast<std::size_t>(infix_parser::node_type::cbrt)]     = Operon::BuiltinOp::Cbrt;
+    map[static_cast<std::size_t>(infix_parser::node_type::log1p)]    = Operon::BuiltinOp::Log1p;
+    map[static_cast<std::size_t>(infix_parser::node_type::logabs)]   = Operon::BuiltinOp::Logabs;
+    map[static_cast<std::size_t>(infix_parser::node_type::sqrtabs)]  = Operon::BuiltinOp::Sqrtabs;
+    map[static_cast<std::size_t>(infix_parser::node_type::aq)]       = Operon::BuiltinOp::Aq;
+    map[static_cast<std::size_t>(infix_parser::node_type::fmin)]     = Operon::BuiltinOp::Fmin;
+    map[static_cast<std::size_t>(infix_parser::node_type::fmax)]     = Operon::BuiltinOp::Fmax;
+    map[static_cast<std::size_t>(infix_parser::node_type::powabs)]   = Operon::BuiltinOp::Powabs;
 
     return map;
 }
 
-constexpr auto node_type_map = MakeNodeTypeMap();
+constexpr auto node_type_map = MakeBuiltinOpMap();
 
 auto ToOperonNode(infix_parser::node const& a) -> Operon::Node
 {
@@ -68,14 +69,11 @@ auto ToOperonNode(infix_parser::node const& a) -> Operon::Node
     if (a.type == infix_parser::node_type::variable) {
         return Operon::Node(Operon::NodeType::Variable, Operon::Hasher{}(a.name));
     }
-    auto const operonType = node_type_map.at(static_cast<std::size_t>(a.type));
-    if (operonType == Operon::NodeTypes::NoType) {
+    auto const op = node_type_map.at(static_cast<std::size_t>(a.type));
+    if (op == Operon::NoBuiltinOp) {
         throw std::runtime_error(fmt::format("unsupported node type: {}", static_cast<int>(a.type)));
     }
-    Operon::Node node(operonType);
-    node.Arity = a.arity;
-    node.Length = a.arity;
-    return node;
+    return Operon::Node::Function(static_cast<Operon::Hash>(op), a.arity);
 }
 
 } // anonymous namespace

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -111,11 +111,11 @@ TEST_CASE("Autodiff forward vs reverse consistency", "[autodiff]")
     constexpr auto epsilon{1e-4F};
 
     // unary
-    pset.SetConfig(NodeType::Exp | NodeType::Log | NodeType::Sin | NodeType::Cos | NodeType::Sqrt | NodeType::Tanh | NodeType::Constant);
+    pset.SetConfig(BuiltinOp::Exp | BuiltinOp::Log | BuiltinOp::Sin | BuiltinOp::Cos | BuiltinOp::Sqrt | BuiltinOp::Tanh | NodeType::Constant);
     auto trees = generateTrees(pset, n / 2, 2);
 
     // binary
-    pset.SetConfig(NodeType::Div | NodeType::Aq | NodeType::Pow | NodeType::Constant);
+    pset.SetConfig(BuiltinOp::Div | BuiltinOp::Aq | BuiltinOp::Pow | NodeType::Constant);
     auto tmp = generateTrees(pset, n / 2, 3);
     std::ranges::copy(tmp, std::back_inserter(trees));
 
@@ -199,8 +199,7 @@ TEST_CASE("Autodiff variable-wise derivative", "[autodiff]")
         v.HashValue = v.CalculatedHashValue = xHash;
         v.Value = 1.0F;
         Operon::Node ref = Operon::Node::Ref(0);
-        Operon::Node mul(Operon::NodeType::Mul);
-        mul.Length = 2;
+        auto mul = Util::MakeOp<Operon::BuiltinOp::Mul>();
         nodes.push_back(v);
         nodes.push_back(ref);
         nodes.push_back(mul);

--- a/test/source/implementation/content_hash.cpp
+++ b/test/source/implementation/content_hash.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include <unordered_set>
 
 #include "operon/core/dataset.hpp"
@@ -62,8 +64,8 @@ TEST_CASE("ContentHash - commutative invariance", "[content_hash]")
     Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
     Node nY(NodeType::Variable); nY.HashValue = varY.Hash;
 
-    Tree const treeXY = Tree({ nX, nY, Node(NodeType::Add) }).UpdateNodes();
-    Tree const treeYX = Tree({ nY, nX, Node(NodeType::Add) }).UpdateNodes();
+    Tree const treeXY = Tree({ nX, nY, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
+    Tree const treeYX = Tree({ nY, nX, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     REQUIRE(ComputeContentHash(treeXY, zobrist) == ComputeContentHash(treeYX, zobrist));
 }
@@ -82,8 +84,8 @@ TEST_CASE("ContentHash - non-commutative sensitivity", "[content_hash]")
     Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
     Node nY(NodeType::Variable); nY.HashValue = varY.Hash;
 
-    Tree const treeXY = Tree({ nX, nY, Node(NodeType::Sub) }).UpdateNodes();
-    Tree const treeYX = Tree({ nY, nX, Node(NodeType::Sub) }).UpdateNodes();
+    Tree const treeXY = Tree({ nX, nY, Util::MakeOp<BuiltinOp::Sub>() }).UpdateNodes();
+    Tree const treeYX = Tree({ nY, nX, Util::MakeOp<BuiltinOp::Sub>() }).UpdateNodes();
 
     REQUIRE(ComputeContentHash(treeXY, zobrist) != ComputeContentHash(treeYX, zobrist));
 }
@@ -109,9 +111,9 @@ TEST_CASE("ContentHash - position independence", "[content_hash]")
     Node nZ(NodeType::Variable); nZ.HashValue = varZ.Hash;
 
     // (x+y)*z : postfix [x, y, Add, z, Mul] - subtree root (Add) at index 2
-    Tree const treeA = Tree({ nX, nY, Node(NodeType::Add), nZ, Node(NodeType::Mul) }).UpdateNodes();
+    Tree const treeA = Tree({ nX, nY, Util::MakeOp<BuiltinOp::Add>(), nZ, Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
     // z*(x+y) : postfix [z, x, y, Add, Mul] - subtree root (Add) at index 3
-    Tree const treeB = Tree({ nZ, nX, nY, Node(NodeType::Add), Node(NodeType::Mul) }).UpdateNodes();
+    Tree const treeB = Tree({ nZ, nX, nY, Util::MakeOp<BuiltinOp::Add>(), Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     std::vector<Operon::Hash> scratchA(treeA.Nodes().size());
     std::vector<Operon::Hash> scratchB(treeB.Nodes().size());
@@ -201,10 +203,10 @@ TEST_CASE("ContentHash - Ref-aware (structural sharing doesn't change the hash)"
     Node nX(NodeType::Variable); nX.HashValue = varX.Hash;
 
     // x * x, no sharing: two independent Variable nodes.
-    Tree const noRef = Tree({ nX, nX, Node(NodeType::Mul) }).UpdateNodes();
+    Tree const noRef = Tree({ nX, nX, Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     // x * Ref(x), sharing the first x via a backward Ref.
-    Tree const withRef = Tree({ nX, Node::Ref(0), Node(NodeType::Mul) }).UpdateNodes();
+    Tree const withRef = Tree({ nX, Node::Ref(0), Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     REQUIRE(ComputeContentHash(noRef, zobrist) == ComputeContentHash(withRef, zobrist));
 }

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -5,6 +5,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#include "../operon_test.hpp"
+
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
@@ -50,7 +52,7 @@ TEST_CASE("Node type traits", "[core]")
 TEST_CASE("Tree construction and access", "[core]")
 {
     Operon::Vector<Node> nodes;
-    std::generate_n(std::back_inserter(nodes), 50, []() { return Node(NodeType::Add); }); // NOLINT
+    std::generate_n(std::back_inserter(nodes), 50, []() { return Util::MakeOp<BuiltinOp::Add>(); }); // NOLINT
     Tree tree{nodes};
 
     SECTION("Tree stores correct number of nodes") {
@@ -68,7 +70,7 @@ TEST_CASE("Tree coefficients", "[core]")
 {
     Node c1(NodeType::Constant); c1.Value = 3.14F; c1.Optimize = true;
     Node c2(NodeType::Constant); c2.Value = 2.71F; c2.Optimize = true;
-    Node const add(NodeType::Add);
+    auto const add = Util::MakeOp<BuiltinOp::Add>();
     Tree tree({c1, c2, add});
     tree.UpdateNodes();
 
@@ -121,10 +123,10 @@ TEST_CASE("PrimitiveSet configuration", "[core]")
     CHECK(!enabled.empty());
 
     // Arithmetic should include Add, Sub, Mul, Div, Constant, Variable
-    CHECK(pset.IsEnabled(Node(NodeType::Add).HashValue));
-    CHECK(pset.IsEnabled(Node(NodeType::Sub).HashValue));
-    CHECK(pset.IsEnabled(Node(NodeType::Mul).HashValue));
-    CHECK(pset.IsEnabled(Node(NodeType::Div).HashValue));
+    CHECK(pset.IsEnabled(Util::MakeOp<BuiltinOp::Add>().HashValue));
+    CHECK(pset.IsEnabled(Util::MakeOp<BuiltinOp::Sub>().HashValue));
+    CHECK(pset.IsEnabled(Util::MakeOp<BuiltinOp::Mul>().HashValue));
+    CHECK(pset.IsEnabled(Util::MakeOp<BuiltinOp::Div>().HashValue));
 }
 
 TEST_CASE("Tree::Simplify", "[core][simplify]")
@@ -136,7 +138,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     auto Var   = []()    { return Node(NT::Variable); };
 
     SECTION("constant folding: Add(2, 3) -> Const(5)") {
-        Operon::Vector<Node> ns{ Const(2), Const(3), Node(NT::Add) };
+        Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -144,7 +146,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     }
 
     SECTION("constant folding: Mul(2, 3) -> Const(6)") {
-        Operon::Vector<Node> ns{ Const(2), Const(3), Node(NT::Mul) };
+        Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -153,7 +155,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("constant folding: nested Add(Mul(2,3), 4) -> Const(10)") {
         // [Const(2), Const(3), Mul, Const(4), Add]
-        Operon::Vector<Node> ns{ Const(2), Const(3), Node(NT::Mul), Const(4), Node(NT::Add) };
+        Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>(), Const(4), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -161,21 +163,21 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     }
 
     SECTION("identity: x + 0 -> x") {
-        Operon::Vector<Node> ns{ Const(0), Var(), Node(NT::Add) };
+        Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("identity: x * 1 -> x") {
-        Operon::Vector<Node> ns{ Const(1), Var(), Node(NT::Mul) };
+        Operon::Vector<Node> ns{ Const(1), Var(), Util::MakeOp<BuiltinOp::Mul>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("annihilator: x * 0 -> 0") {
-        Operon::Vector<Node> ns{ Const(0), Var(), Node(NT::Mul) };
+        Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Mul>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -184,7 +186,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("identity: x - 0 -> x") {
         // post-order Sub(x, 0) = [Const(0), Var, Sub]: Var is i-1 (minuend), Const(0) is k (subtrahend)
-        Operon::Vector<Node> ns{ Const(0), Var(), Node(NT::Sub) };
+        Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Sub>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
@@ -192,7 +194,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("identity: x / 1 -> x") {
         // post-order Div(x, 1) = [Const(1), Var, Div]: Var is i-1 (numerator), Const(1) is k (denominator)
-        Operon::Vector<Node> ns{ Const(1), Var(), Node(NT::Div) };
+        Operon::Vector<Node> ns{ Const(1), Var(), Util::MakeOp<BuiltinOp::Div>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
@@ -200,7 +202,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("Pow: x^0 -> 1") {
         // [Const(0), Var, Pow]: base=Var (j=i-1), exp=Const(0) (k)
-        Operon::Vector<Node> ns{ Const(0), Var(), Node(NT::Pow) };
+        Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -208,7 +210,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     }
 
     SECTION("Pow: x^1 -> x") {
-        Operon::Vector<Node> ns{ Const(1), Var(), Node(NT::Pow) };
+        Operon::Vector<Node> ns{ Const(1), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
@@ -216,7 +218,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("Pow: 1^x -> 1") {
         // [Var, Const(1), Pow]: base=Const(1) (j=i-1), exp=Var (k)
-        Operon::Vector<Node> ns{ Var(), Const(1), Node(NT::Pow) };
+        Operon::Vector<Node> ns{ Var(), Const(1), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -225,8 +227,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("n-ary: Add(x, 0, 0) -> x (two zero children removed)") {
         // Manually set arity=3 for a 3-child Add
-        Node addNode(NT::Add);
-        addNode.Arity = 3;
+        auto addNode = Operon::Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 3);
         Operon::Vector<Node> ns{ Const(0), Const(0), Var(), addNode };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
@@ -234,7 +235,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     }
 
     SECTION("constant folding: Exp(Const(0)) -> Const(1)") {
-        Operon::Vector<Node> ns{ Const(0), Node(NT::Exp) };
+        Operon::Vector<Node> ns{ Const(0), Util::MakeOp<BuiltinOp::Exp>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
@@ -243,35 +244,35 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("strength reduction: Pow(x, 2) -> Square(x)") {
         // [Const(2), Var, Pow]: base=Var (ch[0]=i-1), exp=Const(2) (ch[1])
-        Operon::Vector<Node> ns{ Const(2), Var(), Node(NT::Pow) };
+        Operon::Vector<Node> ns{ Const(2), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Type == NT::Square);
-        CHECK(tree[1].HashValue == Node(NT::Square).HashValue);
+        CHECK(tree[1].Is<BuiltinOp::Square>());
+        CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Square>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("strength reduction: Pow(x, 0.5) -> Sqrt(x)") {
-        Operon::Vector<Node> ns{ Const(0.5), Var(), Node(NT::Pow) };
+        Operon::Vector<Node> ns{ Const(0.5), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Type == NT::Sqrt);
-        CHECK(tree[1].HashValue == Node(NT::Sqrt).HashValue);
+        CHECK(tree[1].Is<BuiltinOp::Sqrt>());
+        CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Sqrt>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("structural inverse: Log(Exp(x)) -> x") {
         // [Var, Exp, Log] in post-order
-        Operon::Vector<Node> ns{ Var(), Node(NT::Exp), Node(NT::Log) };
+        Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Exp>(), Util::MakeOp<BuiltinOp::Log>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("structural inverse: Logabs(Exp(x)) -> x") {
-        Operon::Vector<Node> ns{ Var(), Node(NT::Exp), Node(NT::Logabs) };
+        Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Exp>(), Util::MakeOp<BuiltinOp::Logabs>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
@@ -279,21 +280,21 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
 
     SECTION("structural inverse: Sqrt(Square(x)) -> Abs(x)") {
         // [Var, Square, Sqrt] in post-order
-        Operon::Vector<Node> ns{ Var(), Node(NT::Square), Node(NT::Sqrt) };
+        Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Square>(), Util::MakeOp<BuiltinOp::Sqrt>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Type == NT::Abs);
-        CHECK(tree[1].HashValue == Node(NT::Abs).HashValue);
+        CHECK(tree[1].Is<BuiltinOp::Abs>());
+        CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Abs>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
     }
 
     SECTION("structural inverse: Sqrtabs(Square(x)) -> Abs(x)") {
-        Operon::Vector<Node> ns{ Var(), Node(NT::Square), Node(NT::Sqrtabs) };
+        Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Square>(), Util::MakeOp<BuiltinOp::Sqrtabs>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Type == NT::Abs);
-        CHECK(tree[1].HashValue == Node(NT::Abs).HashValue);
+        CHECK(tree[1].Is<BuiltinOp::Abs>());
+        CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Abs>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
     }
@@ -310,13 +311,13 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         // "children" as constant, collapsing the whole expression (losing
         // the Variable dependency entirely) instead of correctly leaving a
         // Var+Const(5).
-        Operon::Vector<Node> ns{ Var(), Const(2), Const(3), Node(NT::Add), Node(NT::Add) };
+        Operon::Vector<Node> ns{ Var(), Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 3);
         CHECK(tree[0].IsVariable());
         REQUIRE(tree[1].IsConstant());
         CHECK(tree[1].Value == Catch::Approx(5.0));
-        CHECK(tree[2].Type == NT::Add);
+        CHECK(tree[2].Is<BuiltinOp::Add>());
     }
 }
 

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -247,7 +247,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         Operon::Vector<Node> ns{ Const(2), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Is<BuiltinOp::Square>());
+        CHECK(tree[1].IsOp<BuiltinOp::Square>());
         CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Square>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
@@ -257,7 +257,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         Operon::Vector<Node> ns{ Const(0.5), Var(), Util::MakeOp<BuiltinOp::Pow>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Is<BuiltinOp::Sqrt>());
+        CHECK(tree[1].IsOp<BuiltinOp::Sqrt>());
         CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Sqrt>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
@@ -283,7 +283,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Square>(), Util::MakeOp<BuiltinOp::Sqrt>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Is<BuiltinOp::Abs>());
+        CHECK(tree[1].IsOp<BuiltinOp::Abs>());
         CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Abs>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
@@ -293,7 +293,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         Operon::Vector<Node> ns{ Var(), Util::MakeOp<BuiltinOp::Square>(), Util::MakeOp<BuiltinOp::Sqrtabs>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
         REQUIRE(tree.Length() == 2);
-        CHECK(tree[1].Is<BuiltinOp::Abs>());
+        CHECK(tree[1].IsOp<BuiltinOp::Abs>());
         CHECK(tree[1].HashValue == Util::MakeOp<BuiltinOp::Abs>().HashValue);
         CHECK(tree[1].Arity == 1);
         CHECK(tree[0].IsVariable());
@@ -317,7 +317,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         CHECK(tree[0].IsVariable());
         REQUIRE(tree[1].IsConstant());
         CHECK(tree[1].Value == Catch::Approx(5.0));
-        CHECK(tree[2].Is<BuiltinOp::Add>());
+        CHECK(tree[2].IsOp<BuiltinOp::Add>());
     }
 }
 

--- a/test/source/implementation/dispatch_table.cpp
+++ b/test/source/implementation/dispatch_table.cpp
@@ -4,6 +4,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+
+#include "../operon_test.hpp"
+
 #include <numbers>
 #include <numeric>
 
@@ -130,7 +133,7 @@ TEST_CASE("RegisterFunction - user-defined symbol", "[interpreter]") // NOLINT(r
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, myHash);
+        Operon::Node dynNode(Operon::NodeType::Function, myHash);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 
@@ -168,7 +171,7 @@ TEST_CASE("RegisterUnary - scalar lambda adapter", "[interpreter]") // NOLINT(re
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, h);
+        Operon::Node dynNode(Operon::NodeType::Function, h);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 
@@ -187,7 +190,7 @@ TEST_CASE("RegisterUnary - scalar lambda adapter", "[interpreter]") // NOLINT(re
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, h);
+        Operon::Node dynNode(Operon::NodeType::Function, h);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
         dynNode.Value  = 3.0F; // non-unit weight
@@ -234,7 +237,7 @@ TEST_CASE("RegisterBinary - scalar lambda adapter", "[interpreter]")
         Operon::Node varY(Operon::NodeType::Variable);
         varY.HashValue = ds.GetVariable("y").value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, h);
+        Operon::Node dynNode(Operon::NodeType::Function, h);
         dynNode.Arity  = 2;
         dynNode.Length = 2;
 
@@ -325,7 +328,7 @@ TEST_CASE("Auto-diff fallback via Jet<T,1>", "[interpreter]") // NOLINT(readabil
     auto makeTree = [&](Operon::Hash h) -> Operon::Tree {
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
-        Operon::Node dynNode(Operon::NodeType::Dynamic, h);
+        Operon::Node dynNode(Operon::NodeType::Function, h);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
         return Operon::Tree({ varNode, dynNode });
@@ -391,7 +394,7 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
     Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
 
     SECTION("Name and Desc are registered on the node") {
-        Operon::Node const dynNode(Operon::NodeType::Dynamic, hash);
+        Operon::Node const dynNode(Operon::NodeType::Function, hash);
         CHECK(dynNode.Name() == "cube");
         CHECK(dynNode.Desc() == "cube function f(x) = x^3");
     }
@@ -406,7 +409,7 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, hash);
+        Operon::Node dynNode(Operon::NodeType::Function, hash);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 
@@ -424,7 +427,7 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         Operon::Node varNode(Operon::NodeType::Variable);
         varNode.HashValue = ds.GetVariable(x).value().Hash;
 
-        Operon::Node dynNode(Operon::NodeType::Dynamic, hash);
+        Operon::Node dynNode(Operon::NodeType::Function, hash);
         dynNode.Arity  = 1;
         dynNode.Length = 1;
 

--- a/test/source/implementation/enumeration.cpp
+++ b/test/source/implementation/enumeration.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include <cmath>
 
 #include "operon/algorithms/enumeration.hpp"
@@ -38,7 +40,7 @@ TEST_CASE("Complexity - counts all non-Constant nodes", "[enumeration]")
     // count Variable x, Variable y, Add, Mul (4), excluding the Constant.
     Node nx(NodeType::Variable); nx.HashValue = 1;
     Node ny(NodeType::Variable); ny.HashValue = 2;
-    Tree const tree = Tree({ nx, ny, Node(NodeType::Add), Node::Constant(2.0), Node(NodeType::Mul) }).UpdateNodes();
+    Tree const tree = Tree({ nx, ny, Util::MakeOp<BuiltinOp::Add>(), Node::Constant(2.0), Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
     CHECK(SymbolicComplexity(tree) == 4);
 }
 

--- a/test/source/implementation/evaluation.cpp
+++ b/test/source/implementation/evaluation.cpp
@@ -60,8 +60,7 @@ TEST_CASE("Evaluation correctness", "[interpreter]")
     }
 
     SECTION("N-ary fmax") {
-        Operon::Node node(Operon::NodeType::Fmax);
-        node.Arity = 3;
+        auto node = Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Fmax), 3);
         auto a = Operon::Node::Constant(2);
         auto b = Operon::Node::Constant(3);
         auto c = Operon::Node::Constant(4);
@@ -71,8 +70,7 @@ TEST_CASE("Evaluation correctness", "[interpreter]")
     }
 
     SECTION("Unary sub (negation)") {
-        auto node = Operon::Node(Operon::NodeType::Sub);
-        node.Arity = 1;
+        auto node = Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Sub), 1);
         auto tree = Operon::Tree({Operon::Node::Constant(2), node});
         auto estimatedValues = Interpreter<Operon::Scalar, DTable>(&dtable, &ds, &tree).Evaluate(tree.GetCoefficients(), range);
         CHECK(estimatedValues[0] == -2);

--- a/test/source/implementation/grammar.cpp
+++ b/test/source/implementation/grammar.cpp
@@ -13,7 +13,7 @@
 namespace Operon::Test {
 
 namespace {
-    auto HasUnaryProduction(std::span<Production const> ps, NodeType op) -> bool {
+    auto HasUnaryProduction(std::span<Production const> ps, BuiltinOp op) -> bool {
         return std::ranges::any_of(ps, [&](auto const& p) { return p.Op == op; });
     }
 } // namespace
@@ -30,11 +30,11 @@ TEST_CASE("Grammar - TypeCoherent config enables Log/Exp/Sin but not Sqrt/Cbrt",
     Grammar grammar(PrimitiveSet::TypeCoherent, { 1, 2, 3 });
     auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
 
-    CHECK(HasUnaryProduction(ps, NodeType::Log));
-    CHECK(HasUnaryProduction(ps, NodeType::Exp));
-    CHECK(HasUnaryProduction(ps, NodeType::Sin));
-    CHECK_FALSE(HasUnaryProduction(ps, NodeType::Sqrt));
-    CHECK_FALSE(HasUnaryProduction(ps, NodeType::Cbrt));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Log));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Exp));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Sin));
+    CHECK_FALSE(HasUnaryProduction(ps, BuiltinOp::Sqrt));
+    CHECK_FALSE(HasUnaryProduction(ps, BuiltinOp::Cbrt));
 
     // every RecurringFactor production wraps a SimpleExpr operand
     for (auto const& p : ps) {
@@ -48,11 +48,11 @@ TEST_CASE("Grammar - Full config enables Sqrt/Cbrt too", "[grammar]")
     Grammar grammar(PrimitiveSet::Full, { 1, 2, 3 });
     auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
 
-    CHECK(HasUnaryProduction(ps, NodeType::Log));
-    CHECK(HasUnaryProduction(ps, NodeType::Exp));
-    CHECK(HasUnaryProduction(ps, NodeType::Sin));
-    CHECK(HasUnaryProduction(ps, NodeType::Sqrt));
-    CHECK(HasUnaryProduction(ps, NodeType::Cbrt));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Log));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Exp));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Sin));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Sqrt));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Cbrt));
 }
 
 TEST_CASE("Grammar - Configure is independent of Reconfigure order", "[grammar]")
@@ -61,7 +61,7 @@ TEST_CASE("Grammar - Configure is independent of Reconfigure order", "[grammar]"
     grammar.Configure(PrimitiveSet::Full);
     grammar.SetVariables({ 1, 2, 3 });
     auto ps = grammar.Productions(GrammarSymbol::RecurringFactor);
-    CHECK(HasUnaryProduction(ps, NodeType::Sqrt));
+    CHECK(HasUnaryProduction(ps, BuiltinOp::Sqrt));
     CHECK(grammar.VariableHashes().size() == 3);
 }
 
@@ -128,12 +128,12 @@ TEST_CASE("Grammar - Term and SimpleTerm production shapes", "[grammar]")
     REQUIRE(term.size() == 2);
     CHECK(term[0].IsCoercion());
     CHECK(term[0].Operands == std::vector{ GrammarSymbol::RecurringFactor });
-    CHECK(term[1].Op == NodeType::Mul);
+    CHECK(term[1].Op == BuiltinOp::Mul);
     CHECK(term[1].Operands == std::vector{ GrammarSymbol::Term, GrammarSymbol::Term });
 
     auto simpleTerm = grammar.Productions(GrammarSymbol::SimpleTerm);
     REQUIRE(simpleTerm.size() == 1);
-    CHECK(simpleTerm[0].Op == NodeType::Mul);
+    CHECK(simpleTerm[0].Op == BuiltinOp::Mul);
     CHECK(simpleTerm[0].Operands == std::vector{ GrammarSymbol::SimpleTerm, GrammarSymbol::SimpleTerm });
 }
 
@@ -143,11 +143,11 @@ TEST_CASE("Grammar - Expression and SimpleExpr production shapes", "[grammar]")
 
     auto expr = grammar.Productions(GrammarSymbol::Expression);
     REQUIRE(expr.size() == 2);
-    CHECK(expr[0].Op == NodeType::Add);
+    CHECK(expr[0].Op == BuiltinOp::Add);
     CHECK(expr[0].WeightFirstOperand);
     CHECK(expr[0].TrailingConstant);
     CHECK(expr[0].Operands == std::vector{ GrammarSymbol::Term });
-    CHECK(expr[1].Op == NodeType::Add);
+    CHECK(expr[1].Op == BuiltinOp::Add);
     CHECK(expr[1].WeightFirstOperand);
     CHECK_FALSE(expr[1].TrailingConstant);
     CHECK(expr[1].Operands == std::vector{ GrammarSymbol::Term, GrammarSymbol::Expression });

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Parser roundtrip correctness", "[parser]")
     Operon::Dataset ds = Operon::Test::Util::RandomDataset(rng, nrow, ncol);
 
     Operon::PrimitiveSet pset;
-    pset.SetConfig(PrimitiveSet::Arithmetic | NodeType::Aq | NodeType::Exp | NodeType::Log | NodeType::Variable);
+    pset.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Aq | BuiltinOp::Exp | BuiltinOp::Log | NodeType::Variable);
     Operon::BalancedTreeCreator const btc(&pset, ds.VariableHashes(), /* bias= */ 0.0, nNodes);
 
     Operon::Vector<Operon::Tree> trees;
@@ -84,8 +84,8 @@ TEST_CASE("Parse specific expressions", "[parser]")
         Node c1(NodeType::Constant); c1.Value = 2;
         Node c2(NodeType::Constant); c2.Value = 3;
         Node c3(NodeType::Constant); c3.Value = 5;
-        Node const sub(NodeType::Sub);
-        Node const mul(NodeType::Mul);
+        auto const sub = Util::MakeOp<BuiltinOp::Sub>();
+        auto const mul = Util::MakeOp<BuiltinOp::Mul>();
         Operon::Vector<Node> const nodes{c1, c2, c3, sub, mul}; // 5 - 3 * 2
         Tree t(nodes);
         t.UpdateNodes();
@@ -124,7 +124,7 @@ TEST_CASE("Formatter output", "[parser]")
         Operon::RandomGenerator rng(1234);
         Operon::Dataset const ds("./data/Poly-10.csv", true);
         Operon::PrimitiveSet pset;
-        pset.SetConfig(PrimitiveSet::Arithmetic | NodeType::Exp | NodeType::Log);
+        pset.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Exp | BuiltinOp::Log);
         constexpr size_t maxLength = 20;
         Operon::BalancedTreeCreator const btc(&pset, ds.VariableHashes(), /* bias= */ 0.0, maxLength);
 

--- a/test/source/implementation/initialization.cpp
+++ b/test/source/implementation/initialization.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <random>
 
+#include "../operon_test.hpp"
+
 #include "operon/core/dataset.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/operators/creator.hpp"
@@ -41,31 +43,44 @@ TEST_CASE("Grammar sampling", "[operators]")
     grammar.SetConfig(~PrimitiveSetConfig{});
     Operon::RandomGenerator rd(1234);
 
-    std::vector<double> observed(NodeTypes::Count, 0);
+    // Bucket by primitive hash rather than NodeType: post-collapse, every
+    // built-in math op shares NodeType::Function, so a single "Function"
+    // bucket would conflate all 29 ops. Enumerate the actual registered
+    // primitives instead - every BuiltinOp plus the 3 non-Function
+    // terminals (Constant/Variable/Ref; Function itself has no single real
+    // hash and is never registered by SetConfig, see pset.cpp).
+    std::vector<Operon::Hash> hashes;
+    for (size_t i = 0; i < BuiltinOpCount; ++i) {
+        hashes.push_back(static_cast<Operon::Hash>(static_cast<BuiltinOp>(i)));
+    }
+    for (auto type : { NodeType::Constant, NodeType::Variable, NodeType::Ref }) {
+        hashes.push_back(Node(type).HashValue);
+    }
+
+    Operon::Map<Operon::Hash, double> observed;
+    for (auto h : hashes) { observed[h] = 0; }
     size_t const r = grammar.EnabledPrimitives().size() + 1;
 
     const size_t nTrials = 1'000'000;
     for (auto i = 0U; i < nTrials; ++i) {
         auto node = grammar.SampleRandomSymbol(rd, 0, 2);
-        ++observed[NodeTypes::GetIndex(node.Type)];
+        ++observed[node.HashValue];
     }
-    std::transform(observed.begin(), observed.end(), observed.begin(), [&](double v) -> double { return v / nTrials; });
-    std::vector<double> actual(NodeTypes::Count, 0);
-    for (size_t i = 0; i < observed.size(); ++i) {
-        auto type = static_cast<NodeType>(i);
-        auto node = Node(type);
-        actual[NodeTypes::GetIndex(type)] = static_cast<double>(grammar.Frequency(node.HashValue));
-    }
-    auto freqSum = std::reduce(actual.begin(), actual.end(), 0.0, std::plus{});
-    std::transform(actual.begin(), actual.end(), actual.begin(), [&](double v) -> double { return v / freqSum; });
+    for (auto& [h, v] : observed) { v /= static_cast<double>(nTrials); }
+
+    Operon::Map<Operon::Hash, double> actual;
+    for (auto h : hashes) { actual[h] = static_cast<double>(grammar.Frequency(h)); }
+    auto freqSum = 0.0;
+    for (auto const& [h, v] : actual) { freqSum += v; }
+    for (auto& [h, v] : actual) { v /= freqSum; }
+
     auto chi = 0.0;
-    for (auto i = 0U; i < observed.size(); ++i) {
-        Node const node(static_cast<NodeType>(i));
-        if (!grammar.IsEnabled(node.HashValue)) {
+    for (auto h : hashes) {
+        if (!grammar.IsEnabled(h)) {
             continue;
         }
-        auto x = observed[i];
-        auto y = actual[i];
+        auto x = observed[h];
+        auto y = actual[h];
         chi += (x - y) * (x - y) / y;
     }
     chi *= nTrials;
@@ -84,11 +99,11 @@ TEST_CASE("GROW creator", "[operators]") // NOLINT(readability-function-cognitiv
     size_t const n = 1000;
 
     PrimitiveSet grammar;
-    grammar.SetConfig(PrimitiveSet::Arithmetic | NodeType::Log | NodeType::Exp);
-    grammar.SetMaximumArity(Node(NodeType::Add), 2);
-    grammar.SetMaximumArity(Node(NodeType::Mul), 2);
-    grammar.SetMaximumArity(Node(NodeType::Sub), 2);
-    grammar.SetMaximumArity(Node(NodeType::Div), 2);
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Add>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Mul>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Sub>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Div>(), 2);
 
     GrowTreeCreator gtc{&grammar, inputs, maxLength};
     Operon::RandomGenerator random(1234);
@@ -124,11 +139,11 @@ TEST_CASE("BTC creator", "[operators]")
     size_t const n = 1000;
 
     PrimitiveSet grammar;
-    grammar.SetConfig(PrimitiveSet::Arithmetic | NodeType::Log | NodeType::Exp);
-    grammar.SetMaximumArity(Node(NodeType::Add), 2);
-    grammar.SetMaximumArity(Node(NodeType::Mul), 2);
-    grammar.SetMaximumArity(Node(NodeType::Sub), 2);
-    grammar.SetMaximumArity(Node(NodeType::Div), 2);
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Add>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Mul>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Sub>(), 2);
+    grammar.SetMaximumArity(Util::MakeOp<BuiltinOp::Div>(), 2);
 
     BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
     Operon::RandomGenerator random(1234);
@@ -169,7 +184,7 @@ TEST_CASE("PTC2 creator", "[operators]")
     size_t const n = 1000;
 
     PrimitiveSet grammar;
-    grammar.SetConfig(PrimitiveSet::Arithmetic | NodeType::Log | NodeType::Exp);
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
 
     ProbabilisticTreeCreator ptc{&grammar, inputs, /* bias= */ 0.0, maxLength};
     Operon::RandomGenerator random(1234);
@@ -209,8 +224,8 @@ TEST_CASE("AchievableLength snap-down table", "[operators]") // NOLINT(readabili
         // Only arity-2 functions: n > 1 is achievable iff (n-1) is a multiple of 2,
         // i.e. n is odd. So snap_[i] carries the last odd value seen.
         PrimitiveSet pset;
-        pset.SetConfig(NodeType::Add | NodeType::Variable);
-        pset.SetMinMaxArity(Node(NodeType::Add), 2, 2);
+        pset.SetConfig(BuiltinOp::Add | NodeType::Variable);
+        pset.SetMinMaxArity(Util::MakeOp<BuiltinOp::Add>(), 2, 2);
         TestCreator const tc(&pset, 20);
 
         CHECK(tc.SnapDown(1) == 1);
@@ -225,9 +240,9 @@ TEST_CASE("AchievableLength snap-down table", "[operators]") // NOLINT(readabili
     SECTION("Mixed pset (arities 1 and 2): every length is achievable") {
         // Arity-1 means we can always add exactly 1 node, so all lengths >= 1 are reachable.
         PrimitiveSet pset;
-        pset.SetConfig(NodeType::Sin | NodeType::Add | NodeType::Variable);
-        pset.SetMinMaxArity(Node(NodeType::Sin), 1, 1);
-        pset.SetMinMaxArity(Node(NodeType::Add), 2, 2);
+        pset.SetConfig(BuiltinOp::Sin | BuiltinOp::Add | NodeType::Variable);
+        pset.SetMinMaxArity(Util::MakeOp<BuiltinOp::Sin>(), 1, 1);
+        pset.SetMinMaxArity(Util::MakeOp<BuiltinOp::Add>(), 2, 2);
         TestCreator const tc(&pset, 15);
 
         for (size_t n = 1; n <= 15; ++n) {
@@ -239,8 +254,8 @@ TEST_CASE("AchievableLength snap-down table", "[operators]") // NOLINT(readabili
         // Only arity-3 functions: n > 1 is achievable iff (n-1) is a multiple of 3.
         // Achievable: 1, 4, 7, 10, 13, ...
         PrimitiveSet pset;
-        pset.SetConfig(NodeType::Add | NodeType::Variable);
-        pset.SetMinMaxArity(Node(NodeType::Add), 3, 3);
+        pset.SetConfig(BuiltinOp::Add | NodeType::Variable);
+        pset.SetMinMaxArity(Util::MakeOp<BuiltinOp::Add>(), 3, 3);
         TestCreator const tc(&pset, 20);
 
         CHECK(tc.SnapDown(1) == 1);
@@ -262,8 +277,8 @@ TEST_CASE("Creator length contract with unachievable targets", "[operators]") //
     // Requesting any even target must snap down — the returned tree must be strictly
     // within the requested bound.
     PrimitiveSet pset;
-    pset.SetConfig(NodeType::Add | NodeType::Variable);
-    pset.SetMinMaxArity(Node(NodeType::Add), 2, 2);
+    pset.SetConfig(BuiltinOp::Add | NodeType::Variable);
+    pset.SetMinMaxArity(Util::MakeOp<BuiltinOp::Add>(), 2, 2);
 
     auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
     auto inputs = ds.VariableHashes();

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -238,11 +238,11 @@ TEST_CASE("JIT Ref node forward-pass correctness", "[jit][ref]")
     {
         Node v1(NodeType::Variable); v1.HashValue = v1.CalculatedHashValue = x1Hash; v1.Value = 1.0F;
         Node v2(NodeType::Variable); v2.HashValue = v2.CalculatedHashValue = x2Hash; v2.Value = 1.0F;
-        Node add(NodeType::Add);     add.Length = 2;
+        auto add = Util::MakeOp<BuiltinOp::Add>(); add.Length = 2;
         Node v3(NodeType::Variable); v3.HashValue = v3.CalculatedHashValue = x3Hash; v3.Value = 1.0F;
         Node ref = Node::Ref(2);
-        Node sub(NodeType::Sub);     sub.Length = 2;
-        Node mul(NodeType::Mul);     mul.Length = 6;
+        auto sub = Util::MakeOp<BuiltinOp::Sub>(); sub.Length = 2;
+        auto mul = Util::MakeOp<BuiltinOp::Mul>(); mul.Length = 6;
         nodes.push_back(v1);
         nodes.push_back(v2);
         nodes.push_back(add);
@@ -514,9 +514,9 @@ TEST_CASE("JitEvaluator vs interpreter on random population", "[jit][evaluator][
 
     // Full symbol set matching the failing comparison runs (plus Variable as terminal).
     PrimitiveSet pset;
-    pset.SetConfig(NodeType::Add | NodeType::Sub | NodeType::Mul | NodeType::Div |
-                   NodeType::Sin | NodeType::Cos | NodeType::Exp | NodeType::Log |
-                   NodeType::Pow | NodeType::Sqrt | NodeType::Tanh |
+    pset.SetConfig(BuiltinOp::Add | BuiltinOp::Sub | BuiltinOp::Mul | BuiltinOp::Div |
+                   BuiltinOp::Sin | BuiltinOp::Cos | BuiltinOp::Exp | BuiltinOp::Log |
+                   BuiltinOp::Pow | BuiltinOp::Sqrt | BuiltinOp::Tanh |
                    NodeType::Variable);
 
     // Pass all dataset variable hashes since the creator may produce any variable.
@@ -616,13 +616,13 @@ auto EvalCompiledJacobian(
 auto MakeSupportedPsetJit() -> PrimitiveSet {
     PrimitiveSet ps;
     ps.SetConfig(
-        NodeType::Add | NodeType::Mul | NodeType::Sub | NodeType::Div |
-        NodeType::Exp | NodeType::Log | NodeType::Logabs | NodeType::Log1p |
-        NodeType::Sin | NodeType::Cos | NodeType::Tan  |
-        NodeType::Asin | NodeType::Acos | NodeType::Atan |
-        NodeType::Sinh | NodeType::Cosh | NodeType::Tanh |
-        NodeType::Sqrt | NodeType::Cbrt | NodeType::Square |
-        NodeType::Pow  |
+        BuiltinOp::Add | BuiltinOp::Mul | BuiltinOp::Sub | BuiltinOp::Div |
+        BuiltinOp::Exp | BuiltinOp::Log | BuiltinOp::Logabs | BuiltinOp::Log1p |
+        BuiltinOp::Sin | BuiltinOp::Cos | BuiltinOp::Tan  |
+        BuiltinOp::Asin | BuiltinOp::Acos | BuiltinOp::Atan |
+        BuiltinOp::Sinh | BuiltinOp::Cosh | BuiltinOp::Tanh |
+        BuiltinOp::Sqrt | BuiltinOp::Cbrt | BuiltinOp::Square |
+        BuiltinOp::Pow  |
         NodeType::Constant
     );
     return ps;

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -98,7 +98,7 @@ TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators u
     auto child = mut(random, tree);
 
     CHECK(child.Length() == tree.Length());
-    CHECK(child[child.Length() - 1].Is<BuiltinOp::Sin>());
+    CHECK(child[child.Length() - 1].IsOp<BuiltinOp::Sin>());
     CHECK(child[0].HashValue == variableHash);
 }
 

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include "operon/core/dataset.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/core/variable.hpp"
@@ -22,11 +24,11 @@ TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
     auto const maxLength{100};
 
     PrimitiveSet grammar;
-    grammar.SetConfig(PrimitiveSet::Arithmetic | NodeType::Log | NodeType::Exp);
-    grammar.SetFrequency(Node(NodeType::Add).HashValue, 1);
-    grammar.SetFrequency(Node(NodeType::Mul).HashValue, 1);
-    grammar.SetFrequency(Node(NodeType::Sub).HashValue, 1);
-    grammar.SetFrequency(Node(NodeType::Div).HashValue, 1);
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
+    grammar.SetFrequency(Util::MakeOp<BuiltinOp::Add>().HashValue, 1);
+    grammar.SetFrequency(Util::MakeOp<BuiltinOp::Mul>().HashValue, 1);
+    grammar.SetFrequency(Util::MakeOp<BuiltinOp::Sub>().HashValue, 1);
+    grammar.SetFrequency(Util::MakeOp<BuiltinOp::Div>().HashValue, 1);
 
     BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
     UniformCoefficientInitializer cfi;
@@ -87,8 +89,7 @@ TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators u
     Node variable(NodeType::Variable);
     variable.HashValue = variable.CalculatedHashValue = variableHash;
 
-    Node sin(NodeType::Sin);
-    sin.Length = 1;
+    auto sin = Util::MakeOp<BuiltinOp::Sin>();
 
     Tree const tree({ variable, sin });
 
@@ -97,7 +98,7 @@ TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators u
     auto child = mut(random, tree);
 
     CHECK(child.Length() == tree.Length());
-    CHECK(child[child.Length() - 1].Type == NodeType::Sin);
+    CHECK(child[child.Length() - 1].Is<BuiltinOp::Sin>());
     CHECK(child[0].HashValue == variableHash);
 }
 

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -8,87 +8,40 @@
 
 namespace Operon::Test {
 
-TEST_CASE("BuiltinOp::X shares NodeType::X's ordinal and a built-in Node's HashValue", "[core]")
-{
-    // Node(NodeType) sets HashValue = static_cast<Hash>(Type), so for every
-    // built-in math op, Is<NodeType::X>() and Is<BuiltinOp::X>() must agree.
-    auto check = [](NodeType type, BuiltinOp op) {
-        Node const n(type);
-        CHECK(static_cast<Operon::Hash>(type) == static_cast<Operon::Hash>(op));
-        CHECK(n.HashValue == static_cast<Operon::Hash>(op));
-    };
+namespace {
+    // Local equivalent of Util::MakeOp (operon_test.hpp) - this file is
+    // deliberately self-contained (only includes node.hpp), so it doesn't
+    // pull in the shared test harness header just for this one helper.
+    template<BuiltinOp Op>
+    auto MakeOp() -> Node {
+        constexpr uint16_t arity = Node::IsUnaryOp<Op> ? 1 : 2;
+        return Node::Function(static_cast<Operon::Hash>(Op), arity);
+    }
+} // namespace
 
-    check(NodeType::Add, BuiltinOp::Add);
-    check(NodeType::Mul, BuiltinOp::Mul);
-    check(NodeType::Sub, BuiltinOp::Sub);
-    check(NodeType::Div, BuiltinOp::Div);
-    check(NodeType::Fmin, BuiltinOp::Fmin);
-    check(NodeType::Fmax, BuiltinOp::Fmax);
-    check(NodeType::Aq, BuiltinOp::Aq);
-    check(NodeType::Pow, BuiltinOp::Pow);
-    check(NodeType::Powabs, BuiltinOp::Powabs);
-    check(NodeType::Abs, BuiltinOp::Abs);
-    check(NodeType::Acos, BuiltinOp::Acos);
-    check(NodeType::Asin, BuiltinOp::Asin);
-    check(NodeType::Atan, BuiltinOp::Atan);
-    check(NodeType::Cbrt, BuiltinOp::Cbrt);
-    check(NodeType::Ceil, BuiltinOp::Ceil);
-    check(NodeType::Cos, BuiltinOp::Cos);
-    check(NodeType::Cosh, BuiltinOp::Cosh);
-    check(NodeType::Exp, BuiltinOp::Exp);
-    check(NodeType::Floor, BuiltinOp::Floor);
-    check(NodeType::Log, BuiltinOp::Log);
-    check(NodeType::Logabs, BuiltinOp::Logabs);
-    check(NodeType::Log1p, BuiltinOp::Log1p);
-    check(NodeType::Sin, BuiltinOp::Sin);
-    check(NodeType::Sinh, BuiltinOp::Sinh);
-    check(NodeType::Sqrt, BuiltinOp::Sqrt);
-    check(NodeType::Sqrtabs, BuiltinOp::Sqrtabs);
-    check(NodeType::Tan, BuiltinOp::Tan);
-    check(NodeType::Tanh, BuiltinOp::Tanh);
-    check(NodeType::Square, BuiltinOp::Square);
+TEST_CASE("Node::Is<BuiltinOp...>() distinguishes built-in ops by HashValue", "[core]")
+{
+    CHECK(MakeOp<BuiltinOp::Add>().Is<BuiltinOp::Add>());
+    CHECK_FALSE(MakeOp<BuiltinOp::Add>().Is<BuiltinOp::Mul>());
+    CHECK(MakeOp<BuiltinOp::Sin>().Is<BuiltinOp::Sin>());
+    CHECK((MakeOp<BuiltinOp::Fmax>().Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
+    CHECK_FALSE((MakeOp<BuiltinOp::Sub>().Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
 }
 
-TEST_CASE("Node::Is<BuiltinOp...>() agrees with Is<NodeType...>() for built-in nodes", "[core]")
+TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> classify every op consistently", "[core]")
 {
-    CHECK(Node(NodeType::Add).Is<BuiltinOp::Add>());
-    CHECK_FALSE(Node(NodeType::Add).Is<BuiltinOp::Mul>());
-    CHECK(Node(NodeType::Sin).Is<BuiltinOp::Sin>());
-    CHECK((Node(NodeType::Fmax).Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
-    CHECK_FALSE((Node(NodeType::Sub).Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
-}
-
-TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> agree with IsNary/IsBinary/IsUnary<NodeType>", "[core]")
-{
-    auto check = [](NodeType type, bool isNary, bool isBinary, bool isUnary) {
-        CHECK(Node(type).IsLeaf() == false); // sanity: all BuiltinOp-backed types are non-leaf
-        CHECK(isNary == (type == NodeType::Add || type == NodeType::Mul || type == NodeType::Sub
-            || type == NodeType::Div || type == NodeType::Fmin || type == NodeType::Fmax));
-        CHECK(isBinary == (type == NodeType::Aq || type == NodeType::Pow || type == NodeType::Powabs));
+    auto check = [](BuiltinOp op, bool isNary, bool isBinary, bool isUnary) {
+        CHECK(!Node::Function(static_cast<Operon::Hash>(op), 1).IsLeaf()); // sanity: every BuiltinOp-backed node is non-leaf
+        CHECK(isNary == (op == BuiltinOp::Add || op == BuiltinOp::Mul || op == BuiltinOp::Sub
+            || op == BuiltinOp::Div || op == BuiltinOp::Fmin || op == BuiltinOp::Fmax));
+        CHECK(isBinary == (op == BuiltinOp::Aq || op == BuiltinOp::Pow || op == BuiltinOp::Powabs));
         CHECK(isUnary == (!isNary && !isBinary));
+        CHECK((isNary ? 1 : 0) + (isBinary ? 1 : 0) + (isUnary ? 1 : 0) == 1); // mutually exclusive, exhaustive
     };
 
-    // NodeType-keyed boundaries (existing, unchanged)
-    check(NodeType::Add, Node::IsNary<NodeType::Add>, Node::IsBinary<NodeType::Add>, Node::IsUnary<NodeType::Add>);
-    check(NodeType::Aq, Node::IsNary<NodeType::Aq>, Node::IsBinary<NodeType::Aq>, Node::IsUnary<NodeType::Aq>);
-    check(NodeType::Sin, Node::IsNary<NodeType::Sin>, Node::IsBinary<NodeType::Sin>, Node::IsUnary<NodeType::Sin>);
-
-    // BuiltinOp-keyed boundaries must classify every op identically to their
-    // NodeType counterparts.
-    CHECK(Node::IsNaryOp<BuiltinOp::Add> == Node::IsNary<NodeType::Add>);
-    CHECK(Node::IsNaryOp<BuiltinOp::Mul> == Node::IsNary<NodeType::Mul>);
-    CHECK(Node::IsNaryOp<BuiltinOp::Sub> == Node::IsNary<NodeType::Sub>);
-    CHECK(Node::IsNaryOp<BuiltinOp::Div> == Node::IsNary<NodeType::Div>);
-    CHECK(Node::IsNaryOp<BuiltinOp::Fmin> == Node::IsNary<NodeType::Fmin>);
-    CHECK(Node::IsNaryOp<BuiltinOp::Fmax> == Node::IsNary<NodeType::Fmax>);
-
-    CHECK(Node::IsBinaryOp<BuiltinOp::Aq> == Node::IsBinary<NodeType::Aq>);
-    CHECK(Node::IsBinaryOp<BuiltinOp::Pow> == Node::IsBinary<NodeType::Pow>);
-    CHECK(Node::IsBinaryOp<BuiltinOp::Powabs> == Node::IsBinary<NodeType::Powabs>);
-
-    CHECK(Node::IsUnaryOp<BuiltinOp::Abs> == Node::IsUnary<NodeType::Abs>);
-    CHECK(Node::IsUnaryOp<BuiltinOp::Sin> == Node::IsUnary<NodeType::Sin>);
-    CHECK(Node::IsUnaryOp<BuiltinOp::Square> == Node::IsUnary<NodeType::Square>);
+    check(BuiltinOp::Add, Node::IsNaryOp<BuiltinOp::Add>, Node::IsBinaryOp<BuiltinOp::Add>, Node::IsUnaryOp<BuiltinOp::Add>);
+    check(BuiltinOp::Aq, Node::IsNaryOp<BuiltinOp::Aq>, Node::IsBinaryOp<BuiltinOp::Aq>, Node::IsUnaryOp<BuiltinOp::Aq>);
+    check(BuiltinOp::Sin, Node::IsNaryOp<BuiltinOp::Sin>, Node::IsBinaryOp<BuiltinOp::Sin>, Node::IsUnaryOp<BuiltinOp::Sin>);
 
     // Boundary values specifically (most likely place for an off-by-one).
     static_assert(Node::IsNaryOp<BuiltinOp::Fmax>);
@@ -102,58 +55,60 @@ TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> agree with IsNary/IsBinary/I
 
 TEST_CASE("Node::Is*() single-op convenience methods are re-pointed correctly", "[core]")
 {
-    // Each of these now compares HashValue via Is<BuiltinOp::X>() instead of
-    // Type via Is<NodeType::X>() (node.hpp), but must still report true only
-    // for the one op it names and false for every other built-in op.
-    CHECK(Node(NodeType::Add).IsAddition());
-    CHECK_FALSE(Node(NodeType::Mul).IsAddition());
-    CHECK(Node(NodeType::Sub).IsSubtraction());
-    CHECK_FALSE(Node(NodeType::Add).IsSubtraction());
-    CHECK(Node(NodeType::Mul).IsMultiplication());
-    CHECK_FALSE(Node(NodeType::Div).IsMultiplication());
-    CHECK(Node(NodeType::Div).IsDivision());
-    CHECK_FALSE(Node(NodeType::Mul).IsDivision());
-    CHECK(Node(NodeType::Aq).IsAq());
-    CHECK_FALSE(Node(NodeType::Pow).IsAq());
-    CHECK(Node(NodeType::Pow).IsPow());
-    CHECK_FALSE(Node(NodeType::Powabs).IsPow());
-    CHECK(Node(NodeType::Powabs).IsPowabs());
-    CHECK_FALSE(Node(NodeType::Pow).IsPowabs());
-    CHECK(Node(NodeType::Exp).IsExp());
-    CHECK_FALSE(Node(NodeType::Log).IsExp());
-    CHECK(Node(NodeType::Log).IsLog());
-    CHECK_FALSE(Node(NodeType::Exp).IsLog());
-    CHECK(Node(NodeType::Sin).IsSin());
-    CHECK_FALSE(Node(NodeType::Cos).IsSin());
-    CHECK(Node(NodeType::Cos).IsCos());
-    CHECK_FALSE(Node(NodeType::Sin).IsCos());
-    CHECK(Node(NodeType::Tan).IsTan());
-    CHECK_FALSE(Node(NodeType::Tanh).IsTan());
-    CHECK(Node(NodeType::Tanh).IsTanh());
-    CHECK_FALSE(Node(NodeType::Tan).IsTanh());
-    CHECK(Node(NodeType::Sqrt).IsSquareRoot());
-    CHECK_FALSE(Node(NodeType::Cbrt).IsSquareRoot());
-    CHECK(Node(NodeType::Cbrt).IsCubeRoot());
-    CHECK_FALSE(Node(NodeType::Sqrt).IsCubeRoot());
-    CHECK(Node(NodeType::Square).IsSquare());
-    CHECK_FALSE(Node(NodeType::Pow).IsSquare());
+    // Each of these compares HashValue via Is<BuiltinOp::X>() (node.hpp), so
+    // must still report true only for the one op it names and false for
+    // every other built-in op.
+    CHECK(MakeOp<BuiltinOp::Add>().IsAddition());
+    CHECK_FALSE(MakeOp<BuiltinOp::Mul>().IsAddition());
+    CHECK(MakeOp<BuiltinOp::Sub>().IsSubtraction());
+    CHECK_FALSE(MakeOp<BuiltinOp::Add>().IsSubtraction());
+    CHECK(MakeOp<BuiltinOp::Mul>().IsMultiplication());
+    CHECK_FALSE(MakeOp<BuiltinOp::Div>().IsMultiplication());
+    CHECK(MakeOp<BuiltinOp::Div>().IsDivision());
+    CHECK_FALSE(MakeOp<BuiltinOp::Mul>().IsDivision());
+    CHECK(MakeOp<BuiltinOp::Aq>().IsAq());
+    CHECK_FALSE(MakeOp<BuiltinOp::Pow>().IsAq());
+    CHECK(MakeOp<BuiltinOp::Pow>().IsPow());
+    CHECK_FALSE(MakeOp<BuiltinOp::Powabs>().IsPow());
+    CHECK(MakeOp<BuiltinOp::Powabs>().IsPowabs());
+    CHECK_FALSE(MakeOp<BuiltinOp::Pow>().IsPowabs());
+    CHECK(MakeOp<BuiltinOp::Exp>().IsExp());
+    CHECK_FALSE(MakeOp<BuiltinOp::Log>().IsExp());
+    CHECK(MakeOp<BuiltinOp::Log>().IsLog());
+    CHECK_FALSE(MakeOp<BuiltinOp::Exp>().IsLog());
+    CHECK(MakeOp<BuiltinOp::Sin>().IsSin());
+    CHECK_FALSE(MakeOp<BuiltinOp::Cos>().IsSin());
+    CHECK(MakeOp<BuiltinOp::Cos>().IsCos());
+    CHECK_FALSE(MakeOp<BuiltinOp::Sin>().IsCos());
+    CHECK(MakeOp<BuiltinOp::Tan>().IsTan());
+    CHECK_FALSE(MakeOp<BuiltinOp::Tanh>().IsTan());
+    CHECK(MakeOp<BuiltinOp::Tanh>().IsTanh());
+    CHECK_FALSE(MakeOp<BuiltinOp::Tan>().IsTanh());
+    CHECK(MakeOp<BuiltinOp::Sqrt>().IsSquareRoot());
+    CHECK_FALSE(MakeOp<BuiltinOp::Cbrt>().IsSquareRoot());
+    CHECK(MakeOp<BuiltinOp::Cbrt>().IsCubeRoot());
+    CHECK_FALSE(MakeOp<BuiltinOp::Sqrt>().IsCubeRoot());
+    CHECK(MakeOp<BuiltinOp::Square>().IsSquare());
+    CHECK_FALSE(MakeOp<BuiltinOp::Pow>().IsSquare());
 }
 
 TEST_CASE("Node::IsCommutative() agrees for every built-in op", "[core]")
 {
-    for (auto type : { NodeType::Add, NodeType::Mul, NodeType::Fmin, NodeType::Fmax }) {
-        CHECK(Node(type).IsCommutative());
+    for (auto op : { BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax }) {
+        CHECK(Node::Function(static_cast<Operon::Hash>(op), 2).IsCommutative());
     }
-    for (auto type : { NodeType::Sub, NodeType::Div, NodeType::Aq, NodeType::Pow, NodeType::Powabs,
-                        NodeType::Sin, NodeType::Cos, NodeType::Square }) {
-        CHECK_FALSE(Node(type).IsCommutative());
+    for (auto op : { BuiltinOp::Sub, BuiltinOp::Div, BuiltinOp::Aq, BuiltinOp::Pow, BuiltinOp::Powabs }) {
+        CHECK_FALSE(Node::Function(static_cast<Operon::Hash>(op), 2).IsCommutative());
+    }
+    for (auto op : { BuiltinOp::Sin, BuiltinOp::Cos, BuiltinOp::Square }) {
+        CHECK_FALSE(Node::Function(static_cast<Operon::Hash>(op), 1).IsCommutative());
     }
 }
 
 TEST_CASE("Node::Function() sets Type/HashValue/Arity/Length/Optimize consistently", "[core]")
 {
     auto n = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 3);
-    CHECK(n.Type == NodeType::Dynamic);
+    CHECK(n.Type == NodeType::Function);
     CHECK(n.HashValue == static_cast<Operon::Hash>(BuiltinOp::Add));
     CHECK(n.Arity == 3);
     CHECK(n.Length == 3);

--- a/test/source/implementation/node.cpp
+++ b/test/source/implementation/node.cpp
@@ -19,13 +19,13 @@ namespace {
     }
 } // namespace
 
-TEST_CASE("Node::Is<BuiltinOp...>() distinguishes built-in ops by HashValue", "[core]")
+TEST_CASE("Node::IsOp<BuiltinOp...>() distinguishes built-in ops by HashValue", "[core]")
 {
-    CHECK(MakeOp<BuiltinOp::Add>().Is<BuiltinOp::Add>());
-    CHECK_FALSE(MakeOp<BuiltinOp::Add>().Is<BuiltinOp::Mul>());
-    CHECK(MakeOp<BuiltinOp::Sin>().Is<BuiltinOp::Sin>());
-    CHECK((MakeOp<BuiltinOp::Fmax>().Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
-    CHECK_FALSE((MakeOp<BuiltinOp::Sub>().Is<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
+    CHECK(MakeOp<BuiltinOp::Add>().IsOp<BuiltinOp::Add>());
+    CHECK_FALSE(MakeOp<BuiltinOp::Add>().IsOp<BuiltinOp::Mul>());
+    CHECK(MakeOp<BuiltinOp::Sin>().IsOp<BuiltinOp::Sin>());
+    CHECK((MakeOp<BuiltinOp::Fmax>().IsOp<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
+    CHECK_FALSE((MakeOp<BuiltinOp::Sub>().IsOp<BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Fmin, BuiltinOp::Fmax>()));
 }
 
 TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> classify every op consistently", "[core]")
@@ -55,7 +55,7 @@ TEST_CASE("IsNaryOp/IsBinaryOp/IsUnaryOp<BuiltinOp> classify every op consistent
 
 TEST_CASE("Node::Is*() single-op convenience methods are re-pointed correctly", "[core]")
 {
-    // Each of these compares HashValue via Is<BuiltinOp::X>() (node.hpp), so
+    // Each of these compares HashValue via IsOp<BuiltinOp::X>() (node.hpp), so
     // must still report true only for the one op it names and false for
     // every other built-in op.
     CHECK(MakeOp<BuiltinOp::Add>().IsAddition());

--- a/test/source/implementation/node_impact.cpp
+++ b/test/source/implementation/node_impact.cpp
@@ -3,6 +3,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include "operon/analyzers/node_impact.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
@@ -36,7 +38,7 @@ TEST_CASE("NodeImpact - irrelevant subtree has ~zero impact, relevant subtree do
     // an irrelevant constant, so the root's impact should be indistinguishable
     // from the (x0 + x1) subtree's impact, while the Constant{0} leaf's own
     // impact should be ~zero (replacing "0" by its own mean, "0", is a no-op).
-    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add), Node::Constant(0.0), Node(NodeType::Add) }).UpdateNodes();
+    Tree const tree = Tree({ nX0, nX1, Util::MakeOp<BuiltinOp::Add>(), Node::Constant(0.0), Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     auto const range = Operon::Range(0, ds.Rows());
     auto const impact = Operon::NodeImpact(tree, ds, target, range);
@@ -61,7 +63,7 @@ TEST_CASE("NodeImpact - range-less overload matches an explicit whole-dataset ra
 
     Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
     Node nX1(NodeType::Variable); nX1.HashValue = x1.Hash;
-    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add) }).UpdateNodes();
+    Tree const tree = Tree({ nX0, nX1, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     auto const impactExplicit = Operon::NodeImpact(tree, ds, target, Operon::Range(0, ds.Rows()));
     auto const impactDefault = Operon::NodeImpact(tree, ds, target);
@@ -91,7 +93,7 @@ TEST_CASE("NodeImpact - a non-zero-start range aligns predictions against the ma
 
     Node nX0(NodeType::Variable); nX0.HashValue = x0Var.Hash;
     Node nX1(NodeType::Variable); nX1.HashValue = x1Var.Hash;
-    Tree const tree = Tree({ nX0, nX1, Node(NodeType::Add) }).UpdateNodes();
+    Tree const tree = Tree({ nX0, nX1, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     auto const impactFull = Operon::NodeImpact(tree, ds, target, Operon::Range(0, ds.Rows()));
     auto const impactPrefixed = Operon::NodeImpact(tree, prefixed, target, Operon::Range(2, prefixed.Rows()));
@@ -116,7 +118,7 @@ TEST_CASE("NodeImpact - duplicate variable occurrences are scored independently"
 
     Node nX0a(NodeType::Variable); nX0a.HashValue = x0Var.Hash;
     Node nX0b(NodeType::Variable); nX0b.HashValue = x0Var.Hash;
-    Tree const tree = Tree({ nX0a, nX0b, Node(NodeType::Mul) }).UpdateNodes();
+    Tree const tree = Tree({ nX0a, nX0b, Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     auto const range = Operon::Range(0, ds.Rows());
     auto const impact = Operon::NodeImpact(tree, ds, target, range);
@@ -136,7 +138,7 @@ TEST_CASE("NodeImpact - trees with Ref nodes are unsupported", "[analyzers][node
     Node nX0(NodeType::Variable); nX0.HashValue = x0.Hash;
 
     // x0 * Ref(x0) - structural sharing via a backward Ref.
-    Tree const tree = Tree({ nX0, Node::Ref(0), Node(NodeType::Mul) }).UpdateNodes();
+    Tree const tree = Tree({ nX0, Node::Ref(0), Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     auto const range = Operon::Range(0, ds.Rows());
     auto const impact = Operon::NodeImpact(tree, ds, target, range);

--- a/test/source/implementation/pappus_backend.cpp
+++ b/test/source/implementation/pappus_backend.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Interval backend: arithmetic", "[pappus][interval]")
     };
 
     SECTION("X1 + X2 -> [4, 6]") {
-        auto eval = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Add)});
+        auto eval = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Add>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, 4.0, 6.0, 1e-5));
     }
@@ -107,26 +107,26 @@ TEST_CASE("Interval backend: arithmetic", "[pappus][interval]")
     SECTION("X1 - X2 -> [-3, -1]") {
         // operon lays out binary-op children with the semantic LEFT operand at
         // the higher index (rightmost); `Tree::Indices` yields rightmost-first.
-        auto eval = make({Var(X2), Var(X1), Operon::Node(Operon::NodeType::Sub)});
+        auto eval = make({Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Sub>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, -3.0, -1.0, 1e-5));
     }
 
     SECTION("X1 * X2 -> [3, 8]") {
-        auto eval = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Mul)});
+        auto eval = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Mul>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, 3.0, 8.0, 1e-5));
     }
 
     SECTION("X1 / X2 -> [0.25, 0.6667]") {
-        auto eval = make({Var(X2), Var(X1), Operon::Node(Operon::NodeType::Div)});
+        auto eval = make({Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Div>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(r.inf() <= 0.25 + 1e-5);
         REQUIRE(r.sup() + 1e-5 >= 2.0/3.0);
     }
 
     SECTION("neg(X1) -> [-2, -1]") {
-        auto node = Operon::Node(Operon::NodeType::Sub);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Sub>();
         node.Arity = 1;
         auto eval = make({Var(X1), node});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
@@ -134,7 +134,7 @@ TEST_CASE("Interval backend: arithmetic", "[pappus][interval]")
     }
 
     SECTION("inv(X1) -> [0.5, 1]") {
-        auto node = Operon::Node(Operon::NodeType::Div);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Div>();
         node.Arity = 1;
         auto eval = make({Var(X1), node});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
@@ -147,8 +147,8 @@ TEST_CASE("Interval backend: unary transcendentals", "[pappus][interval]")
     constexpr Operon::Hash X1{1};
     auto d = Domains();
 
-    auto make = [&](IE::Domain dom, Operon::NodeType op) -> std::pair<IE, IE::Interval> {
-        static Operon::Tree t; t = Operon::Tree({Var(X1), Operon::Node(op)}).UpdateNodes(); // NOLINT
+    auto make = [&](IE::Domain dom, Operon::BuiltinOp op) -> std::pair<IE, IE::Interval> {
+        static Operon::Tree t; t = Operon::Tree({Var(X1), Operon::Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes(); // NOLINT
         auto dm = Domains();
         dm[X1] = {S{dom.first}, S{dom.second}};
         IE eval(&t, std::move(dm));
@@ -156,23 +156,23 @@ TEST_CASE("Interval backend: unary transcendentals", "[pappus][interval]")
     };
 
     SECTION("square([-1, 2]) -> [0, 4]") {
-        auto [eval, r] = make({-1, 2}, Operon::NodeType::Square);
+        auto [eval, r] = make({-1, 2}, Operon::BuiltinOp::Square);
         REQUIRE(Contains(r, 0.0, 4.0, 1e-4));
     }
 
     SECTION("sqrt([1, 4]) -> [1, 2]") {
-        auto [eval, r] = make({1, 4}, Operon::NodeType::Sqrt);
+        auto [eval, r] = make({1, 4}, Operon::BuiltinOp::Sqrt);
         REQUIRE(Contains(r, 1.0, 2.0, 1e-4));
     }
 
     SECTION("exp([0, 1]) -> [1, e]") {
-        auto [eval, r] = make({0, 1}, Operon::NodeType::Exp);
+        auto [eval, r] = make({0, 1}, Operon::BuiltinOp::Exp);
         REQUIRE(r.inf() <= 1.0 + 1e-4);
         REQUIRE(r.sup() + 1e-3 >= std::exp(1.0));
     }
 
     SECTION("log([1, e]) -> [0, 1]") {
-        auto [eval, r] = make({1, std::exp(1.0)}, Operon::NodeType::Log);
+        auto [eval, r] = make({1, std::exp(1.0)}, Operon::BuiltinOp::Log);
         REQUIRE(r.inf() <= 0.0 + 1e-4);
         REQUIRE(r.sup() + 1e-3 >= 1.0);
     }
@@ -183,8 +183,8 @@ TEST_CASE("Interval backend: nested tree", "[pappus][interval]")
     constexpr Operon::Hash X1{1}, X2{2}, X3{3};
     // (X1 + X2) * X3
     Operon::Vector<Operon::Node> ns{
-        Var(X1), Var(X2), Operon::Node(Operon::NodeType::Add),
-        Var(X3), Operon::Node(Operon::NodeType::Mul)};
+        Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Add>(),
+        Var(X3), Util::MakeOp<Operon::BuiltinOp::Mul>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
 
     auto d = Domains();
@@ -201,8 +201,8 @@ TEST_CASE("Interval backend: abs and composable ops", "[pappus][interval]")
 {
     constexpr Operon::Hash X1{1};
 
-    auto make = [&](IE::Domain dom, Operon::NodeType op) -> std::pair<IE, IE::Interval> {
-        static Operon::Tree t; t = Operon::Tree({Var(X1), Operon::Node(op)}).UpdateNodes(); // NOLINT
+    auto make = [&](IE::Domain dom, Operon::BuiltinOp op) -> std::pair<IE, IE::Interval> {
+        static Operon::Tree t; t = Operon::Tree({Var(X1), Operon::Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes(); // NOLINT
         auto dm = Domains();
         dm[X1] = {S{dom.first}, S{dom.second}};
         IE eval(&t, std::move(dm));
@@ -210,23 +210,23 @@ TEST_CASE("Interval backend: abs and composable ops", "[pappus][interval]")
     };
 
     SECTION("abs([-3, -1]) -> [1, 3]") {
-        auto [eval, r] = make({-3, -1}, Operon::NodeType::Abs);
+        auto [eval, r] = make({-3, -1}, Operon::BuiltinOp::Abs);
         REQUIRE(Contains(r, 1.0, 3.0, 1e-4));
     }
     SECTION("abs([-1, 2]) -> [0, 2]") {
-        auto [eval, r] = make({-1, 2}, Operon::NodeType::Abs);
+        auto [eval, r] = make({-1, 2}, Operon::BuiltinOp::Abs);
         REQUIRE(Contains(r, 0.0, 2.0, 1e-4));
     }
     SECTION("abs([2, 5]) -> [2, 5]") {
-        auto [eval, r] = make({2, 5}, Operon::NodeType::Abs);
+        auto [eval, r] = make({2, 5}, Operon::BuiltinOp::Abs);
         REQUIRE(Contains(r, 2.0, 5.0, 1e-4));
     }
     SECTION("sqrtabs([-1, 4]) -> [0, 2]") {
-        auto [eval, r] = make({-1, 4}, Operon::NodeType::Sqrtabs);
+        auto [eval, r] = make({-1, 4}, Operon::BuiltinOp::Sqrtabs);
         REQUIRE(Contains(r, 0.0, 2.0, 1e-3));
     }
     SECTION("logabs([-3, -1]) -> [0, log(3)]") {
-        auto [eval, r] = make({-3, -1}, Operon::NodeType::Logabs);
+        auto [eval, r] = make({-3, -1}, Operon::BuiltinOp::Logabs);
         REQUIRE(r.inf() <= 0.0 + 1e-4);
         REQUIRE(r.sup() + 1e-3 >= std::log(3.0));
     }
@@ -247,12 +247,12 @@ TEST_CASE("Interval backend: fmin/fmax", "[pappus][interval]")
 
     SECTION("fmin(X1, X2) -> [1, 3]") {
         // min([1,3], [2,4]) = [min(1,2), min(3,4)] = [1, 3]
-        auto r = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Fmin)});
+        auto r = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Fmin>()});
         REQUIRE(Contains(r, 1.0, 3.0, 1e-5));
     }
     SECTION("fmax(X1, X2) -> [2, 4]") {
         // max([1,3], [2,4]) = [max(1,2), max(3,4)] = [2, 4]
-        auto r = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Fmax)});
+        auto r = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Fmax>()});
         REQUIRE(Contains(r, 2.0, 4.0, 1e-5));
     }
 }
@@ -264,7 +264,7 @@ TEST_CASE("Interval backend: aq", "[pappus][interval]")
     // X1 in [3, 6], X2 in [0, 2] -> 1+X2^2 in [1, 5] -> sqrt in [1, sqrt(5)]
     // -> aq in [3/sqrt(5), 6/1] = [1.34, 6]
     Operon::Vector<Operon::Node> ns{
-        Var(X2), Var(X1), Operon::Node(Operon::NodeType::Aq)};
+        Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Aq>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
     auto d = Domains();
     d[X1] = {S{3}, S{6}};
@@ -285,7 +285,7 @@ TEST_CASE("Affine backend: aq", "[pappus][affine]")
     // (interval [-1, 4] instead of [0, 4]), making 1+X2^2 contain 0 and
     // triggering inv() to throw. This is a known affine arithmetic limitation.
     Operon::Vector<Operon::Node> ns{
-        Var(X2), Var(X1), Operon::Node(Operon::NodeType::Aq)};
+        Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Aq>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
     auto d = Domains();
     d[X1] = {S{3}, S{6}};
@@ -303,7 +303,7 @@ TEST_CASE("Affine backend: abs (non-zero-crossing)", "[pappus][affine]")
     constexpr Operon::Hash X1{1};
 
     SECTION("abs of positive domain -> identity") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Abs)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Abs>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{2}, S{5}};
         AE eval(&tree, std::move(d));
@@ -312,7 +312,7 @@ TEST_CASE("Affine backend: abs (non-zero-crossing)", "[pappus][affine]")
     }
 
     SECTION("abs of negative domain -> negation") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Abs)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Abs>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-5}, S{-2}};
         AE eval(&tree, std::move(d));
@@ -322,7 +322,7 @@ TEST_CASE("Affine backend: abs (non-zero-crossing)", "[pappus][affine]")
 
     SECTION("abs of zero-crossing domain -> sound enclosure") {
         // Now supported via pappus affine abs (Chebyshev V-shape).
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Abs)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Abs>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-1}, S{2}};
         AE eval(&tree, std::move(d));
@@ -336,8 +336,8 @@ TEST_CASE("Interval backend: cbrt, log1p, floor, ceil", "[pappus][interval]")
 {
     constexpr Operon::Hash X1{1};
 
-    auto make = [&](IE::Domain dom, Operon::NodeType op) -> IE::Interval {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(op)}).UpdateNodes();
+    auto make = [&](IE::Domain dom, Operon::BuiltinOp op) -> IE::Interval {
+        auto tree = Operon::Tree({Var(X1), Operon::Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes();
         auto dm = Domains();
         dm[X1] = {S{dom.first}, S{dom.second}};
         IE eval(&tree, std::move(dm));
@@ -345,24 +345,24 @@ TEST_CASE("Interval backend: cbrt, log1p, floor, ceil", "[pappus][interval]")
     };
 
     SECTION("cbrt([-1, 8]) -> [-1, 2]") {
-        auto r = make({-1, 8}, Operon::NodeType::Cbrt);
+        auto r = make({-1, 8}, Operon::BuiltinOp::Cbrt);
         REQUIRE(Contains(r, -1.0, 2.0, 1e-4));
     }
     SECTION("cbrt([1, 27]) -> [1, 3]") {
-        auto r = make({1, 27}, Operon::NodeType::Cbrt);
+        auto r = make({1, 27}, Operon::BuiltinOp::Cbrt);
         REQUIRE(Contains(r, 1.0, 3.0, 1e-4));
     }
     SECTION("log1p([0, e-1]) -> [0, 1]") {
-        auto r = make({0, std::exp(1.0) - 1.0}, Operon::NodeType::Log1p);
+        auto r = make({0, std::exp(1.0) - 1.0}, Operon::BuiltinOp::Log1p);
         REQUIRE(r.inf() <= 0.0 + 1e-4);
         REQUIRE(r.sup() + 1e-3 >= 1.0);
     }
     SECTION("floor([-1.5, 8.7]) -> [-2, 8]") {
-        auto r = make({-1.5, 8.7}, Operon::NodeType::Floor);
+        auto r = make({-1.5, 8.7}, Operon::BuiltinOp::Floor);
         REQUIRE(Contains(r, -2.0, 8.0, 1e-5));
     }
     SECTION("ceil([-1.5, 8.7]) -> [-1, 9]") {
-        auto r = make({-1.5, 8.7}, Operon::NodeType::Ceil);
+        auto r = make({-1.5, 8.7}, Operon::BuiltinOp::Ceil);
         REQUIRE(Contains(r, -1.0, 9.0, 1e-5));
     }
 }
@@ -372,7 +372,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
     constexpr Operon::Hash X1{1}, X2{2};
 
     SECTION("cbrt([1, 27]) -> contains [1, 3]") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Cbrt)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Cbrt>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{1}, S{27}};
         AE eval(&tree, std::move(d));
@@ -380,7 +380,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
         REQUIRE(Contains(r, 1.0, 3.0, 1e-3));
     }
     SECTION("log1p([0, 1]) -> contains [0, log(2)]") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Log1p)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Log1p>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{0}, S{1}};
         AE eval(&tree, std::move(d));
@@ -390,7 +390,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
         REQUIRE(iv.sup() + 1e-3 >= std::log(2.0));
     }
     SECTION("fmin([1,3], [2,4]) -> contains [1, 3]") {
-        auto tree = Operon::Tree({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Fmin)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Fmin>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{1}, S{3}};
         d[X2] = {S{2}, S{4}};
@@ -399,7 +399,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
         REQUIRE(Contains(r, 1.0, 3.0, 1e-3));
     }
     SECTION("fmax([1,3], [2,4]) -> contains [2, 4]") {
-        auto tree = Operon::Tree({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Fmax)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Fmax>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{1}, S{3}};
         d[X2] = {S{2}, S{4}};
@@ -408,7 +408,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
         REQUIRE(Contains(r, 2.0, 4.0, 1e-3));
     }
     SECTION("floor([-1.5, 8.7]) -> contains [-2, 8]") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Floor)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Floor>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-1.5}, S{8.7}};
         AE eval(&tree, std::move(d));
@@ -416,7 +416,7 @@ TEST_CASE("Affine backend: cbrt, log1p, floor, ceil, fmin, fmax", "[pappus][affi
         REQUIRE(Contains(r, -2.0, 8.0, 1e-3));
     }
     SECTION("ceil([-1.5, 8.7]) -> contains [-1, 9]") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Ceil)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Ceil>()}).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-1.5}, S{8.7}};
         AE eval(&tree, std::move(d));
@@ -446,19 +446,19 @@ TEST_CASE("Affine backend: arithmetic", "[pappus][affine]")
     };
 
     SECTION("X1 + X2 (exact in affine) -> [4, 6]") {
-        auto eval = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Add)});
+        auto eval = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Add>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, 4.0, 6.0, 1e-4));
     }
 
     SECTION("X1 * X2 (affine enclosure contains [3, 8])") {
-        auto eval = make({Var(X1), Var(X2), Operon::Node(Operon::NodeType::Mul)});
+        auto eval = make({Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Mul>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, 3.0, 8.0, 1e-3));
     }
 
     SECTION("X1 - X2 -> contains [-3, -1]") {
-        auto eval = make({Var(X2), Var(X1), Operon::Node(Operon::NodeType::Sub)});
+        auto eval = make({Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Sub>()});
         auto const r = eval.Evaluate(eval.GetTree()->GetCoefficients());
         REQUIRE(Contains(r, -3.0, -1.0, 1e-4));
     }
@@ -470,8 +470,8 @@ TEST_CASE("Affine backend: shared context", "[pappus][affine]")
     // no mixed-context exception should arise.
     constexpr Operon::Hash X1{1}, X2{2};
     Operon::Vector<Operon::Node> ns{
-        Var(X1), Var(X2), Operon::Node(Operon::NodeType::Add),
-        Operon::Node(Operon::NodeType::Exp)};
+        Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Add>(),
+        Util::MakeOp<Operon::BuiltinOp::Exp>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
     auto d = Domains();
     d[X1] = {S{0}, S{1}};
@@ -509,7 +509,7 @@ TEST_CASE("Affine backend: no index reuse across evaluations", "[pappus][affine]
 TEST_CASE("Affine backend: inv over zero-containing domain throws", "[pappus][affine]")
 {
     constexpr Operon::Hash X1{1};
-    auto node = Operon::Node(Operon::NodeType::Div);
+    auto node = Util::MakeOp<Operon::BuiltinOp::Div>();
     node.Arity = 1;
     auto tree = Operon::Tree({Var(X1), node}).UpdateNodes();
     auto d = Domains();
@@ -549,7 +549,7 @@ TEST_CASE("Interval backend: empty interval propagation", "[pappus][interval]")
     constexpr Operon::Hash X1{1};
 
     SECTION("log of negative domain -> empty") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Log)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Log>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{-3}, S{-1}};
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -559,7 +559,7 @@ TEST_CASE("Interval backend: empty interval propagation", "[pappus][interval]")
     }
 
     SECTION("sqrt of negative domain -> empty") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Sqrt)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Sqrt>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{-4}, S{-1}};
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -569,8 +569,8 @@ TEST_CASE("Interval backend: empty interval propagation", "[pappus][interval]")
     SECTION("empty propagates through exp") {
         // exp(log(x)) for x in [-3, -1]: log returns empty, exp(empty) = empty
         Operon::Vector<Operon::Node> ns{
-            Var(X1), Operon::Node(Operon::NodeType::Log),
-            Operon::Node(Operon::NodeType::Exp)};
+            Var(X1), Util::MakeOp<Operon::BuiltinOp::Log>(),
+            Util::MakeOp<Operon::BuiltinOp::Exp>()};
         auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
         auto d = Domains(); d[X1] = {S{-3}, S{-1}};
         IE eval(&tree, std::move(d));
@@ -579,7 +579,7 @@ TEST_CASE("Interval backend: empty interval propagation", "[pappus][interval]")
     }
 
     SECTION("log1p of domain below -1 -> empty") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Log1p)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Log1p>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{-3}, S{-2}};
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -592,7 +592,7 @@ TEST_CASE("Interval backend: infinite bounds", "[pappus][interval]")
     constexpr Operon::Hash X1{1};
 
     SECTION("inv of zero-containing domain -> infinite") {
-        auto node = Operon::Node(Operon::NodeType::Div);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Div>();
         node.Arity = 1;
         auto tree = Operon::Tree({Var(X1), node}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{-1}, S{1}}; // contains zero
@@ -605,7 +605,7 @@ TEST_CASE("Interval backend: infinite bounds", "[pappus][interval]")
 
     SECTION("exp of unbounded domain -> unbounded upper") {
         // exp([0, inf]) = [1, inf]
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Exp)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Exp>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{0}, S{std::numeric_limits<S>::infinity()}};
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -619,7 +619,7 @@ TEST_CASE("Interval backend: single-point (degenerate) intervals", "[pappus][int
     constexpr Operon::Hash X1{1};
 
     SECTION("constant domain [c, c]") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Square)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Square>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{2}, S{2}}; // point interval
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -628,7 +628,7 @@ TEST_CASE("Interval backend: single-point (degenerate) intervals", "[pappus][int
     }
 
     SECTION("sqrt of point interval") {
-        auto tree = Operon::Tree({Var(X1), Operon::Node(Operon::NodeType::Sqrt)}).UpdateNodes();
+        auto tree = Operon::Tree({Var(X1), Util::MakeOp<Operon::BuiltinOp::Sqrt>()}).UpdateNodes();
         auto d = Domains(); d[X1] = {S{9}, S{9}};
         IE eval(&tree, std::move(d));
         auto const r = eval.Evaluate(tree.GetCoefficients());
@@ -644,7 +644,7 @@ TEST_CASE("Interval backend: n-ary Fmin/Fmax with arity > 2", "[pappus][interval
     constexpr Operon::Hash X1{1}, X2{2}, X3{3};
 
     SECTION("ternary fmin") {
-        auto node = Operon::Node(Operon::NodeType::Fmin);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Fmin>();
         node.Arity = 3;
         auto tree = Operon::Tree({Var(X1), Var(X2), Var(X3), node}).UpdateNodes();
         auto d = Domains();
@@ -658,7 +658,7 @@ TEST_CASE("Interval backend: n-ary Fmin/Fmax with arity > 2", "[pappus][interval
     }
 
     SECTION("ternary fmax") {
-        auto node = Operon::Node(Operon::NodeType::Fmax);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Fmax>();
         node.Arity = 3;
         auto tree = Operon::Tree({Var(X1), Var(X2), Var(X3), node}).UpdateNodes();
         auto d = Domains();
@@ -679,7 +679,7 @@ TEST_CASE("Affine backend: n-ary Fmin/Fmax with arity > 2", "[pappus][affine]")
     constexpr Operon::Hash X1{1}, X2{2}, X3{3};
 
     SECTION("ternary fmin") {
-        auto node = Operon::Node(Operon::NodeType::Fmin);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Fmin>();
         node.Arity = 3;
         auto tree = Operon::Tree({Var(X1), Var(X2), Var(X3), node}).UpdateNodes();
         auto d = Domains();
@@ -693,7 +693,7 @@ TEST_CASE("Affine backend: n-ary Fmin/Fmax with arity > 2", "[pappus][affine]")
     }
 
     SECTION("ternary fmax") {
-        auto node = Operon::Node(Operon::NodeType::Fmax);
+        auto node = Util::MakeOp<Operon::BuiltinOp::Fmax>();
         node.Arity = 3;
         auto tree = Operon::Tree({Var(X1), Var(X2), Var(X3), node}).UpdateNodes();
         auto d = Domains();
@@ -714,9 +714,9 @@ TEST_CASE("Affine backend: max_terms condensation", "[pappus][affine]")
     constexpr Operon::Hash X1{1}, X2{2};
     // A tree that generates many noise terms: X1 * X2 * X1 * X2 (via Mul chain)
     Operon::Vector<Operon::Node> ns{
-        Var(X1), Var(X2), Operon::Node(Operon::NodeType::Mul),
-        Var(X1), Operon::Node(Operon::NodeType::Mul),
-        Var(X2), Operon::Node(Operon::NodeType::Mul)};
+        Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Mul>(),
+        Var(X1), Util::MakeOp<Operon::BuiltinOp::Mul>(),
+        Var(X2), Util::MakeOp<Operon::BuiltinOp::Mul>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
     auto d = Domains();
     d[X1] = {S{1}, S{2}};
@@ -754,7 +754,7 @@ TEST_CASE("Interval backend: pow/powabs child ordering", "[pappus][interval]")
 
     SECTION("pow(base=[2,3], exp=[1,2]) -> contains [2, 9]") {
         // {X2, X1, Pow}: X1 is base (j=i-1), X2 is exponent (k).
-        Operon::Vector<Operon::Node> ns{Var(X2), Var(X1), Operon::Node(Operon::NodeType::Pow)};
+        Operon::Vector<Operon::Node> ns{Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Pow>()};
         auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{2}, S{3}};  // base
@@ -768,7 +768,7 @@ TEST_CASE("Interval backend: pow/powabs child ordering", "[pappus][interval]")
 
     SECTION("powabs(base=[-3,2], exp=[2,3]) -> contains [0, 27]") {
         // {X2, X1, Powabs}: abs(X1) is base, X2 is exponent.
-        Operon::Vector<Operon::Node> ns{Var(X2), Var(X1), Operon::Node(Operon::NodeType::Powabs)};
+        Operon::Vector<Operon::Node> ns{Var(X2), Var(X1), Util::MakeOp<Operon::BuiltinOp::Powabs>()};
         auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-3}, S{2}};  // abs → [0, 3]
@@ -799,7 +799,7 @@ TEST_CASE("Affine backend: pow/powabs child ordering", "[pappus][affine]")
     //   Swapped: pow(2, [2,3])   -> [4, 8],    sup <= 8
 
     SECTION("pow(base=[2,3], exp=const_2) -> enclosure contains [4, 9]") {
-        Operon::Vector<Operon::Node> ns{Const(2.0), Var(X1), Operon::Node(Operon::NodeType::Pow)};
+        Operon::Vector<Operon::Node> ns{Const(2.0), Var(X1), Util::MakeOp<Operon::BuiltinOp::Pow>()};
         auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{2}, S{3}};
@@ -817,7 +817,7 @@ TEST_CASE("Affine backend: pow/powabs child ordering", "[pappus][affine]")
     //   Swapped: pow(abs(const_3)=3, [-3,-1]) -> 3^[-3,-1] ≈ [1/27, 1/3]
 
     SECTION("powabs(base=[-3,-1], exp=const_3) -> enclosure contains [1, 27]") {
-        Operon::Vector<Operon::Node> ns{Const(3.0), Var(X1), Operon::Node(Operon::NodeType::Powabs)};
+        Operon::Vector<Operon::Node> ns{Const(3.0), Var(X1), Util::MakeOp<Operon::BuiltinOp::Powabs>()};
         auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
         auto d = Domains();
         d[X1] = {S{-3}, S{-1}};  // all-negative: abs = exact negation, min(abs) = 1 > 0
@@ -849,9 +849,9 @@ TEST_CASE("Pappus backends: evaluation throughput", "[pappus][performance]")
 
     constexpr Operon::Hash X1{1}, X2{2}, X3{3};
     Operon::Vector<Operon::Node> ns{
-        Var(X1), Var(X2), Operon::Node(Operon::NodeType::Add),
-        Operon::Node(Operon::NodeType::Exp),
-        Var(X3), Operon::Node(Operon::NodeType::Mul)};
+        Var(X1), Var(X2), Util::MakeOp<Operon::BuiltinOp::Add>(),
+        Util::MakeOp<Operon::BuiltinOp::Exp>(),
+        Var(X3), Util::MakeOp<Operon::BuiltinOp::Mul>()};
     auto tree = Operon::Tree(std::move(ns)).UpdateNodes();
     auto coeffs = tree.GetCoefficients();
 

--- a/test/source/implementation/permutation_importance.cpp
+++ b/test/source/implementation/permutation_importance.cpp
@@ -3,6 +3,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include "operon/analyzers/gradient_importance.hpp"
 #include "operon/analyzers/permutation_importance.hpp"
 #include "operon/core/dataset.hpp"
@@ -124,7 +126,7 @@ TEST_CASE("PermutationImportance - duplicate variable occurrences collapse to on
 
     Node nX0a(NodeType::Variable); nX0a.HashValue = x0Var.Hash;
     Node nX0b(NodeType::Variable); nX0b.HashValue = x0Var.Hash;
-    Tree const tree = Tree({ nX0a, nX0b, Node(NodeType::Mul) }).UpdateNodes();
+    Tree const tree = Tree({ nX0a, nX0b, Util::MakeOp<BuiltinOp::Mul>() }).UpdateNodes();
 
     auto const range = Operon::Range(0, ds.Rows());
     Operon::RandomGenerator rng(1234);
@@ -147,7 +149,7 @@ TEST_CASE("GradientImportance - relevant variable outranks unused one", "[analyz
     // y_hat = x0 + 0*x1 - x1 appears in the tree (so it gets scored) but
     // contributes nothing, unlike the shuffle-based test above where an unused
     // variable would simply be absent from the result.
-    Tree const tree = Tree({ nX0, nX1, nConstZero, Node(NodeType::Mul), Node(NodeType::Add) }).UpdateNodes();
+    Tree const tree = Tree({ nX0, nX1, nConstZero, Util::MakeOp<BuiltinOp::Mul>(), Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     auto const range = Operon::Range(0, ds.Rows());
     auto const importance = Operon::GradientImportance(tree, ds, range);

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -252,18 +252,20 @@ TEST_CASE("Checkpoint BEVE rejects wrong version", "[serialization]")
     auto beve = Operon::Serialization::ToBeve(cp);
     REQUIRE(!beve.empty());
 
-    // Magic is at some position; version=1 (LE: 01 00 00 00) follows it.
-    // Search starting after the magic bytes so we land on the version value.
+    // Magic is at some position; the current CheckpointVersion (LE) follows
+    // it. Search starting after the magic bytes so we land on the version
+    // value.
     constexpr std::array<char, 4> MagicLE{ '\x4B', '\x43', '\x50', '\x4F' };
     auto magicIt = std::search(beve.begin(), beve.end(), MagicLE.begin(), MagicLE.end());
     REQUIRE(magicIt != beve.end());
 
     // Generation=0 avoids a false match; assumes BEVE writes fields in
-    // declaration order with no other \x01\x00\x00\x00 between magic and version.
-    constexpr std::array<char, 4> VersionLE{ '\x01', '\x00', '\x00', '\x00' };
-    auto versionIt = std::search(magicIt + 4, beve.end(), VersionLE.begin(), VersionLE.end());
+    // declaration order with no other occurrence of the version bytes
+    // between magic and version.
+    constexpr auto CurrentVersion = std::to_array<char>({ '\x02', '\x00', '\x00', '\x00' }); // must track CheckpointVersion in serialization.cpp
+    auto versionIt = std::search(magicIt + 4, beve.end(), CurrentVersion.begin(), CurrentVersion.end());
     REQUIRE(versionIt != beve.end());
-    *versionIt = static_cast<char>(0x02); // bump version to 2
+    *versionIt = static_cast<char>(CurrentVersion[0] + 1); // bump to a version that doesn't match
 
     auto bad = Operon::Serialization::CheckpointFromBeve(beve);
     CHECK(!bad);

--- a/test/source/implementation/standard_library.cpp
+++ b/test/source/implementation/standard_library.cpp
@@ -32,23 +32,23 @@ TEST_CASE("StandardLibrary populates dispatch tables and node names consistently
     Operon::StandardLibrary::Register(dtRuntime);
 
     SECTION("Both tables contain the same set of built-in hashes") {
-        for (auto i = 0UL; i < Operon::NodeTypes::Count - 4; ++i) {
-            auto const h = Operon::Node(static_cast<Operon::NodeType>(i)).HashValue;
+        for (auto i = 0UL; i < Operon::BuiltinOpCount; ++i) {
+            auto const h = static_cast<Operon::Hash>(static_cast<Operon::BuiltinOp>(i));
             CHECK(dtDefault.Contains(h));
             CHECK(dtRuntime.Contains(h));
         }
     }
 
     SECTION("Built-in names and descriptions are available through the unified hash registry") {
-        CHECK(Operon::Node(Operon::NodeType::Add).Name() == "+");
-        CHECK(Operon::Node(Operon::NodeType::Add).Desc() == "n-ary addition f(a,b,c,...) = a + b + c + ...");
-        CHECK(Operon::Node(Operon::NodeType::Dynamic).Name() == "dyn");
+        CHECK(Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Add), 2).Name() == "+");
+        CHECK(Operon::Node::Function(static_cast<Operon::Hash>(Operon::BuiltinOp::Add), 2).Desc() == "n-ary addition f(a,b,c,...) = a + b + c + ...");
+        CHECK(Operon::Node(Operon::NodeType::Function).Name() == "dyn"); // generic fallback, no specific hash registered
         CHECK(Operon::Node(Operon::NodeType::Variable).Name() == "variable");
     }
 
     SECTION("Registered callables are the identical compiled kernels (same function pointer target)") {
-        for (auto i = 0UL; i < Operon::NodeTypes::Count - 4; ++i) {
-            auto const h = Operon::Node(static_cast<Operon::NodeType>(i)).HashValue;
+        for (auto i = 0UL; i < Operon::BuiltinOpCount; ++i) {
+            auto const h = static_cast<Operon::Hash>(static_cast<Operon::BuiltinOp>(i));
 
             auto const& fDefault = dtDefault.GetFunction<Scalar>(h);
             auto const& fRuntime = dtRuntime.GetFunction<Scalar>(h);
@@ -98,12 +98,12 @@ TEST_CASE("StandardLibrary populates dispatch tables and node names consistently
     }
 }
 
-TEST_CASE("Unregistered Dynamic nodes fall back to the generic name/desc", "[interpreter]")
+TEST_CASE("Unregistered Function nodes fall back to the generic name/desc", "[interpreter]")
 {
     Operon::StandardLibrary::RegisterNames();
 
     Operon::Hash const unregisteredHash = Operon::Hasher{}("test::unregistered_dynamic_fallback");
-    Operon::Node const dynNode(Operon::NodeType::Dynamic, unregisteredHash);
+    Operon::Node const dynNode(Operon::NodeType::Function, unregisteredHash);
 
     SECTION("Name() returns the generic \"dyn\" fallback") {
         CHECK(dynNode.Name() == "dyn");
@@ -113,26 +113,38 @@ TEST_CASE("Unregistered Dynamic nodes fall back to the generic name/desc", "[int
         CHECK(dynNode.Desc() == "user-defined function");
     }
 
-    SECTION("A registered Dynamic node still resolves to its specific name") {
+    SECTION("A registered Function node still resolves to its specific name") {
         Operon::Hash const registeredHash = Operon::Hasher{}("test::registered_dynamic_fallback");
         Operon::Node::RegisterName(registeredHash, "myop", "my custom op");
-        Operon::Node const registeredDyn(Operon::NodeType::Dynamic, registeredHash);
+        Operon::Node const registeredDyn(Operon::NodeType::Function, registeredHash);
         CHECK(registeredDyn.Name() == "myop");
         CHECK(registeredDyn.Desc() == "my custom op");
     }
 }
 
-TEST_CASE("StandardLibrary::ArityLimits matches Node(type).Arity's position-based inference", "[interpreter]")
+TEST_CASE("StandardLibrary::ArityLimits agrees with IsNaryOp/IsBinaryOp/IsUnaryOp classification", "[interpreter]")
 {
-    // PR1 gives PrimitiveSet an arity source independent of Node(t).Arity;
-    // this pins that the new source agrees with the old inference for every
-    // built-in type, so decoupling the source doesn't change observed arity.
-    for (auto i = 0UL; i < Operon::NodeTypes::Count; ++i) {
-        auto const type = static_cast<Operon::NodeType>(i);
-        auto const [minArity, maxArity] = Operon::StandardLibrary::ArityLimits(type);
-        auto const expected = Operon::Node(type).Arity;
-        CHECK(minArity == expected);
-        CHECK(maxArity == expected);
+    // Arity is registry-sourced now, not inferred from any enum position
+    // (that inference was removed along with NodeType's per-op enumerators).
+    // What should still hold: n-ary/binary ops report MinArity==MaxArity==2,
+    // unary ops report MinArity==MaxArity==1.
+    for (auto i = 0UL; i < Operon::BuiltinOpCount; ++i) {
+        auto const op = static_cast<Operon::BuiltinOp>(i);
+        auto const [minArity, maxArity] = Operon::StandardLibrary::ArityLimits(op);
+        CHECK(minArity == maxArity);
+    }
+    // Spot-check a representative op from each category directly.
+    {
+        auto const [lo, hi] = Operon::StandardLibrary::ArityLimits(Operon::BuiltinOp::Add);
+        CHECK(lo == 2); CHECK(hi == 2);
+    }
+    {
+        auto const [lo, hi] = Operon::StandardLibrary::ArityLimits(Operon::BuiltinOp::Pow);
+        CHECK(lo == 2); CHECK(hi == 2);
+    }
+    {
+        auto const [lo, hi] = Operon::StandardLibrary::ArityLimits(Operon::BuiltinOp::Sin);
+        CHECK(lo == 1); CHECK(hi == 1);
     }
 }
 
@@ -141,8 +153,8 @@ TEST_CASE("PrimitiveSet preset configs source arity from the registry, not Node(
     Operon::PrimitiveSet pset;
     pset.SetConfig(Operon::PrimitiveSet::Full);
 
-    auto const addHash = Operon::Node(Operon::NodeType::Add).HashValue;
-    auto const sinHash = Operon::Node(Operon::NodeType::Sin).HashValue;
+    auto const addHash = static_cast<Operon::Hash>(Operon::BuiltinOp::Add);
+    auto const sinHash = static_cast<Operon::Hash>(Operon::BuiltinOp::Sin);
     auto const constHash = Operon::Node(Operon::NodeType::Constant).HashValue;
     auto const varHash = Operon::Node(Operon::NodeType::Variable).HashValue;
 
@@ -173,10 +185,7 @@ TEST_CASE("RegisterNaryFunction registers a variable-arity function end-to-end",
     Operon::RegisterNaryFunction<DT, Scalar>(dt, pset, info, /*maxArity=*/5, primal);
 
     auto makeTree = [&] {
-        Operon::Node dyn(Operon::NodeType::Dynamic, hash);
-        dyn.Arity    = 3;
-        dyn.Length   = 3;
-        dyn.Optimize = false; // matches AddFunction: function nodes are never coefficient-optimized
+        auto dyn = Operon::Node::Function(hash, 3); // sets Arity=Length=3, Optimize=false
         return Operon::Tree({
             Operon::Node::Constant(1.0),
             Operon::Node::Constant(2.0),
@@ -236,10 +245,7 @@ TEST_CASE("RegisterNaryFunction registers a variable-arity function end-to-end",
         auto prodPrimal = [](auto acc, auto x) -> auto { return acc * x; };
         Operon::RegisterNaryFunction<DT, Scalar>(dtProd, psetProd, prodInfo, /*maxArity=*/3, prodPrimal);
 
-        Operon::Node dyn(Operon::NodeType::Dynamic, prodHash);
-        dyn.Arity    = 3;
-        dyn.Length   = 3;
-        dyn.Optimize = false;
+        auto dyn = Operon::Node::Function(prodHash, 3);
         Operon::Tree const tree({
             Operon::Node::Constant(2.0),
             Operon::Node::Constant(3.0),

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -207,8 +207,8 @@ TEST_CASE("BuildJacobianDag - Mul(c1,c2) product rule", "[tree_diff]")
     // Different constants → different derivative roots.
     CHECK(dag.Roots[0] != dag.Roots[1]);
     // Product rule emits Mul(Const(1), Ref(other)) for each column.
-    CHECK(dag.Nodes[dag.Roots[0]].Is<BuiltinOp::Mul>());
-    CHECK(dag.Nodes[dag.Roots[1]].Is<BuiltinOp::Mul>());
+    CHECK(dag.Nodes[dag.Roots[0]].IsOp<BuiltinOp::Mul>());
+    CHECK(dag.Nodes[dag.Roots[1]].IsOp<BuiltinOp::Mul>());
 }
 
 TEST_CASE("BuildJacobianDag - Sin(c) root is Mul", "[tree_diff]")
@@ -221,7 +221,7 @@ TEST_CASE("BuildJacobianDag - Sin(c) root is Mul", "[tree_diff]")
     auto dag = BuildJacobianDag(tree);
     REQUIRE(dag.Roots.size() == 1);
     REQUIRE(dag.Roots[0] != NoGrad);
-    CHECK(dag.Nodes[dag.Roots[0]].Is<BuiltinOp::Mul>());
+    CHECK(dag.Nodes[dag.Roots[0]].IsOp<BuiltinOp::Mul>());
 }
 
 TEST_CASE("BuildJacobianDag - original nodes are preserved exactly", "[tree_diff]")

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -73,13 +73,13 @@ auto EvalDagJacobian(
 auto MakeSupportedPset() -> PrimitiveSet {
     PrimitiveSet ps;
     ps.SetConfig(
-        NodeType::Add | NodeType::Mul | NodeType::Sub | NodeType::Div |
-        NodeType::Exp | NodeType::Log | NodeType::Logabs | NodeType::Log1p |
-        NodeType::Sin | NodeType::Cos | NodeType::Tan  |
-        NodeType::Asin | NodeType::Acos | NodeType::Atan |
-        NodeType::Sinh | NodeType::Cosh | NodeType::Tanh |
-        NodeType::Sqrt | NodeType::Cbrt | NodeType::Square |
-        NodeType::Pow  |
+        BuiltinOp::Add | BuiltinOp::Mul | BuiltinOp::Sub | BuiltinOp::Div |
+        BuiltinOp::Exp | BuiltinOp::Log | BuiltinOp::Logabs | BuiltinOp::Log1p |
+        BuiltinOp::Sin | BuiltinOp::Cos | BuiltinOp::Tan  |
+        BuiltinOp::Asin | BuiltinOp::Acos | BuiltinOp::Atan |
+        BuiltinOp::Sinh | BuiltinOp::Cosh | BuiltinOp::Tanh |
+        BuiltinOp::Sqrt | BuiltinOp::Cbrt | BuiltinOp::Square |
+        BuiltinOp::Pow  |
         NodeType::Constant | NodeType::Variable
     );
     return ps;
@@ -177,7 +177,7 @@ TEST_CASE("BuildJacobianDag - Add(c1,c2) both partials are 1", "[tree_diff]")
     Operon::Vector<Node> nodes;
     auto c1 = Node::Constant(2.0F); c1.Optimize = true;
     auto c2 = Node::Constant(3.0F); c2.Optimize = true;
-    Node add{NodeType::Add}; add.Arity = 2; add.Length = 2;
+    auto add = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 2);
     nodes.push_back(c1); nodes.push_back(c2); nodes.push_back(add);
     Tree tree{nodes};
 
@@ -196,7 +196,7 @@ TEST_CASE("BuildJacobianDag - Mul(c1,c2) product rule", "[tree_diff]")
     Operon::Vector<Node> nodes;
     auto c1 = Node::Constant(2.0F); c1.Optimize = true;
     auto c2 = Node::Constant(3.0F); c2.Optimize = true;
-    Node mul{NodeType::Mul}; mul.Arity = 2; mul.Length = 2;
+    auto mul = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Mul), 2);
     nodes.push_back(c1); nodes.push_back(c2); nodes.push_back(mul);
     Tree tree{nodes};
 
@@ -207,8 +207,8 @@ TEST_CASE("BuildJacobianDag - Mul(c1,c2) product rule", "[tree_diff]")
     // Different constants → different derivative roots.
     CHECK(dag.Roots[0] != dag.Roots[1]);
     // Product rule emits Mul(Const(1), Ref(other)) for each column.
-    CHECK(dag.Nodes[dag.Roots[0]].Type == NodeType::Mul);
-    CHECK(dag.Nodes[dag.Roots[1]].Type == NodeType::Mul);
+    CHECK(dag.Nodes[dag.Roots[0]].Is<BuiltinOp::Mul>());
+    CHECK(dag.Nodes[dag.Roots[1]].Is<BuiltinOp::Mul>());
 }
 
 TEST_CASE("BuildJacobianDag - Sin(c) root is Mul", "[tree_diff]")
@@ -216,12 +216,12 @@ TEST_CASE("BuildJacobianDag - Sin(c) root is Mul", "[tree_diff]")
     Operon::Vector<Node> nodes;
     auto c = Node::Constant(1.0F); c.Optimize = true;
     nodes.push_back(c);
-    nodes.push_back(Node{NodeType::Sin});
+    nodes.push_back(Util::MakeOp<BuiltinOp::Sin>());
     Tree tree{nodes};
     auto dag = BuildJacobianDag(tree);
     REQUIRE(dag.Roots.size() == 1);
     REQUIRE(dag.Roots[0] != NoGrad);
-    CHECK(dag.Nodes[dag.Roots[0]].Type == NodeType::Mul);
+    CHECK(dag.Nodes[dag.Roots[0]].Is<BuiltinOp::Mul>());
 }
 
 TEST_CASE("BuildJacobianDag - original nodes are preserved exactly", "[tree_diff]")
@@ -229,7 +229,7 @@ TEST_CASE("BuildJacobianDag - original nodes are preserved exactly", "[tree_diff
     Operon::Vector<Node> nodes;
     auto c = Node::Constant(7.0F); c.Optimize = true;
     nodes.push_back(c);
-    nodes.push_back(Node{NodeType::Exp});
+    nodes.push_back(Util::MakeOp<BuiltinOp::Exp>());
     Tree tree{nodes};
     auto dag = BuildJacobianDag(tree);
     REQUIRE(dag.OriginalSize == tree.Length());
@@ -246,7 +246,7 @@ TEST_CASE("BuildJacobianDag - Add4 hash-cons collapses all partials", "[tree_dif
         auto c = Node::Constant(static_cast<float>(k + 1)); c.Optimize = true;
         nodes.push_back(c);
     }
-    Node add{NodeType::Add}; add.Arity = 4; add.Length = 4;
+    auto add = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 4);
     nodes.push_back(add);
     Tree tree{nodes};
     auto dag = BuildJacobianDag(tree);
@@ -435,7 +435,7 @@ TEST_CASE("BuildHessianDag - square(c) Hessian is 2", "[tree_diff][hessian]")
     Operon::Vector<Node> nodes;
     auto c = Node::Constant(5.0F); c.Optimize = true;
     nodes.push_back(c);
-    nodes.push_back(Node{NodeType::Square});
+    nodes.push_back(Util::MakeOp<BuiltinOp::Square>());
     Tree tree{nodes};
 
     auto dag = BuildHessianDag(tree);
@@ -464,7 +464,7 @@ TEST_CASE("BuildHessianDag - Add(c1,c2) all Hessian entries zero", "[tree_diff][
     Operon::Vector<Node> nodes;
     auto c1 = Node::Constant(2.0F); c1.Optimize = true;
     auto c2 = Node::Constant(3.0F); c2.Optimize = true;
-    Node add{NodeType::Add}; add.Arity = 2; add.Length = 2;
+    auto add = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Add), 2);
     nodes.push_back(c1); nodes.push_back(c2); nodes.push_back(add);
     Tree tree{nodes};
 
@@ -482,7 +482,7 @@ TEST_CASE("BuildHessianDag - Mul(c1,c2) mixed partial is 1", "[tree_diff][hessia
     Operon::Vector<Node> nodes;
     auto c1 = Node::Constant(2.0F); c1.Optimize = true;
     auto c2 = Node::Constant(3.0F); c2.Optimize = true;
-    Node mul{NodeType::Mul}; mul.Arity = 2; mul.Length = 2;
+    auto mul = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Mul), 2);
     nodes.push_back(c1); nodes.push_back(c2); nodes.push_back(mul);
     Tree tree{nodes};
 

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include "../operon_test.hpp"
+
 #include "operon/core/dataset.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/pset.hpp"
@@ -70,9 +72,9 @@ TEST_CASE("Zobrist - position sensitivity (deterministic)", "[zobrist]")
     Zobrist const cache(rng, MaxLength, {});  // no variables needed: trees use only constants
 
     // postfix: [Constant, Cos, Sin]  =>  sin(cos(c))
-    Tree const tree1 = Tree({ Node(NodeType::Constant), Node(NodeType::Cos), Node(NodeType::Sin) }).UpdateNodes();
+    Tree const tree1 = Tree({ Node(NodeType::Constant), Util::MakeOp<BuiltinOp::Cos>(), Util::MakeOp<BuiltinOp::Sin>() }).UpdateNodes();
     // postfix: [Constant, Sin, Cos]  =>  cos(sin(c))
-    Tree const tree2 = Tree({ Node(NodeType::Constant), Node(NodeType::Sin), Node(NodeType::Cos) }).UpdateNodes();
+    Tree const tree2 = Tree({ Node(NodeType::Constant), Util::MakeOp<BuiltinOp::Sin>(), Util::MakeOp<BuiltinOp::Cos>() }).UpdateNodes();
 
     REQUIRE(cache.ComputeHash(tree1) != cache.ComputeHash(tree2));
 }
@@ -92,9 +94,9 @@ TEST_CASE("Zobrist - commuted variables yield different hashes", "[zobrist]")
     Node nY(NodeType::Variable); nY.HashValue = varY.Hash; nY.IsEnabled = true;
 
     // postfix: [X, Y, Add] => Add(X, Y)
-    Tree const treeXY = Tree({ nX, nY, Node(NodeType::Add) }).UpdateNodes();
+    Tree const treeXY = Tree({ nX, nY, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
     // postfix: [Y, X, Add] => Add(Y, X)
-    Tree const treeYX = Tree({ nY, nX, Node(NodeType::Add) }).UpdateNodes();
+    Tree const treeYX = Tree({ nY, nX, Util::MakeOp<BuiltinOp::Add>() }).UpdateNodes();
 
     REQUIRE(cache.ComputeHash(treeXY) != cache.ComputeHash(treeYX));
 }
@@ -214,8 +216,8 @@ TEST_CASE("Zobrist - distinct built-in ops at the same position yield distinct h
     Operon::RandomGenerator rng(Seed);
     Zobrist const cache(rng, MaxLength, {});
 
-    REQUIRE(cache.ComputeHash(Node(NodeType::Add), 0) != cache.ComputeHash(Node(NodeType::Mul), 0));
-    REQUIRE(cache.ComputeHash(Node(NodeType::Sin), 0) != cache.ComputeHash(Node(NodeType::Cos), 0));
+    REQUIRE(cache.ComputeHash(Util::MakeOp<BuiltinOp::Add>(), 0) != cache.ComputeHash(Util::MakeOp<BuiltinOp::Mul>(), 0));
+    REQUIRE(cache.ComputeHash(Util::MakeOp<BuiltinOp::Sin>(), 0) != cache.ComputeHash(Util::MakeOp<BuiltinOp::Cos>(), 0));
 }
 
 TEST_CASE("Zobrist - distinct Dynamic-hash user functions yield distinct hashes", "[zobrist]")
@@ -234,13 +236,13 @@ TEST_CASE("Zobrist - distinct Dynamic-hash user functions yield distinct hashes"
     Operon::Hash const hashB = Operon::Hasher{}("userFunctionB");
     REQUIRE(hashA != hashB);
 
-    Node const nodeA(NodeType::Dynamic, hashA);
-    Node const nodeB(NodeType::Dynamic, hashB);
+    Node const nodeA(NodeType::Function, hashA);
+    Node const nodeB(NodeType::Function, hashB);
 
     REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(nodeB, 0));
 
     // Also distinct from a built-in occupying the same tree position.
-    REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(Node(NodeType::Add), 0));
+    REQUIRE(cache.ComputeHash(nodeA, 0) != cache.ComputeHash(Util::MakeOp<BuiltinOp::Add>(), 0));
 
     // Same Dynamic hash at two different positions must also differ - pins
     // position-sensitivity for the non-table combine path specifically,
@@ -259,8 +261,8 @@ TEST_CASE("Zobrist - different Optimize flags yield different hashes", "[zobrist
     Node c1(NodeType::Constant); c1.Value = 1.0f; c1.Optimize = true;
     Node c2(NodeType::Constant); c2.Value = 1.0f; c2.Optimize = false;
 
-    Tree const tree1 = Tree({ c1, Node(NodeType::Sin) }).UpdateNodes();
-    Tree const tree2 = Tree({ c2, Node(NodeType::Sin) }).UpdateNodes();
+    Tree const tree1 = Tree({ c1, Util::MakeOp<BuiltinOp::Sin>() }).UpdateNodes();
+    Tree const tree2 = Tree({ c2, Util::MakeOp<BuiltinOp::Sin>() }).UpdateNodes();
 
     REQUIRE(cache.ComputeHash(tree1) != cache.ComputeHash(tree2));
 }

--- a/test/source/operon_test.hpp
+++ b/test/source/operon_test.hpp
@@ -19,6 +19,17 @@
 #include "operon/interpreter/dual.hpp"
 
 namespace Operon::Test::Util {
+    // Test convenience: construct a Function node for a built-in op with a
+    // sensible default arity (1 for unary ops, 2 for binary/n-ary ops),
+    // mirroring the pre-collapse Node(NodeType) constructor's automatic
+    // arity inference. Call sites that need a different arity still set
+    // .Arity explicitly afterward, same as before the collapse.
+    template<BuiltinOp Op>
+    auto MakeOp() -> Node {
+        constexpr uint16_t arity = Node::IsUnaryOp<Op> ? 1 : 2;
+        return Node::Function(static_cast<Operon::Hash>(Op), arity);
+    }
+
     inline auto RandomDataset(Operon::RandomGenerator& rng, int rows, int cols) -> Operon::Dataset {
         std::uniform_real_distribution<Operon::Scalar> dist(-1.F, +1.F);
         std::vector<std::string> names(cols);
@@ -47,31 +58,28 @@ namespace Operon::Test::Util {
             for (auto i = 0UL; i < nodes.size(); ++i) {
                 auto const& n = nodes[i];
                 auto const v = n.Optimize ? coeff[idx++] : T{n.Value};
-                switch(n.Type) {
-                    case NodeType::Constant: {
-                        buffer.col(i).segment(row, rem).setConstant(v);
-                        break;
-                    }
-                    case NodeType::Variable: {
-                        auto const* ptr = dataset.GetValues(n.HashValue).subspan(row, rem).data();
-                        buffer.col(i).segment(row, rem) = v * Eigen::Map<Eigen::Array<Operon::Scalar, -1, 1> const>(ptr, rem, 1).template cast<T>();
-                        break;
-                    }
-                    case NodeType::Add: {
+                if (n.Type == NodeType::Constant) {
+                    buffer.col(i).segment(row, rem).setConstant(v);
+                } else if (n.Type == NodeType::Variable) {
+                    auto const* ptr = dataset.GetValues(n.HashValue).subspan(row, rem).data();
+                    buffer.col(i).segment(row, rem) = v * Eigen::Map<Eigen::Array<Operon::Scalar, -1, 1> const>(ptr, rem, 1).template cast<T>();
+                } else
+                switch(n.HashValue) {
+                    case Operon::Hash(BuiltinOp::Add): {
                         buffer.col(i).setConstant(T{0});
                         for (auto j : Tree::Indices(nodes, i)) {
                             buffer.col(i) += buffer.col(j);
                         }
                         break;
                     }
-                    case NodeType::Mul: {
+                    case Operon::Hash(BuiltinOp::Mul): {
                         buffer.col(i).setConstant(T{1});
                         for (auto j : Tree::Indices(nodes, i)) {
                             buffer.col(i) *= buffer.col(j);
                         }
                         break;
                     }
-                    case NodeType::Sub: {
+                    case Operon::Hash(BuiltinOp::Sub): {
                         if (n.Arity == 1) {
                             buffer.col(i) = -buffer.col(i-1);
                         } else {
@@ -83,7 +91,7 @@ namespace Operon::Test::Util {
                         }
                         break;
                     }
-                    case NodeType::Div: {
+                    case Operon::Hash(BuiltinOp::Div): {
                         if (n.Arity == 1) {
                             buffer.col(i) = buffer.col(i-1).inverse();
                         } else {
@@ -95,7 +103,7 @@ namespace Operon::Test::Util {
                         }
                         break;
                     }
-                    case NodeType::Fmin: {
+                    case Operon::Hash(BuiltinOp::Fmin): {
                         buffer.col(i) = buffer.col(i-1);
                         for (auto j : Tree::Indices(nodes, i)) {
                             if (j == i-1) { continue; }
@@ -103,7 +111,7 @@ namespace Operon::Test::Util {
                         }
                         break;
                     }
-                    case NodeType::Fmax: {
+                    case Operon::Hash(BuiltinOp::Fmax): {
                         buffer.col(i) = buffer.col(i-1);
                         for (auto j : Tree::Indices(nodes, i)) {
                             if (j == i-1) { continue; }
@@ -111,101 +119,101 @@ namespace Operon::Test::Util {
                         }
                         break;
                     }
-                    case NodeType::Aq: {
+                    case Operon::Hash(BuiltinOp::Aq): {
                         auto j = i-1;
                         auto k = j - (nodes[j].Length + 1);
                         buffer.col(i) = buffer.col(j) / (T{1} + buffer.col(k).square()).sqrt();
                         break;
                     }
-                    case NodeType::Pow: {
+                    case Operon::Hash(BuiltinOp::Pow): {
                         auto j = i-1;
                         auto k = j - (nodes[j].Length + 1);
                         buffer.col(i) = buffer.col(j).pow(buffer.col(k));
                         break;
                     }
-                    case NodeType::Powabs: {
+                    case Operon::Hash(BuiltinOp::Powabs): {
                         auto j = i-1;
                         auto k = j - (nodes[j].Length + 1);
                         buffer.col(i) = buffer.col(j).abs().pow(buffer.col(k));
                         break;
                     }
-                    case NodeType::Abs: {
+                    case Operon::Hash(BuiltinOp::Abs): {
                         buffer.col(i) = buffer.col(i-1).abs();
                         break;
                     }
-                    case NodeType::Acos: {
+                    case Operon::Hash(BuiltinOp::Acos): {
                         buffer.col(i) = buffer.col(i-1).acos();
                         break;
                     }
-                    case NodeType::Asin: {
+                    case Operon::Hash(BuiltinOp::Asin): {
                         buffer.col(i) = buffer.col(i-1).asin();
                         break;
                     }
-                    case NodeType::Atan: {
+                    case Operon::Hash(BuiltinOp::Atan): {
                         buffer.col(i) = buffer.col(i-1).atan();
                         break;
                     }
-                    case NodeType::Cbrt: {
+                    case Operon::Hash(BuiltinOp::Cbrt): {
                         buffer.col(i) = buffer.col(i-1).unaryExpr([](auto x) { return ceres::cbrt(x); });
                         break;
                     }
-                    case NodeType::Ceil: {
+                    case Operon::Hash(BuiltinOp::Ceil): {
                         buffer.col(i) = buffer.col(i-1).ceil();
                         break;
                     }
-                    case NodeType::Cos: {
+                    case Operon::Hash(BuiltinOp::Cos): {
                         buffer.col(i) = buffer.col(i-1).cos();
                         break;
                     }
-                    case NodeType::Cosh: {
+                    case Operon::Hash(BuiltinOp::Cosh): {
                         buffer.col(i) = buffer.col(i-1).cosh();
                         break;
                     }
-                    case NodeType::Exp: {
+                    case Operon::Hash(BuiltinOp::Exp): {
                         buffer.col(i) = buffer.col(i-1).exp();
                         break;
                     }
-                    case NodeType::Floor: {
+                    case Operon::Hash(BuiltinOp::Floor): {
                         buffer.col(i) = buffer.col(i-1).floor();
                         break;
                     }
-                    case NodeType::Log: {
+                    case Operon::Hash(BuiltinOp::Log): {
                         buffer.col(i) = buffer.col(i-1).log();
                         break;
                     }
-                    case NodeType::Logabs: {
+                    case Operon::Hash(BuiltinOp::Logabs): {
                         buffer.col(i) = buffer.col(i-1).abs().log();
                         break;
                     }
-                    case NodeType::Log1p: {
+                    case Operon::Hash(BuiltinOp::Log1p): {
                         buffer.col(i) = buffer.col(i-1).log1p();
                         break;
                     }
-                    case NodeType::Sin: {
+                    case Operon::Hash(BuiltinOp::Sin): {
                         buffer.col(i) = buffer.col(i-1).sin();
                         break;
                     }
-                    case NodeType::Sinh: {
+                    case Operon::Hash(BuiltinOp::Sinh): {
                         buffer.col(i) = buffer.col(i-1).sinh();
                         break;
                     }
-                    case NodeType::Sqrt: {
+                    case Operon::Hash(BuiltinOp::Sqrt): {
                         buffer.col(i) = buffer.col(i-1).sqrt();
                         break;
                     }
-                    case NodeType::Sqrtabs: {
+                    case Operon::Hash(BuiltinOp::Sqrtabs): {
                         buffer.col(i) = buffer.col(i-1).abs().sqrt();
                         break;
                     }
-                    case NodeType::Square: {
+                    case Operon::Hash(BuiltinOp::Square): {
                         buffer.col(i) = buffer.col(i-1).square();
                         break;
                     }
-                    case NodeType::Tan: {
+                    case Operon::Hash(BuiltinOp::Tan): {
                         buffer.col(i) = buffer.col(i-1).tan();
                         break;
                     }
-                    case NodeType::Tanh: {
+                    case Operon::Hash(BuiltinOp::Tanh): {
                         buffer.col(i) = buffer.col(i-1).tanh();
                         break;
                     }

--- a/test/source/performance/autodiff.cpp
+++ b/test/source/performance/autodiff.cpp
@@ -8,6 +8,7 @@
 #include "../operon_test.hpp"
 
 #include "operon/core/pset.hpp"
+#include "operon/core/standard_library.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
 #include "operon/operators/creator.hpp"
@@ -27,7 +28,7 @@ TEST_CASE("Autodiff performance", "[performance]")
     nb::Bench b;
     b.timeUnit(std::chrono::milliseconds(1), "ms");
 
-    Operon::PrimitiveSet pset{Operon::PrimitiveSet::Arithmetic | Operon::NodeType::Exp | Operon::NodeType::Log | Operon::NodeType::Sin | Operon::NodeType::Cos | Operon::NodeType::Sqrt | Operon::NodeType::Pow | Operon::NodeType::Tanh};
+    Operon::PrimitiveSet pset{Operon::PrimitiveSet::Arithmetic | Operon::BuiltinOp::Exp | Operon::BuiltinOp::Log | Operon::BuiltinOp::Sin | Operon::BuiltinOp::Cos | Operon::BuiltinOp::Sqrt | Operon::BuiltinOp::Pow | Operon::BuiltinOp::Tanh};
     constexpr size_t maxLength = 200;
     Operon::BalancedTreeCreator const creator(&pset, ds.VariableHashes(), /* bias= */ 0.0, maxLength);
 
@@ -97,7 +98,7 @@ TEST_CASE("Reverse mode performance", "[performance]")
     nb::Bench b;
     b.timeUnit(std::chrono::milliseconds(1), "ms");
 
-    Operon::PrimitiveSet pset{Operon::PrimitiveSet::Arithmetic | Operon::NodeType::Exp | Operon::NodeType::Log | Operon::NodeType::Sin | Operon::NodeType::Cos | Operon::NodeType::Sqrt};
+    Operon::PrimitiveSet pset{Operon::PrimitiveSet::Arithmetic | Operon::BuiltinOp::Exp | Operon::BuiltinOp::Log | Operon::BuiltinOp::Sin | Operon::BuiltinOp::Cos | Operon::BuiltinOp::Sqrt};
 
     using DTable = DispatchTable<Operon::Scalar>;
     DTable const dtable;
@@ -149,12 +150,11 @@ TEST_CASE("Primitive performance", "[performance]")
 
     Operon::ScalarDispatch dt;
 
-    for (auto i = 0UL; i < NodeTypes::Count; ++i) {
-        auto t = static_cast<NodeType>(i);
-        Node n{t};
+    for (auto i = 0UL; i < BuiltinOpCount; ++i) {
+        auto op = static_cast<BuiltinOp>(i);
+        auto const minArity = StandardLibrary::ArityLimits(op).first;
+        auto n = Node::Function(static_cast<Operon::Hash>(op), minArity);
         n.Value = dist(rng);
-        if (n.IsLeaf()) { continue; }
-        if (t == NodeType::Dynamic) { continue; }
         std::vector<Tree> trees;
         trees.reserve(N);
         for (auto j = 0; j < N; ++j) {
@@ -174,12 +174,11 @@ TEST_CASE("Primitive performance", "[performance]")
         });
     }
 
-    for (auto i = 0UL; i < NodeTypes::Count; ++i) {
-        auto t = static_cast<NodeType>(i);
-        Node n{t};
+    for (auto i = 0UL; i < BuiltinOpCount; ++i) {
+        auto op = static_cast<BuiltinOp>(i);
+        auto const minArity = StandardLibrary::ArityLimits(op).first;
+        auto n = Node::Function(static_cast<Operon::Hash>(op), minArity);
         n.Value = dist(rng);
-        if (n.IsLeaf()) { continue; }
-        if (t == NodeType::Dynamic) { continue; }
         std::vector<Tree> trees;
         trees.reserve(N);
         for (auto j = 0; j < N; ++j) {
@@ -252,7 +251,7 @@ TEST_CASE("Optimizer performance", "[performance]")
 
     nb::Bench b;
     Operon::PrimitiveSet pset;
-    Operon::PrimitiveSetConfig const psetcfg = Operon::PrimitiveSet::Arithmetic | Operon::NodeType::Exp | Operon::NodeType::Log | Operon::NodeType::Sin | Operon::NodeType::Cos;
+    Operon::PrimitiveSetConfig const psetcfg = Operon::PrimitiveSet::Arithmetic | Operon::BuiltinOp::Exp | Operon::BuiltinOp::Log | Operon::BuiltinOp::Sin | Operon::BuiltinOp::Cos;
     pset.SetConfig(psetcfg);
     constexpr size_t maxLength = 200;
     Operon::BalancedTreeCreator const creator(&pset, ds.VariableHashes(), /* bias= */ 0.0, maxLength);

--- a/test/source/performance/distance.cpp
+++ b/test/source/performance/distance.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Intersection performance", "[performance]") // NOLINT(readability-fun
     std::uniform_int_distribution<size_t> sizeDistribution(1, maxLength);
 
     PrimitiveSet grammar;
-    grammar.SetConfig(PrimitiveSet::Arithmetic | NodeType::Exp | NodeType::Log);
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Exp | BuiltinOp::Log);
 
     std::vector<Tree> trees(n);
     BalancedTreeCreator btc(&grammar, ds.VariableHashes(), /* bias= */ 0.0, maxLength);

--- a/test/source/performance/evaluation.cpp
+++ b/test/source/performance/evaluation.cpp
@@ -89,8 +89,8 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
 
     auto test = [&](tf::Executor& executor, nb::Bench& b, PrimitiveSetConfig cfg, const std::string& name) -> void {
         pset.SetConfig(cfg);
-        for (auto t : {NodeType::Add, NodeType::Sub, NodeType::Div, NodeType::Mul}) {
-            pset.SetMinMaxArity(Node(t).HashValue, 2, 2);
+        for (auto t : {BuiltinOp::Add, BuiltinOp::Sub, BuiltinOp::Div, BuiltinOp::Mul}) {
+            pset.SetMinMaxArity(static_cast<Operon::Hash>(t), 2, 2);
         }
         std::ranges::generate(trees, [&]() -> Tree { return creator(rd, sizeDistribution(rd), 0, maxDepth); });
 
@@ -115,7 +115,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + exp").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Exp, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Exp, fmt::format("N = {}", i));
         }
     }
 
@@ -123,7 +123,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + log").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Log, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Log, fmt::format("N = {}", i));
         }
     }
 
@@ -132,7 +132,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b2.title("arithmetic + sin").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b2, PrimitiveSet::Arithmetic | NodeType::Sin, fmt::format("N = {}", i));
+            test(executor, b2, PrimitiveSet::Arithmetic | BuiltinOp::Sin, fmt::format("N = {}", i));
         }
     }
 
@@ -140,7 +140,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + cos").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Cos, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Cos, fmt::format("N = {}", i));
         }
     }
 
@@ -148,7 +148,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + tan").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Tan, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Tan, fmt::format("N = {}", i));
         }
     }
 
@@ -156,7 +156,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + sqrt").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Sqrt, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Sqrt, fmt::format("N = {}", i));
         }
     }
 
@@ -164,7 +164,7 @@ TEST_CASE("Evaluation performance", "[performance]") // NOLINT(readability-funct
         b.title("arithmetic + cbrt").relative(true).performanceCounters(true).minEpochIterations(minEpochIterations);
         for (size_t i = 1; i <= maxConcurrency; ++i) {
             tf::Executor executor(i);
-            test(executor, b, PrimitiveSet::Arithmetic | NodeType::Cbrt, fmt::format("N = {}", i));
+            test(executor, b, PrimitiveSet::Arithmetic | BuiltinOp::Cbrt, fmt::format("N = {}", i));
         }
     }
 }
@@ -307,8 +307,8 @@ TEST_CASE("JIT evaluator performance", "[performance][jit]")
 
     auto bench_pset = [&](PrimitiveSetConfig cfg, std::string const& title) {
         problem.GetPrimitiveSet().SetConfig(cfg);
-        for (auto t : {NodeType::Add, NodeType::Sub, NodeType::Div, NodeType::Mul}) {
-            problem.GetPrimitiveSet().SetMinMaxArity(Node(t).HashValue, 2, 2);
+        for (auto t : {BuiltinOp::Add, BuiltinOp::Sub, BuiltinOp::Div, BuiltinOp::Mul}) {
+            problem.GetPrimitiveSet().SetMinMaxArity(static_cast<Operon::Hash>(t), 2, 2);
         }
 
         std::uniform_int_distribution<size_t> sizeDistribution(1, maxLength);
@@ -417,8 +417,8 @@ TEST_CASE("JIT evaluator performance", "[performance][jit]")
     };
 
     SECTION("arithmetic")       { bench_pset(PrimitiveSet::Arithmetic, "arithmetic"); }
-    SECTION("arithmetic + sin") { bench_pset(PrimitiveSet::Arithmetic | NodeType::Sin, "arithmetic+sin"); }
-    SECTION("arithmetic + exp") { bench_pset(PrimitiveSet::Arithmetic | NodeType::Exp, "arithmetic+exp"); }
+    SECTION("arithmetic + sin") { bench_pset(PrimitiveSet::Arithmetic | BuiltinOp::Sin, "arithmetic+sin"); }
+    SECTION("arithmetic + exp") { bench_pset(PrimitiveSet::Arithmetic | BuiltinOp::Exp, "arithmetic+exp"); }
 }
 
 TEST_CASE("JIT LM optimizer performance", "[performance][jit][optimizer]")
@@ -451,8 +451,8 @@ TEST_CASE("JIT LM optimizer performance", "[performance][jit][optimizer]")
 
     auto bench_pset = [&](PrimitiveSetConfig cfg, std::string const& title) {
         problem.GetPrimitiveSet().SetConfig(cfg | NodeType::Constant);
-        for (auto t : {NodeType::Add, NodeType::Sub, NodeType::Div, NodeType::Mul}) {
-            problem.GetPrimitiveSet().SetMinMaxArity(Node(t).HashValue, 2, 2);
+        for (auto t : {BuiltinOp::Add, BuiltinOp::Sub, BuiltinOp::Div, BuiltinOp::Mul}) {
+            problem.GetPrimitiveSet().SetMinMaxArity(static_cast<Operon::Hash>(t), 2, 2);
         }
 
         std::uniform_int_distribution<size_t> sizeDistribution(5, maxLength);
@@ -510,7 +510,7 @@ TEST_CASE("JIT LM optimizer performance", "[performance][jit][optimizer]")
     };
 
     SECTION("arithmetic") { bench_pset(PrimitiveSet::Arithmetic, "arithmetic"); }
-    SECTION("arithmetic + sin") { bench_pset(PrimitiveSet::Arithmetic | NodeType::Sin, "arithmetic+sin"); }
+    SECTION("arithmetic + sin") { bench_pset(PrimitiveSet::Arithmetic | BuiltinOp::Sin, "arithmetic+sin"); }
 }
 #endif // HAVE_ASMJIT
 

--- a/test/source/performance/infix_parser.cpp
+++ b/test/source/performance/infix_parser.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Parser throughput", "[performance]")
     auto ds = Util::RandomDataset(rng, nrow, ncol);
 
     Operon::PrimitiveSet pset;
-    pset.SetConfig(PrimitiveSet::Arithmetic | NodeType::Exp | NodeType::Log | NodeType::Variable);
+    pset.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Exp | BuiltinOp::Log | NodeType::Variable);
 
     BalancedTreeCreator const creator{&pset, ds.VariableHashes(), /* bias= */ 0.0, maxLength};
     std::uniform_int_distribution<size_t> dist(1, maxLength);


### PR DESCRIPTION
## Summary

`NodeType` shrinks from ~30 enumerators (one per built-in math op, plus `Dynamic`) down to 4 categories: `Constant`, `Variable`, `Ref`, `Function`. Every built-in math op is now a `Function`-typed `Node` distinguished by its `HashValue` (`BuiltinOp`, introduced in prior PRs #137/#139), not by a dedicated `NodeType` enumerator. `Node::Function(hash, arity)` is the single construction path for both built-in and user-defined functions, generalizing what `Dynamic` nodes already did.

- `PrimitiveSetConfig` is redesigned as a `BuiltinOp`-count-plus-4 bitset (same total bit count as the previous 33-value layout).
- Grammar's `Production::Op` and mutation's n-ary gate move to `BuiltinOp`.
- The infix formatter/parser, interval/affine evaluators, and JIT codegen are re-keyed onto `HashValue`-based dispatch instead of switching on `Type`.
- Serialization's `NodeProxy` gains an explicit `Arity` field (position-based arity inference no longer exists post-collapse) and the checkpoint format version is bumped — old checkpoints are not decodable under the new `NodeType` layout and are now rejected explicitly rather than silently misdecoded.

This is the follow-up to #139 (dispatch/registry retarget), completing the `NodeType` collapse described in tracking issue #136.

## Test plan

- [x] Static build: full non-performance suite green (24018 assertions, 248 cases)
- [x] Shared build (`-DBUILD_SHARED_LIBS=ON`): builds clean
- [x] 30-seed `operon_compare` runs (Poly-10, Friedman-II) against `main`: identical r²_test distributions (Mann-Whitney p=1.0000 on both)