### PR TITLE
core: registry-based redesign of tree_diff/interval/affine/JIT dispatch (generic-nodes PR 8/9/10)

### DIFF
--- a/include/operon/core/hash_registry.hpp
+++ b/include/operon/core/hash_registry.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_HASH_REGISTRY_HPP
+#define OPERON_HASH_REGISTRY_HPP
+
+#include <stdexcept>
+
+#include "types.hpp"
+
+// A small, generic hash-keyed registry shared by the symbolic-differentiation
+// (tree_diff.cpp), interval/affine (interval_evaluator.hpp/affine_evaluator.hpp),
+// and JIT-codegen (jit_compiler.cpp) registries. Each of those instantiates
+// HashRegistry<Fn> for its own distinct Fn type, kept as separate C++ types
+// rather than one shared per-hash struct: they have different compile-time
+// availability (JIT is conditional on HAVE_ASMJIT; the others are always
+// present) and different consumers, so bundling them would leak
+// backend-specific types (e.g. asmjit) onto callers that don't care.
+//
+// This header has no dependency on any of its consumers' Fn types.
+
+namespace Operon {
+
+template<typename Fn>
+class HashRegistry {
+public:
+    // Write-once: throws on a hash that's already registered. Deliberately
+    // stricter than DispatchTable::RegisterFunction (which overwrites), so a
+    // repeat registration is a caught mistake rather than a silent, later
+    // divergence between what's registered and what's cached/assumed
+    // elsewhere under the same hash.
+    void Register(Operon::Hash hash, Fn fn)
+    {
+        auto [it, inserted] = map_.try_emplace(hash, std::move(fn));
+        if (!inserted) {
+            throw std::invalid_argument("HashRegistry: hash is already registered");
+        }
+    }
+
+    [[nodiscard]] auto TryGet(Operon::Hash hash) const -> Fn const*
+    {
+        auto it = map_.find(hash);
+        return it != map_.end() ? &it->second : nullptr;
+    }
+
+    [[nodiscard]] auto Contains(Operon::Hash hash) const -> bool { return map_.contains(hash); }
+
+private:
+    Operon::Map<Operon::Hash, Fn> map_;
+};
+
+} // namespace Operon
+
+#endif

--- a/include/operon/core/hash_registry.hpp
+++ b/include/operon/core/hash_registry.hpp
@@ -5,6 +5,7 @@
 #define OPERON_HASH_REGISTRY_HPP
 
 #include <stdexcept>
+#include <utility>
 
 #include "types.hpp"
 

--- a/include/operon/core/tree_diff.hpp
+++ b/include/operon/core/tree_diff.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
+
 #include "contracts.hpp"
 #include "node.hpp"
 #include "tree.hpp"
@@ -11,6 +14,35 @@
 #include "operon/operon_export.hpp"
 
 namespace Operon {
+
+// A symbolic derivative rule for a unary built-in or user-defined function:
+// given the dag under construction (`dag`/`memo`/`h`, threaded the same way
+// Deriv()'s own helpers in tree_diff.cpp thread them, for hash-consing),
+// this node's own dag index `i`, and its argument's dag index `j`, returns
+// the dag index of f'(j) — or Operon::Vector<Node>::size_type(-1)
+// (tree_diff.cpp's `Zero` sentinel) if no derivative is computable. Several
+// rules need `i` (e.g. Exp: f'(j) = exp(j) = the node's own result, at `i`),
+// not just `j`, hence both are threaded through.
+using UnarySymbolicDerivRule = std::function<std::size_t(
+    Operon::Vector<Node>& dag,
+    Operon::Map<Operon::Hash, std::size_t>& memo,
+    Operon::Vector<Operon::Hash>& h,
+    std::size_t i,
+    std::size_t j)>;
+
+// Register a symbolic derivative rule for a unary function (built-in or
+// user-defined), keyed by the same hash the function's Node::HashValue
+// carries. Looked up by BuildJacobianDag/BuildHessianDag's internal Deriv()
+// for every unary node; a miss degrades to "not differentiable" (Zero),
+// identical to today's behavior for an unregistered op. Throws if `hash` is
+// already registered (write-once, see HashRegistry::Register).
+OPERON_EXPORT void RegisterUnarySymbolicDeriv(Operon::Hash hash, UnarySymbolicDerivRule rule);
+
+// Query whether a symbolic derivative rule is registered for `hash` (built-in
+// or user-defined). Mainly useful for coverage checks (e.g. asserting every
+// BuiltinOp is either registered here or deliberately excluded as a
+// structural/non-smooth case handled directly in Deriv()).
+OPERON_EXPORT auto HasUnarySymbolicDeriv(Operon::Hash hash) -> bool;
 
 // A flat postfix array containing the original tree (indices 0..OriginalSize-1)
 // plus appended symbolic derivative subtrees. Shared subexpressions between

--- a/include/operon/interpreter/affine_evaluator.hpp
+++ b/include/operon/interpreter/affine_evaluator.hpp
@@ -5,6 +5,7 @@
 #define OPERON_AFFINE_EVALUATOR_HPP
 
 #include <fmt/format.h>
+#include <functional>
 #include <gsl/pointers>
 #include <optional>
 #include <stdexcept>
@@ -12,6 +13,7 @@
 #include <vector>
 
 #include "operon/core/contracts.hpp"
+#include "operon/core/hash_registry.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
@@ -34,6 +36,54 @@
 #endif
 
 namespace Operon {
+
+// Registered affine callbacks for unary/binary built-in or user-defined
+// functions, keyed by Node::HashValue. See interval_evaluator.hpp's matching
+// comment for the full rationale (global inline Meyer singletons, no
+// registry parameter threaded through the constructor/Evaluate(), plain
+// non-locking HashRegistry since all writes finish before Evaluate() is
+// first called from a GP worker thread). Only real difference from
+// IntervalUnaryFn/IntervalBinaryFn: every call here takes the shared
+// affine_context first — the context-threaded finalize overload of
+// PAPPUS_DEFINE_UNARY_OP is the only one either evaluator ever calls (the
+// bare affine_form<T>-only overload, without a context, is never used here).
+using AffineUnaryFn  = std::function<pappus::affine_form<Operon::Scalar>(
+    pappus::ops::affine_context<Operon::Scalar> const&, pappus::affine_form<Operon::Scalar> const&)>;
+using AffineBinaryFn = std::function<pappus::affine_form<Operon::Scalar>(
+    pappus::ops::affine_context<Operon::Scalar> const&,
+    pappus::affine_form<Operon::Scalar> const&, pappus::affine_form<Operon::Scalar> const&)>;
+
+using AffineUnaryRegistry  = HashRegistry<AffineUnaryFn>;
+using AffineBinaryRegistry = HashRegistry<AffineBinaryFn>;
+
+inline auto AffineUnaryRules() -> AffineUnaryRegistry&
+{
+    static AffineUnaryRegistry registry;
+    return registry;
+}
+
+inline auto AffineBinaryRules() -> AffineBinaryRegistry&
+{
+    static AffineBinaryRegistry registry;
+    return registry;
+}
+
+// Register an affine callback for a unary function (built-in or
+// user-defined), keyed by the same hash the function's Node::HashValue
+// carries. A miss at evaluation time means the tree cannot be bounded at
+// all — AffineEvaluator::Evaluate() still throws on a miss, unchanged from
+// today. Throws if `hash` is already registered (write-once).
+inline void RegisterUnaryAffine(Operon::Hash hash, AffineUnaryFn fn)
+{
+    AffineUnaryRules().Register(hash, std::move(fn));
+}
+
+// Register an affine callback for a binary function. See
+// RegisterUnaryAffine for the miss-behavior note.
+inline void RegisterBinaryAffine(Operon::Hash hash, AffineBinaryFn fn)
+{
+    AffineBinaryRules().Register(hash, std::move(fn));
+}
 
 // Forward affine-arithmetic bounds for an Operon tree over a single input
 // domain. Mirrors `IntervalEvaluator` but every `affine_form` shares one
@@ -90,6 +140,8 @@ public:
         // sound (conservative) bounds. Resetting the counter would reuse
         // indices, causing pappus to merge terms from independent evaluations
         // and produce falsely-narrow enclosures.
+
+        RegisterBuiltins();
 
         auto const& nodes = tree_->Nodes();
         auto const n = nodes.size();
@@ -179,6 +231,9 @@ public:
                 EXPECT(static_cast<std::size_t>(node.RefTo) < primal_.size());
                 primal_.push_back(primal_[node.RefTo]);
             } else {
+                // Add/Mul/Sub/Div/Fmin/Fmax stay hardcoded: verified n-ary
+                // folds, same scope boundary as IntervalEvaluator. Every
+                // other op goes through the registry.
                 switch (node.HashValue) {
                 case Operon::Hash(BuiltinOp::Add):
                     primal_.push_back(addFold(i) * v);
@@ -196,97 +251,24 @@ public:
                     primal_.push_back((node.Arity == 1 ? pappus::ops::inv<Scalar>(ctx_, primal_[i - 1])
                                                       : divFold(i)) * v);
                     break;
-                case Operon::Hash(BuiltinOp::Square):
-                    primal_.push_back(pappus::ops::square<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Sqrt):
-                    primal_.push_back(pappus::ops::sqrt<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Exp):
-                    primal_.push_back(pappus::ops::exp<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Log):
-                    primal_.push_back(pappus::ops::log<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Sin):
-                    primal_.push_back(pappus::ops::sin<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Cos):
-                    primal_.push_back(pappus::ops::cos<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Tan):
-                    primal_.push_back(pappus::ops::tan<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Asin):
-                    primal_.push_back(pappus::ops::asin<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Acos):
-                    primal_.push_back(pappus::ops::acos<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Atan):
-                    primal_.push_back(pappus::ops::atan<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Sinh):
-                    primal_.push_back(pappus::ops::sinh<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Cosh):
-                    primal_.push_back(pappus::ops::cosh<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Tanh):
-                    primal_.push_back(pappus::ops::tanh<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Pow): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    primal_.push_back(pappus::ops::pow<Scalar>(ctx_, primal_[j], primal_[k]) * v);
-                    break;
-                }
-                case Operon::Hash(BuiltinOp::Aq): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    primal_.push_back(pappus::ops::aq<Scalar>(ctx_, primal_[j], primal_[k]) * v);
-                    break;
-                }
-                case Operon::Hash(BuiltinOp::Abs):
-                    // May throw if the domain crosses zero (requires Chebyshev V-shape).
-                    primal_.push_back(pappus::ops::abs<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Sqrtabs):
-                    primal_.push_back(pappus::ops::sqrtabs<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Logabs):
-                    primal_.push_back(pappus::ops::logabs<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Powabs): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    auto absBase = pappus::ops::abs<Scalar>(ctx_, primal_[j]);
-                    primal_.push_back(pappus::ops::pow<Scalar>(ctx_, absBase, primal_[k]) * v);
-                    break;
-                }
                 case Operon::Hash(BuiltinOp::Fmin):
                     primal_.push_back(minFold(i) * v);
                     break;
                 case Operon::Hash(BuiltinOp::Fmax):
                     primal_.push_back(maxFold(i) * v);
                     break;
-                case Operon::Hash(BuiltinOp::Cbrt):
-                    primal_.push_back(pappus::ops::cbrt<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Log1p):
-                    // May throw if the domain includes values <= -1.
-                    primal_.push_back(pappus::ops::log1p<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Floor):
-                    primal_.push_back(pappus::ops::floor<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
-                case Operon::Hash(BuiltinOp::Ceil):
-                    primal_.push_back(pappus::ops::ceil<Scalar>(ctx_, primal_[i - 1]) * v);
-                    break;
                 default:
-                    throw std::runtime_error(fmt::format(
-                        "AffineEvaluator: node kind `{}` not yet mapped",
-                        node.Name()));
+                    if (auto const* unary = AffineUnaryRules().TryGet(node.HashValue)) {
+                        primal_.push_back((*unary)(ctx_, primal_[i - 1]) * v);
+                    } else if (auto const* binary = AffineBinaryRules().TryGet(node.HashValue)) {
+                        auto const j = static_cast<std::size_t>(i - 1);
+                        auto const k = j - (nodes[j].Length + 1);
+                        primal_.push_back((*binary)(ctx_, primal_[j], primal_[k]) * v);
+                    } else {
+                        throw std::runtime_error(fmt::format(
+                            "AffineEvaluator: node kind `{}` not yet mapped",
+                            node.Name()));
+                    }
                 }
             }
         }
@@ -294,6 +276,55 @@ public:
     }
 
 private:
+    // Registers the built-in unary/binary affine rules exactly once,
+    // mirroring IntervalEvaluator::RegisterBuiltins(). Every rule is lifted
+    // verbatim out of the old switch above, each calling `pappus::ops::xxx`
+    // fully qualified (see interval_evaluator.hpp for the ADL rationale).
+    static void RegisterBuiltins()
+    {
+        static auto const registered = [] {
+            auto& unary  = AffineUnaryRules();
+            auto& binary = AffineBinaryRules();
+
+            unary.Register(Operon::Hash(BuiltinOp::Square), [](Context const& ctx, Affine const& v) { return pappus::ops::square<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sqrt), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrt<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Exp), [](Context const& ctx, Affine const& v) { return pappus::ops::exp<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Log), [](Context const& ctx, Affine const& v) { return pappus::ops::log<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sin), [](Context const& ctx, Affine const& v) { return pappus::ops::sin<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cos), [](Context const& ctx, Affine const& v) { return pappus::ops::cos<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Tan), [](Context const& ctx, Affine const& v) { return pappus::ops::tan<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Asin), [](Context const& ctx, Affine const& v) { return pappus::ops::asin<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Acos), [](Context const& ctx, Affine const& v) { return pappus::ops::acos<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Atan), [](Context const& ctx, Affine const& v) { return pappus::ops::atan<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sinh), [](Context const& ctx, Affine const& v) { return pappus::ops::sinh<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cosh), [](Context const& ctx, Affine const& v) { return pappus::ops::cosh<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Tanh), [](Context const& ctx, Affine const& v) { return pappus::ops::tanh<Scalar>(ctx, v); });
+            // May throw if the domain crosses zero (requires Chebyshev V-shape).
+            unary.Register(Operon::Hash(BuiltinOp::Abs), [](Context const& ctx, Affine const& v) { return pappus::ops::abs<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrtabs<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Logabs), [](Context const& ctx, Affine const& v) { return pappus::ops::logabs<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cbrt), [](Context const& ctx, Affine const& v) { return pappus::ops::cbrt<Scalar>(ctx, v); });
+            // May throw if the domain includes values <= -1.
+            unary.Register(Operon::Hash(BuiltinOp::Log1p), [](Context const& ctx, Affine const& v) { return pappus::ops::log1p<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Floor), [](Context const& ctx, Affine const& v) { return pappus::ops::floor<Scalar>(ctx, v); });
+            unary.Register(Operon::Hash(BuiltinOp::Ceil), [](Context const& ctx, Affine const& v) { return pappus::ops::ceil<Scalar>(ctx, v); });
+
+            binary.Register(Operon::Hash(BuiltinOp::Pow), [](Context const& ctx, Affine const& a, Affine const& b) {
+                return pappus::ops::pow<Scalar>(ctx, a, b);
+            });
+            binary.Register(Operon::Hash(BuiltinOp::Aq), [](Context const& ctx, Affine const& a, Affine const& b) {
+                return pappus::ops::aq<Scalar>(ctx, a, b);
+            });
+            binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Context const& ctx, Affine const& a, Affine const& b) {
+                auto absBase = pappus::ops::abs<Scalar>(ctx, a);
+                return pappus::ops::pow<Scalar>(ctx, absBase, b);
+            });
+
+            return true;
+        }();
+        static_cast<void>(registered);
+    }
+
     gsl::not_null<Operon::Tree const*> tree_;
     DomainMap domains_;
     mutable Context ctx_; // shared by all forms; counter grows monotonically

--- a/include/operon/interpreter/affine_evaluator.hpp
+++ b/include/operon/interpreter/affine_evaluator.hpp
@@ -56,6 +56,9 @@ using AffineBinaryFn = std::function<pappus::affine_form<Operon::Scalar>(
 using AffineUnaryRegistry  = HashRegistry<AffineUnaryFn>;
 using AffineBinaryRegistry = HashRegistry<AffineBinaryFn>;
 
+// Direct registry access — see interval_evaluator.hpp's matching comment.
+// Prefer RegisterUnaryAffine/RegisterBinaryAffine over calling .Register()
+// on the registry returned here directly.
 inline auto AffineUnaryRules() -> AffineUnaryRegistry&
 {
     static AffineUnaryRegistry registry;
@@ -68,20 +71,82 @@ inline auto AffineBinaryRules() -> AffineBinaryRegistry&
     return registry;
 }
 
+// Registers the built-in unary/binary affine rules exactly once, mirroring
+// interval_evaluator.hpp's RegisterIntervalBuiltins(). Every rule is lifted
+// verbatim out of AffineEvaluator's old switch statement, each calling
+// `pappus::ops::xxx` fully qualified (see interval_evaluator.hpp for the ADL
+// rationale). A free function (not an AffineEvaluator member) so both
+// AffineEvaluator::Evaluate() and the public Register{Unary,Binary}Affine()
+// entry points below can call it — the latter must trigger it before
+// writing, for the same reason RegisterIntervalBuiltins() does: a user hash
+// colliding with a built-in should throw immediately at the user's own call
+// site, not later inside Evaluate().
+inline void RegisterAffineBuiltins()
+{
+    using Scalar = Operon::Scalar;
+    using Affine = pappus::affine_form<Scalar>;
+    using Context = pappus::ops::affine_context<Scalar>;
+    static auto const registered = [] {
+        auto& unary  = AffineUnaryRules();
+        auto& binary = AffineBinaryRules();
+
+        unary.Register(Operon::Hash(BuiltinOp::Square), [](Context const& ctx, Affine const& v) { return pappus::ops::square<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrt), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrt<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Exp), [](Context const& ctx, Affine const& v) { return pappus::ops::exp<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log), [](Context const& ctx, Affine const& v) { return pappus::ops::log<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sin), [](Context const& ctx, Affine const& v) { return pappus::ops::sin<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cos), [](Context const& ctx, Affine const& v) { return pappus::ops::cos<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tan), [](Context const& ctx, Affine const& v) { return pappus::ops::tan<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Asin), [](Context const& ctx, Affine const& v) { return pappus::ops::asin<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Acos), [](Context const& ctx, Affine const& v) { return pappus::ops::acos<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Atan), [](Context const& ctx, Affine const& v) { return pappus::ops::atan<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sinh), [](Context const& ctx, Affine const& v) { return pappus::ops::sinh<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cosh), [](Context const& ctx, Affine const& v) { return pappus::ops::cosh<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tanh), [](Context const& ctx, Affine const& v) { return pappus::ops::tanh<Scalar>(ctx, v); });
+        // May throw if the domain crosses zero (requires Chebyshev V-shape).
+        unary.Register(Operon::Hash(BuiltinOp::Abs), [](Context const& ctx, Affine const& v) { return pappus::ops::abs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrtabs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Logabs), [](Context const& ctx, Affine const& v) { return pappus::ops::logabs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cbrt), [](Context const& ctx, Affine const& v) { return pappus::ops::cbrt<Scalar>(ctx, v); });
+        // May throw if the domain includes values <= -1.
+        unary.Register(Operon::Hash(BuiltinOp::Log1p), [](Context const& ctx, Affine const& v) { return pappus::ops::log1p<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Floor), [](Context const& ctx, Affine const& v) { return pappus::ops::floor<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Ceil), [](Context const& ctx, Affine const& v) { return pappus::ops::ceil<Scalar>(ctx, v); });
+
+        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Context const& ctx, Affine const& a, Affine const& b) {
+            return pappus::ops::pow<Scalar>(ctx, a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Context const& ctx, Affine const& a, Affine const& b) {
+            return pappus::ops::aq<Scalar>(ctx, a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Context const& ctx, Affine const& a, Affine const& b) {
+            auto absBase = pappus::ops::abs<Scalar>(ctx, a);
+            return pappus::ops::pow<Scalar>(ctx, absBase, b);
+        });
+
+        return true;
+    }();
+    static_cast<void>(registered);
+}
+
 // Register an affine callback for a unary function (built-in or
 // user-defined), keyed by the same hash the function's Node::HashValue
 // carries. A miss at evaluation time means the tree cannot be bounded at
 // all — AffineEvaluator::Evaluate() still throws on a miss, unchanged from
-// today. Throws if `hash` is already registered (write-once).
+// today. Throws if `hash` is already registered (write-once) — including
+// when `hash` collides with a built-in, since RegisterAffineBuiltins() above
+// always runs first.
 inline void RegisterUnaryAffine(Operon::Hash hash, AffineUnaryFn fn)
 {
+    RegisterAffineBuiltins();
     AffineUnaryRules().Register(hash, std::move(fn));
 }
 
 // Register an affine callback for a binary function. See
-// RegisterUnaryAffine for the miss-behavior note.
+// RegisterUnaryAffine for the miss-behavior and built-in-collision notes.
 inline void RegisterBinaryAffine(Operon::Hash hash, AffineBinaryFn fn)
 {
+    RegisterAffineBuiltins();
     AffineBinaryRules().Register(hash, std::move(fn));
 }
 
@@ -141,7 +206,7 @@ public:
         // indices, causing pappus to merge terms from independent evaluations
         // and produce falsely-narrow enclosures.
 
-        RegisterBuiltins();
+        RegisterAffineBuiltins();
 
         auto const& nodes = tree_->Nodes();
         auto const n = nodes.size();
@@ -258,17 +323,27 @@ public:
                     primal_.push_back(maxFold(i) * v);
                     break;
                 default:
-                    if (auto const* unary = AffineUnaryRules().TryGet(node.HashValue)) {
-                        primal_.push_back((*unary)(ctx_, primal_[i - 1]) * v);
-                    } else if (auto const* binary = AffineBinaryRules().TryGet(node.HashValue)) {
-                        auto const j = static_cast<std::size_t>(i - 1);
-                        auto const k = j - (nodes[j].Length + 1);
-                        primal_.push_back((*binary)(ctx_, primal_[j], primal_[k]) * v);
-                    } else {
-                        throw std::runtime_error(fmt::format(
-                            "AffineEvaluator: node kind `{}` not yet mapped",
-                            node.Name()));
+                    // Gated on the node's actual arity (exactly 1 for unary,
+                    // exactly 2 for binary) — see interval_evaluator.hpp's
+                    // matching comment for the full rationale, including why
+                    // arity 0 / arity >= 3 must also fall through to the
+                    // throw rather than only guarding against 1-vs-2.
+                    if (node.Arity == 1) {
+                        if (auto const* unary = AffineUnaryRules().TryGet(node.HashValue)) {
+                            primal_.push_back((*unary)(ctx_, primal_[i - 1]) * v);
+                            break;
+                        }
+                    } else if (node.Arity == 2) {
+                        if (auto const* binary = AffineBinaryRules().TryGet(node.HashValue)) {
+                            auto const j = static_cast<std::size_t>(i - 1);
+                            auto const k = j - (nodes[j].Length + 1);
+                            primal_.push_back((*binary)(ctx_, primal_[j], primal_[k]) * v);
+                            break;
+                        }
                     }
+                    throw std::runtime_error(fmt::format(
+                        "AffineEvaluator: node kind `{}` not yet mapped",
+                        node.Name()));
                 }
             }
         }
@@ -276,55 +351,6 @@ public:
     }
 
 private:
-    // Registers the built-in unary/binary affine rules exactly once,
-    // mirroring IntervalEvaluator::RegisterBuiltins(). Every rule is lifted
-    // verbatim out of the old switch above, each calling `pappus::ops::xxx`
-    // fully qualified (see interval_evaluator.hpp for the ADL rationale).
-    static void RegisterBuiltins()
-    {
-        static auto const registered = [] {
-            auto& unary  = AffineUnaryRules();
-            auto& binary = AffineBinaryRules();
-
-            unary.Register(Operon::Hash(BuiltinOp::Square), [](Context const& ctx, Affine const& v) { return pappus::ops::square<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sqrt), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrt<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Exp), [](Context const& ctx, Affine const& v) { return pappus::ops::exp<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Log), [](Context const& ctx, Affine const& v) { return pappus::ops::log<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sin), [](Context const& ctx, Affine const& v) { return pappus::ops::sin<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cos), [](Context const& ctx, Affine const& v) { return pappus::ops::cos<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Tan), [](Context const& ctx, Affine const& v) { return pappus::ops::tan<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Asin), [](Context const& ctx, Affine const& v) { return pappus::ops::asin<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Acos), [](Context const& ctx, Affine const& v) { return pappus::ops::acos<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Atan), [](Context const& ctx, Affine const& v) { return pappus::ops::atan<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sinh), [](Context const& ctx, Affine const& v) { return pappus::ops::sinh<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cosh), [](Context const& ctx, Affine const& v) { return pappus::ops::cosh<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Tanh), [](Context const& ctx, Affine const& v) { return pappus::ops::tanh<Scalar>(ctx, v); });
-            // May throw if the domain crosses zero (requires Chebyshev V-shape).
-            unary.Register(Operon::Hash(BuiltinOp::Abs), [](Context const& ctx, Affine const& v) { return pappus::ops::abs<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrtabs<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Logabs), [](Context const& ctx, Affine const& v) { return pappus::ops::logabs<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cbrt), [](Context const& ctx, Affine const& v) { return pappus::ops::cbrt<Scalar>(ctx, v); });
-            // May throw if the domain includes values <= -1.
-            unary.Register(Operon::Hash(BuiltinOp::Log1p), [](Context const& ctx, Affine const& v) { return pappus::ops::log1p<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Floor), [](Context const& ctx, Affine const& v) { return pappus::ops::floor<Scalar>(ctx, v); });
-            unary.Register(Operon::Hash(BuiltinOp::Ceil), [](Context const& ctx, Affine const& v) { return pappus::ops::ceil<Scalar>(ctx, v); });
-
-            binary.Register(Operon::Hash(BuiltinOp::Pow), [](Context const& ctx, Affine const& a, Affine const& b) {
-                return pappus::ops::pow<Scalar>(ctx, a, b);
-            });
-            binary.Register(Operon::Hash(BuiltinOp::Aq), [](Context const& ctx, Affine const& a, Affine const& b) {
-                return pappus::ops::aq<Scalar>(ctx, a, b);
-            });
-            binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Context const& ctx, Affine const& a, Affine const& b) {
-                auto absBase = pappus::ops::abs<Scalar>(ctx, a);
-                return pappus::ops::pow<Scalar>(ctx, absBase, b);
-            });
-
-            return true;
-        }();
-        static_cast<void>(registered);
-    }
-
     gsl::not_null<Operon::Tree const*> tree_;
     DomainMap domains_;
     mutable Context ctx_; // shared by all forms; counter grows monotonically

--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -36,10 +36,9 @@ namespace Operon::JIT {
 //
 // AVX2-only, no scalar/SSE counterpart: operon's own build unconditionally
 // requires AVX2 hardware (-march=x86-64-v3 on Linux, /arch:AVX2 on the
-// Windows preset), so the scalar JIT path this file used to also carry is
+// Windows preset), so the scalar JIT path this file used to also carry was
 // dead code on every officially-built platform — deleted rather than
-// ported to a registry (see docs; this repo's local planning notes have the
-// full investigation).
+// ported to a registry.
 using JitUnaryCodegenFn  = std::function<asmjit::x86::Vec(asmjit::x86::Compiler&, asmjit::x86::Vec const&)>;
 using JitBinaryCodegenFn = std::function<asmjit::x86::Vec(asmjit::x86::Compiler&, asmjit::x86::Vec const&, asmjit::x86::Vec const&)>;
 
@@ -148,14 +147,12 @@ class OPERON_EXPORT TreeCompiler {
 public:
     explicit TreeCompiler(JitRuntimePool const* pool) : pool_(pool) {}
 
-    // AVX2-only: no scalar/SSE fallback path (deleted along with
-    // EmitNodesScalar — dead code given operon's own build-wide AVX2
-    // requirement, see hash_registry.hpp-adjacent design notes). Returns
-    // nullptr if AVX2 unavailable, an op has no registered codegen, or
-    // compile fails for any other reason — all three degrade the same way,
-    // to interpreter fallback at the JitEvaluator layer.
-    //
-    // AVX2 vectorized path (8 rows/iter). Returns nullptr if AVX2 unavailable or compile fails.
+    // AVX2 vectorized path (8 rows/iter). No scalar/SSE fallback path
+    // (deleted along with EmitNodesScalar — dead code given operon's own
+    // build-wide AVX2 requirement). Returns nullptr if AVX2 unavailable, an
+    // op has no registered codegen, or compile fails for any other reason —
+    // all three degrade the same way, to interpreter fallback at the
+    // JitEvaluator layer.
     auto CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<CompileMeta>;
 
     // Compiles all ∂f/∂c_k. Returns nullptr if AVX2 unavailable, no roots, or compile fails.

--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -10,15 +10,62 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <vector>
 
+#include "operon/core/hash_registry.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/tree_diff.hpp"
 #include "operon/core/types.hpp"
 #include "operon/operon_export.hpp"
 
 namespace Operon::JIT {
+
+// Registered AVX2 codegen callbacks for unary/binary built-in or user-defined
+// functions, keyed by Node::HashValue. Each callback emits asmjit
+// instructions for one op's result into a fresh Vec (a ymm_ps register),
+// given already-emitted operand Vec(s) — the same "emit into a stack slot"
+// shape EmitNodesAvx2's old switch cases had, just as standalone callables.
+// Scoped to asmjit's x86::Compiler virtual-register API only (never raw
+// x86::Assembler), matching the codegen this file already emits everywhere
+// else — a structural safety measure, not just a style choice: Compiler's
+// virtual-register allocator (as opposed to Assembler's fixed physical
+// registers) is what makes composing independently-written callbacks safe
+// without them fighting over concrete registers.
+//
+// AVX2-only, no scalar/SSE counterpart: operon's own build unconditionally
+// requires AVX2 hardware (-march=x86-64-v3 on Linux, /arch:AVX2 on the
+// Windows preset), so the scalar JIT path this file used to also carry is
+// dead code on every officially-built platform — deleted rather than
+// ported to a registry (see docs; this repo's local planning notes have the
+// full investigation).
+using JitUnaryCodegenFn  = std::function<asmjit::x86::Vec(asmjit::x86::Compiler&, asmjit::x86::Vec const&)>;
+using JitBinaryCodegenFn = std::function<asmjit::x86::Vec(asmjit::x86::Compiler&, asmjit::x86::Vec const&, asmjit::x86::Vec const&)>;
+
+using JitUnaryCodegenRegistry  = HashRegistry<JitUnaryCodegenFn>;
+using JitBinaryCodegenRegistry = HashRegistry<JitBinaryCodegenFn>;
+
+// Register an AVX2 codegen callback for a unary function (built-in or
+// user-defined), keyed by the same hash the function's Node::HashValue
+// carries. A miss at compile time means that tree isn't JIT-compilable —
+// CompileAVX2/CompileJacobian fall back to returning nullptr (the existing
+// JitEvaluator caller already treats a nullptr compile result as "use the
+// interpreter for this tree"), not a thrown exception reaching the caller.
+// Throws if `hash` is already registered (write-once).
+OPERON_EXPORT void RegisterUnaryJitCodegen(Operon::Hash hash, JitUnaryCodegenFn fn);
+
+// Register an AVX2 codegen callback for a binary function. See
+// RegisterUnaryJitCodegen for the miss-behavior note.
+OPERON_EXPORT void RegisterBinaryJitCodegen(Operon::Hash hash, JitBinaryCodegenFn fn);
+
+// Query whether an AVX2 codegen callback is registered for `hash` (built-in
+// or user-defined), forcing built-in registration first. Mainly useful for
+// coverage checks (e.g. asserting every BuiltinOp is either registered here
+// or deliberately excluded as a structural n-ary case handled directly in
+// EmitNodesAvx2).
+OPERON_EXPORT auto HasUnaryJitCodegen(Operon::Hash hash) -> bool;
+OPERON_EXPORT auto HasBinaryJitCodegen(Operon::Hash hash) -> bool;
 
 // Compiled forward-pass signature.
 //   out:    float[nRows]
@@ -101,9 +148,13 @@ class OPERON_EXPORT TreeCompiler {
 public:
     explicit TreeCompiler(JitRuntimePool const* pool) : pool_(pool) {}
 
-    // Scalar path. Returns nullptr on failure.
-    auto Compile(Operon::Tree const& tree) -> std::unique_ptr<CompileMeta>;
-
+    // AVX2-only: no scalar/SSE fallback path (deleted along with
+    // EmitNodesScalar — dead code given operon's own build-wide AVX2
+    // requirement, see hash_registry.hpp-adjacent design notes). Returns
+    // nullptr if AVX2 unavailable, an op has no registered codegen, or
+    // compile fails for any other reason — all three degrade the same way,
+    // to interpreter fallback at the JitEvaluator layer.
+    //
     // AVX2 vectorized path (8 rows/iter). Returns nullptr if AVX2 unavailable or compile fails.
     auto CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<CompileMeta>;
 

--- a/include/operon/interpreter/interval_evaluator.hpp
+++ b/include/operon/interpreter/interval_evaluator.hpp
@@ -61,6 +61,13 @@ using IntervalBinaryFn = std::function<pappus::interval<Operon::Scalar>(pappus::
 using IntervalUnaryRegistry  = HashRegistry<IntervalUnaryFn>;
 using IntervalBinaryRegistry = HashRegistry<IntervalBinaryFn>;
 
+// Direct registry access — needed by RegisterUnaryInterval/RegisterBinaryInterval
+// below (same TU) and by tests that assert on registration state. Prefer
+// RegisterUnaryInterval/RegisterBinaryInterval for registering a rule: calling
+// .Register() on the registry returned here directly skips the built-in
+// lazy-init those functions trigger first, reopening the ordering hazard they
+// exist to close (a user hash colliding with a built-in would be silently
+// accepted instead of throwing immediately).
 inline auto IntervalUnaryRules() -> IntervalUnaryRegistry&
 {
     static IntervalUnaryRegistry registry;
@@ -73,21 +80,83 @@ inline auto IntervalBinaryRules() -> IntervalBinaryRegistry&
     return registry;
 }
 
+// Registers the built-in unary/binary interval rules exactly once, mirroring
+// StandardLibrary::RegisterNames()'s lazy-static-lambda-once pattern. Every
+// rule is lifted verbatim out of IntervalEvaluator's old switch statement;
+// each lambda calls `pappus::ops::xxx` fully qualified rather than relying on
+// ADL, sidestepping the pappus::ops sibling-namespace ADL gap entirely (that
+// gap only bites a generic lambda expecting implicit lookup — these are
+// written inside operon's own code and can just spell out the qualified
+// name, same as the switch bodies already did). A free function (not an
+// IntervalEvaluator member) so both IntervalEvaluator::Evaluate() and the
+// public Register{Unary,Binary}Interval() entry points below can call it —
+// the latter must trigger it before writing, so that a user hash colliding
+// with a built-in throws immediately at the user's own call site instead of
+// being accepted now and only discovered (as a confusing, differently-hashed
+// throw) the first time Evaluate() runs.
+inline void RegisterIntervalBuiltins()
+{
+    using Scalar = Operon::Scalar;
+    using Interval = pappus::interval<Scalar>;
+    static auto const registered = [] {
+        auto& unary  = IntervalUnaryRules();
+        auto& binary = IntervalBinaryRules();
+
+        unary.Register(Operon::Hash(BuiltinOp::Square),  [](Interval const& v) { return pappus::ops::square<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrt),    [](Interval const& v) { return pappus::ops::sqrt<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Exp),     [](Interval const& v) { return pappus::ops::exp<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log),     [](Interval const& v) { return pappus::ops::log<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sin),     [](Interval const& v) { return pappus::ops::sin<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cos),     [](Interval const& v) { return pappus::ops::cos<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tan),     [](Interval const& v) { return pappus::ops::tan<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Asin),    [](Interval const& v) { return pappus::ops::asin<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Acos),    [](Interval const& v) { return pappus::ops::acos<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Atan),    [](Interval const& v) { return pappus::ops::atan<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sinh),    [](Interval const& v) { return pappus::ops::sinh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cosh),    [](Interval const& v) { return pappus::ops::cosh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tanh),    [](Interval const& v) { return pappus::ops::tanh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Abs),     [](Interval const& v) { return pappus::ops::abs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Interval const& v) { return pappus::ops::sqrtabs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Logabs),  [](Interval const& v) { return pappus::ops::logabs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cbrt),    [](Interval const& v) { return pappus::ops::cbrt<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log1p),   [](Interval const& v) { return pappus::ops::log1p<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Floor),   [](Interval const& v) { return pappus::ops::floor<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Ceil),    [](Interval const& v) { return pappus::ops::ceil<Scalar>(v); });
+
+        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Interval const& a, Interval const& b) {
+            return pappus::ops::pow<Scalar>(a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Interval const& a, Interval const& b) {
+            return pappus::ops::aq<Scalar>(a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Interval const& a, Interval const& b) {
+            return pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(a), b);
+        });
+
+        return true;
+    }();
+    static_cast<void>(registered);
+}
+
 // Register an interval callback for a unary function (built-in or
 // user-defined), keyed by the same hash the function's Node::HashValue
 // carries. A miss at evaluation time is not "not differentiable" the way a
 // missing tree_diff rule is — it means the tree cannot be bounded at all,
 // and IntervalEvaluator::Evaluate() still throws on a miss, unchanged from
-// today. Throws if `hash` is already registered (write-once).
+// today. Throws if `hash` is already registered (write-once) — including
+// when `hash` collides with a built-in, since RegisterIntervalBuiltins()
+// above always runs first.
 inline void RegisterUnaryInterval(Operon::Hash hash, IntervalUnaryFn fn)
 {
+    RegisterIntervalBuiltins();
     IntervalUnaryRules().Register(hash, std::move(fn));
 }
 
 // Register an interval callback for a binary function. See
-// RegisterUnaryInterval for the miss-behavior note.
+// RegisterUnaryInterval for the miss-behavior and built-in-collision notes.
 inline void RegisterBinaryInterval(Operon::Hash hash, IntervalBinaryFn fn)
 {
+    RegisterIntervalBuiltins();
     IntervalBinaryRules().Register(hash, std::move(fn));
 }
 
@@ -131,7 +200,7 @@ public:
     // `Node::Optimize == true`, consumed in node order.
     [[nodiscard]] auto Evaluate(Operon::Span<Scalar const> coeff) const -> Interval
     {
-        RegisterBuiltins();
+        RegisterIntervalBuiltins();
 
         auto const& nodes = tree_->Nodes();
         auto const n = nodes.size();
@@ -227,10 +296,9 @@ public:
             } else {
                 // Add/Mul/Sub/Div/Fmin/Fmax stay hardcoded: each is a verified
                 // n-ary fold over an arbitrary number of children, not a
-                // single-hash unary/binary registry entry (see
-                // tinkering-glowing-anvil.md's PR 9 scope boundary). Every
-                // other op — unary and binary alike — goes through the
-                // registry, built-in or user-defined.
+                // single-hash unary/binary registry entry. Every other op —
+                // unary and binary alike — goes through the registry,
+                // built-in or user-defined.
                 switch (node.HashValue) {
                 case Operon::Hash(BuiltinOp::Add):
                     primal_[i] = addFold(i) * v;
@@ -253,17 +321,31 @@ public:
                     primal_[i] = maxFold(i) * v;
                     break;
                 default:
-                    if (auto const* unary = IntervalUnaryRules().TryGet(node.HashValue)) {
-                        primal_[i] = (*unary)(primal_[i - 1]) * v;
-                    } else if (auto const* binary = IntervalBinaryRules().TryGet(node.HashValue)) {
-                        auto const j = static_cast<std::size_t>(i - 1);
-                        auto const k = j - (nodes[j].Length + 1);
-                        primal_[i] = (*binary)(primal_[j], primal_[k]) * v;
-                    } else {
-                        throw std::runtime_error(fmt::format(
-                            "IntervalEvaluator: node kind `{}` not yet mapped",
-                            node.Name()));
+                    // Gated on the node's actual arity (exactly 1 for unary,
+                    // exactly 2 for binary) so a hash mistakenly registered
+                    // under the wrong registry falls through to the "not yet
+                    // mapped" throw below, rather than reading a nonexistent
+                    // operand (arity 1 through the binary path), silently
+                    // ignoring one (arity 2 through the unary path), or —
+                    // for arity 0 or arity >= 3 registered as binary —
+                    // reading unrelated primal_ entries or dropping operands
+                    // beyond the first two.
+                    if (node.Arity == 1) {
+                        if (auto const* unary = IntervalUnaryRules().TryGet(node.HashValue)) {
+                            primal_[i] = (*unary)(primal_[i - 1]) * v;
+                            break;
+                        }
+                    } else if (node.Arity == 2) {
+                        if (auto const* binary = IntervalBinaryRules().TryGet(node.HashValue)) {
+                            auto const j = static_cast<std::size_t>(i - 1);
+                            auto const k = j - (nodes[j].Length + 1);
+                            primal_[i] = (*binary)(primal_[j], primal_[k]) * v;
+                            break;
+                        }
                     }
+                    throw std::runtime_error(fmt::format(
+                        "IntervalEvaluator: node kind `{}` not yet mapped",
+                        node.Name()));
                 }
             }
         }
@@ -271,56 +353,6 @@ public:
     }
 
 private:
-    // Registers the built-in unary/binary interval rules exactly once,
-    // mirroring StandardLibrary::RegisterNames()'s lazy-static-lambda-once
-    // pattern. Every rule is lifted verbatim out of the old switch above;
-    // each lambda calls `pappus::ops::xxx` fully qualified rather than
-    // relying on ADL, sidestepping the pappus::ops sibling-namespace ADL
-    // gap entirely (that gap only bites a generic lambda expecting implicit
-    // lookup — these are written inside operon's own code and can just
-    // spell out the qualified name, same as the switch bodies already did).
-    static void RegisterBuiltins()
-    {
-        static auto const registered = [] {
-            auto& unary  = IntervalUnaryRules();
-            auto& binary = IntervalBinaryRules();
-
-            unary.Register(Operon::Hash(BuiltinOp::Square),  [](Interval const& v) { return pappus::ops::square<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sqrt),    [](Interval const& v) { return pappus::ops::sqrt<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Exp),     [](Interval const& v) { return pappus::ops::exp<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Log),     [](Interval const& v) { return pappus::ops::log<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sin),     [](Interval const& v) { return pappus::ops::sin<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cos),     [](Interval const& v) { return pappus::ops::cos<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Tan),     [](Interval const& v) { return pappus::ops::tan<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Asin),    [](Interval const& v) { return pappus::ops::asin<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Acos),    [](Interval const& v) { return pappus::ops::acos<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Atan),    [](Interval const& v) { return pappus::ops::atan<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sinh),    [](Interval const& v) { return pappus::ops::sinh<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cosh),    [](Interval const& v) { return pappus::ops::cosh<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Tanh),    [](Interval const& v) { return pappus::ops::tanh<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Abs),     [](Interval const& v) { return pappus::ops::abs<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Interval const& v) { return pappus::ops::sqrtabs<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Logabs),  [](Interval const& v) { return pappus::ops::logabs<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Cbrt),    [](Interval const& v) { return pappus::ops::cbrt<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Log1p),   [](Interval const& v) { return pappus::ops::log1p<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Floor),   [](Interval const& v) { return pappus::ops::floor<Scalar>(v); });
-            unary.Register(Operon::Hash(BuiltinOp::Ceil),    [](Interval const& v) { return pappus::ops::ceil<Scalar>(v); });
-
-            binary.Register(Operon::Hash(BuiltinOp::Pow), [](Interval const& a, Interval const& b) {
-                return pappus::ops::pow<Scalar>(a, b);
-            });
-            binary.Register(Operon::Hash(BuiltinOp::Aq), [](Interval const& a, Interval const& b) {
-                return pappus::ops::aq<Scalar>(a, b);
-            });
-            binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Interval const& a, Interval const& b) {
-                return pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(a), b);
-            });
-
-            return true;
-        }();
-        static_cast<void>(registered);
-    }
-
     gsl::not_null<Operon::Tree const*> tree_;
     DomainMap domains_;
     mutable std::vector<Interval> primal_; // reused across Evaluate calls

--- a/include/operon/interpreter/interval_evaluator.hpp
+++ b/include/operon/interpreter/interval_evaluator.hpp
@@ -5,12 +5,14 @@
 #define OPERON_INTERVAL_EVALUATOR_HPP
 
 #include <fmt/format.h>
+#include <functional>
 #include <gsl/pointers>
 #include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include "operon/core/contracts.hpp"
+#include "operon/core/hash_registry.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
@@ -36,6 +38,58 @@
 #endif
 
 namespace Operon {
+
+// Registered interval callbacks for unary/binary built-in or user-defined
+// functions, keyed by Node::HashValue. Global function-local-static
+// singletons (`inline` for one-definition-rule safety, since
+// IntervalEvaluator is a header-only class with no .cpp) mirroring the
+// pattern used by tree_diff.cpp's SymbolicDerivRegistry: no registry
+// parameter needs to thread through IntervalEvaluator's constructor or
+// Evaluate(). All writes (built-in registration below, plus any user calls
+// to RegisterUnaryInterval/RegisterBinaryInterval) happen before Evaluate()
+// is first called from a GP worker thread, so the plain (non-locking)
+// Operon::Map HashRegistry already uses is sufficient — no sharded-lock map
+// type needed, same read-only-after-setup contract DispatchTable relies on.
+//
+// Only two argument shapes are needed (not three, despite pappus's
+// PAPPUS_DEFINE_UNARY_OP macro generating three overloads per op): interval
+// calls never take a context, unlike affine's context-threaded finalize
+// overload (see affine_evaluator.hpp).
+using IntervalUnaryFn  = std::function<pappus::interval<Operon::Scalar>(pappus::interval<Operon::Scalar> const&)>;
+using IntervalBinaryFn = std::function<pappus::interval<Operon::Scalar>(pappus::interval<Operon::Scalar> const&, pappus::interval<Operon::Scalar> const&)>;
+
+using IntervalUnaryRegistry  = HashRegistry<IntervalUnaryFn>;
+using IntervalBinaryRegistry = HashRegistry<IntervalBinaryFn>;
+
+inline auto IntervalUnaryRules() -> IntervalUnaryRegistry&
+{
+    static IntervalUnaryRegistry registry;
+    return registry;
+}
+
+inline auto IntervalBinaryRules() -> IntervalBinaryRegistry&
+{
+    static IntervalBinaryRegistry registry;
+    return registry;
+}
+
+// Register an interval callback for a unary function (built-in or
+// user-defined), keyed by the same hash the function's Node::HashValue
+// carries. A miss at evaluation time is not "not differentiable" the way a
+// missing tree_diff rule is — it means the tree cannot be bounded at all,
+// and IntervalEvaluator::Evaluate() still throws on a miss, unchanged from
+// today. Throws if `hash` is already registered (write-once).
+inline void RegisterUnaryInterval(Operon::Hash hash, IntervalUnaryFn fn)
+{
+    IntervalUnaryRules().Register(hash, std::move(fn));
+}
+
+// Register an interval callback for a binary function. See
+// RegisterUnaryInterval for the miss-behavior note.
+inline void RegisterBinaryInterval(Operon::Hash hash, IntervalBinaryFn fn)
+{
+    IntervalBinaryRules().Register(hash, std::move(fn));
+}
 
 // Forward rigorous bounds for an Operon tree over a single input domain.
 //
@@ -77,6 +131,8 @@ public:
     // `Node::Optimize == true`, consumed in node order.
     [[nodiscard]] auto Evaluate(Operon::Span<Scalar const> coeff) const -> Interval
     {
+        RegisterBuiltins();
+
         auto const& nodes = tree_->Nodes();
         auto const n = nodes.size();
         if (n == 0) { throw std::runtime_error("IntervalEvaluator: empty tree"); }
@@ -169,6 +225,12 @@ public:
                 EXPECT(static_cast<std::size_t>(node.RefTo) < i);
                 primal_[i] = primal_[node.RefTo];
             } else {
+                // Add/Mul/Sub/Div/Fmin/Fmax stay hardcoded: each is a verified
+                // n-ary fold over an arbitrary number of children, not a
+                // single-hash unary/binary registry entry (see
+                // tinkering-glowing-anvil.md's PR 9 scope boundary). Every
+                // other op — unary and binary alike — goes through the
+                // registry, built-in or user-defined.
                 switch (node.HashValue) {
                 case Operon::Hash(BuiltinOp::Add):
                     primal_[i] = addFold(i) * v;
@@ -184,94 +246,24 @@ public:
                     primal_[i] = (node.Arity == 1 ? pappus::ops::inv<Scalar>(primal_[i - 1])
                                                   : divFold(i)) * v;
                     break;
-                case Operon::Hash(BuiltinOp::Square):
-                    primal_[i] = pappus::ops::square<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Sqrt):
-                    primal_[i] = pappus::ops::sqrt<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Exp):
-                    primal_[i] = pappus::ops::exp<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Log):
-                    primal_[i] = pappus::ops::log<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Sin):
-                    primal_[i] = pappus::ops::sin<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Cos):
-                    primal_[i] = pappus::ops::cos<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Tan):
-                    primal_[i] = pappus::ops::tan<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Asin):
-                    primal_[i] = pappus::ops::asin<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Acos):
-                    primal_[i] = pappus::ops::acos<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Atan):
-                    primal_[i] = pappus::ops::atan<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Sinh):
-                    primal_[i] = pappus::ops::sinh<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Cosh):
-                    primal_[i] = pappus::ops::cosh<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Tanh):
-                    primal_[i] = pappus::ops::tanh<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Pow): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    primal_[i] = pappus::ops::pow<Scalar>(primal_[j], primal_[k]) * v;
-                    break;
-                }
-                case Operon::Hash(BuiltinOp::Abs):
-                    primal_[i] = pappus::ops::abs<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Sqrtabs):
-                    primal_[i] = pappus::ops::sqrtabs<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Logabs):
-                    primal_[i] = pappus::ops::logabs<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Powabs): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    primal_[i] = pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(primal_[j]), primal_[k]) * v;
-                    break;
-                }
-                case Operon::Hash(BuiltinOp::Aq): {
-                    auto const j = static_cast<std::size_t>(i - 1);
-                    auto const k = j - (nodes[j].Length + 1);
-                    primal_[i] = pappus::ops::aq<Scalar>(primal_[j], primal_[k]) * v;
-                    break;
-                }
                 case Operon::Hash(BuiltinOp::Fmin):
                     primal_[i] = minFold(i) * v;
                     break;
                 case Operon::Hash(BuiltinOp::Fmax):
                     primal_[i] = maxFold(i) * v;
                     break;
-                case Operon::Hash(BuiltinOp::Cbrt):
-                    primal_[i] = pappus::ops::cbrt<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Log1p):
-                    primal_[i] = pappus::ops::log1p<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Floor):
-                    primal_[i] = pappus::ops::floor<Scalar>(primal_[i - 1]) * v;
-                    break;
-                case Operon::Hash(BuiltinOp::Ceil):
-                    primal_[i] = pappus::ops::ceil<Scalar>(primal_[i - 1]) * v;
-                    break;
                 default:
-                    throw std::runtime_error(fmt::format(
-                        "IntervalEvaluator: node kind `{}` not yet mapped",
-                        node.Name()));
+                    if (auto const* unary = IntervalUnaryRules().TryGet(node.HashValue)) {
+                        primal_[i] = (*unary)(primal_[i - 1]) * v;
+                    } else if (auto const* binary = IntervalBinaryRules().TryGet(node.HashValue)) {
+                        auto const j = static_cast<std::size_t>(i - 1);
+                        auto const k = j - (nodes[j].Length + 1);
+                        primal_[i] = (*binary)(primal_[j], primal_[k]) * v;
+                    } else {
+                        throw std::runtime_error(fmt::format(
+                            "IntervalEvaluator: node kind `{}` not yet mapped",
+                            node.Name()));
+                    }
                 }
             }
         }
@@ -279,6 +271,56 @@ public:
     }
 
 private:
+    // Registers the built-in unary/binary interval rules exactly once,
+    // mirroring StandardLibrary::RegisterNames()'s lazy-static-lambda-once
+    // pattern. Every rule is lifted verbatim out of the old switch above;
+    // each lambda calls `pappus::ops::xxx` fully qualified rather than
+    // relying on ADL, sidestepping the pappus::ops sibling-namespace ADL
+    // gap entirely (that gap only bites a generic lambda expecting implicit
+    // lookup — these are written inside operon's own code and can just
+    // spell out the qualified name, same as the switch bodies already did).
+    static void RegisterBuiltins()
+    {
+        static auto const registered = [] {
+            auto& unary  = IntervalUnaryRules();
+            auto& binary = IntervalBinaryRules();
+
+            unary.Register(Operon::Hash(BuiltinOp::Square),  [](Interval const& v) { return pappus::ops::square<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sqrt),    [](Interval const& v) { return pappus::ops::sqrt<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Exp),     [](Interval const& v) { return pappus::ops::exp<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Log),     [](Interval const& v) { return pappus::ops::log<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sin),     [](Interval const& v) { return pappus::ops::sin<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cos),     [](Interval const& v) { return pappus::ops::cos<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Tan),     [](Interval const& v) { return pappus::ops::tan<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Asin),    [](Interval const& v) { return pappus::ops::asin<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Acos),    [](Interval const& v) { return pappus::ops::acos<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Atan),    [](Interval const& v) { return pappus::ops::atan<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sinh),    [](Interval const& v) { return pappus::ops::sinh<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cosh),    [](Interval const& v) { return pappus::ops::cosh<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Tanh),    [](Interval const& v) { return pappus::ops::tanh<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Abs),     [](Interval const& v) { return pappus::ops::abs<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Interval const& v) { return pappus::ops::sqrtabs<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Logabs),  [](Interval const& v) { return pappus::ops::logabs<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Cbrt),    [](Interval const& v) { return pappus::ops::cbrt<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Log1p),   [](Interval const& v) { return pappus::ops::log1p<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Floor),   [](Interval const& v) { return pappus::ops::floor<Scalar>(v); });
+            unary.Register(Operon::Hash(BuiltinOp::Ceil),    [](Interval const& v) { return pappus::ops::ceil<Scalar>(v); });
+
+            binary.Register(Operon::Hash(BuiltinOp::Pow), [](Interval const& a, Interval const& b) {
+                return pappus::ops::pow<Scalar>(a, b);
+            });
+            binary.Register(Operon::Hash(BuiltinOp::Aq), [](Interval const& a, Interval const& b) {
+                return pappus::ops::aq<Scalar>(a, b);
+            });
+            binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Interval const& a, Interval const& b) {
+                return pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(a), b);
+            });
+
+            return true;
+        }();
+        static_cast<void>(registered);
+    }
+
     gsl::not_null<Operon::Tree const*> tree_;
     DomainMap domains_;
     mutable std::vector<Interval> primal_; // reused across Evaluate calls

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 
 #include "operon/core/contracts.hpp"
+#include "operon/core/hash_registry.hpp"
 #include "operon/core/subtree.hpp"
 
 namespace Operon {
@@ -111,6 +112,146 @@ auto AddTerms(Nodes& dag, Memo& memo, Hashes& h,
         result = MakeBinary(dag, memo, h, BuiltinOp::Add, result, terms[k]);
     }
     return result;
+}
+
+// Registry of symbolic derivative rules for unary functions, keyed by
+// Node::HashValue. A global, function-local-static singleton (mirroring
+// Node::RegisterName/Descriptions() in node.cpp) so BuildJacobianDag/
+// BuildHessianDag's public signature doesn't need a registry parameter
+// threaded through every call site. Populated once with the built-in rules
+// (RegisterBuiltinSymbolicDerivs, below) plus whatever user-defined rules
+// Operon::RegisterUnarySymbolicDeriv() adds. All writes happen at setup
+// time, before any parallel evaluation starts reading via Deriv() from
+// worker threads — the same read-only-after-setup contract DispatchTable's
+// own (non-locking) Operon::Map already relies on, so no sharded-lock map
+// type is needed here.
+using SymbolicDerivRegistry = HashRegistry<UnarySymbolicDerivRule>;
+
+auto SymbolicDerivRules() -> SymbolicDerivRegistry&
+{
+    static SymbolicDerivRegistry registry;
+    return registry;
+}
+
+// Register the built-in unary derivative rules exactly once. Lives here
+// (rather than in StandardLibrary, which has no visibility into this TU's
+// private hash-consing helpers MakeUnary/MakeBinary/GetConst) mirroring
+// StandardLibrary::RegisterNames()'s lazy-static-lambda-once pattern.
+// Every rule below is lifted verbatim out of Deriv()'s old unary switch;
+// Abs/Sqrtabs/Floor/Ceil are intentionally left unregistered (non-smooth or
+// not-yet-implemented), degrading to Zero exactly like today's `default:`.
+void RegisterBuiltinSymbolicDerivs()
+{
+    static auto const registered = [] {
+        auto& reg = SymbolicDerivRules();
+
+        reg.Register(Operon::Hash(BuiltinOp::Exp),
+            [](Nodes& /*dag*/, Memo& /*memo*/, Hashes& /*h*/, std::size_t i, std::size_t /*j*/) -> std::size_t {
+                return i; // d exp(j)/dj = exp(j) = result
+            });
+
+        UnarySymbolicDerivRule logRule =
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1 = GetConst(dag, memo, h, Scalar{1});
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, j);
+            };
+        reg.Register(Operon::Hash(BuiltinOp::Log), logRule);
+        reg.Register(Operon::Hash(BuiltinOp::Logabs), logRule);
+
+        reg.Register(Operon::Hash(BuiltinOp::Log1p),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1 = GetConst(dag, memo, h, Scalar{1});
+                auto onePlusJ = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, j);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, onePlusJ);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Sin),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                return MakeUnary(dag, memo, h, BuiltinOp::Cos, j);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Cos),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto sinJ = MakeUnary(dag, memo, h, BuiltinOp::Sin, j);
+                auto neg1 = GetConst(dag, memo, h, Scalar{-1});
+                return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, sinJ);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Tan),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
+                auto c1  = GetConst(dag, memo, h, Scalar{1});
+                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+                return MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqI);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Acos),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1    = GetConst(dag, memo, h, Scalar{1});
+                auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+                auto denom = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
+                auto sqD   = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
+                auto recip = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
+                auto neg1  = GetConst(dag, memo, h, Scalar{-1});
+                return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, recip);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Asin),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1    = GetConst(dag, memo, h, Scalar{1});
+                auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+                auto denom = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
+                auto sqD   = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Atan),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1    = GetConst(dag, memo, h, Scalar{1});
+                auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
+                auto denom = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqJ);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, denom);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Sinh),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                return MakeUnary(dag, memo, h, BuiltinOp::Cosh, j);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Cosh),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                return MakeUnary(dag, memo, h, BuiltinOp::Sinh, j);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Tanh),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
+                auto c1  = GetConst(dag, memo, h, Scalar{1});
+                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+                return MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqI);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Sqrt),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
+                auto c2   = GetConst(dag, memo, h, Scalar{2});
+                auto twoJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, i, twoJ);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Cbrt),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
+                auto c3     = GetConst(dag, memo, h, Scalar{3});
+                auto threeJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, j);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, i, threeJ);
+            });
+
+        reg.Register(Operon::Hash(BuiltinOp::Square),
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c2 = GetConst(dag, memo, h, Scalar{2});
+                return MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
+            });
+
+        return true;
+    }();
+    static_cast<void>(registered);
 }
 
 // Forward declaration for mutual recursion.
@@ -295,131 +436,14 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto dj = Deriv(orig, dag, memo, h, j, targetC);
         if (dj == Zero) { return Zero; }
 
-        std::size_t fp = Zero; // symbolic f'(j)
-
-        switch (n.HashValue) {
-        case Operon::Hash(BuiltinOp::Exp):
-            // d exp(j)/dj = exp(j) = result
-            fp = i;
-            break;
-
-        case Operon::Hash(BuiltinOp::Log):
-        case Operon::Hash(BuiltinOp::Logabs): {
-            // d log(j)/dj = 1/j
-            auto c1 = GetConst(dag, memo, h, Scalar{1});
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, j);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Log1p): {
-            // d log(1+j)/dj = 1/(1+j)
-            auto c1 = GetConst(dag, memo, h, Scalar{1});
-            auto onePlusJ = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, j);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, onePlusJ);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Sin):
-            // d sin(j)/dj = cos(j)
-            fp = MakeUnary(dag, memo, h, BuiltinOp::Cos, j);
-            break;
-
-        case Operon::Hash(BuiltinOp::Cos): {
-            // d cos(j)/dj = -sin(j)
-            auto sinJ = MakeUnary(dag, memo, h, BuiltinOp::Sin, j);
-            auto neg1  = GetConst(dag, memo, h, Scalar{-1});
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, sinJ);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Tan): {
-            // d tan(j)/dj = 1 + tan^2(j) = 1 + result^2
-            auto c1   = GetConst(dag, memo, h, Scalar{1});
-            auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqI);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Acos): {
-            // d acos(j)/dj = -1/sqrt(1 - j^2)
-            auto c1     = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
-            auto denom  = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
-            auto sqD   = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
-            auto recip  = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
-            auto neg1   = GetConst(dag, memo, h, Scalar{-1});
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, recip);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Asin): {
-            // d asin(j)/dj = 1/sqrt(1 - j^2)
-            auto c1    = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ  = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
-            auto denom = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
-            auto sqD  = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, denom);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, sqD);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Atan): {
-            // d atan(j)/dj = 1/(1 + j^2)
-            auto c1    = GetConst(dag, memo, h, Scalar{1});
-            auto sqJ  = MakeUnary(dag, memo, h, BuiltinOp::Square, j);
-            auto denom = MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqJ);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, c1, denom);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Sinh):
-            // d sinh(j)/dj = cosh(j)
-            fp = MakeUnary(dag, memo, h, BuiltinOp::Cosh, j);
-            break;
-
-        case Operon::Hash(BuiltinOp::Cosh):
-            // d cosh(j)/dj = sinh(j)
-            fp = MakeUnary(dag, memo, h, BuiltinOp::Sinh, j);
-            break;
-
-        case Operon::Hash(BuiltinOp::Tanh): {
-            // d tanh(j)/dj = 1 - tanh^2(j) = 1 - result^2
-            auto c1   = GetConst(dag, memo, h, Scalar{1});
-            auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqI);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Sqrt): {
-            // d sqrt(j)/dj = result / (2 * j)
-            auto c2   = GetConst(dag, memo, h, Scalar{2});
-            auto twoJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, i, twoJ);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Cbrt): {
-            // d cbrt(j)/dj = result / (3 * j)
-            auto c3    = GetConst(dag, memo, h, Scalar{3});
-            auto threeJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, j);
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Div, i, threeJ);
-            break;
-        }
-
-        case Operon::Hash(BuiltinOp::Square): {
-            // d j^2/dj = 2 * j
-            auto c2 = GetConst(dag, memo, h, Scalar{2});
-            fp = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
-            break;
-        }
-
-        // Non-smooth or not-yet-implemented: return zero gradient.
-        case Operon::Hash(BuiltinOp::Abs):
-        case Operon::Hash(BuiltinOp::Sqrtabs):
-        case Operon::Hash(BuiltinOp::Floor):
-        case Operon::Hash(BuiltinOp::Ceil):
-        default:
-            return Zero;
-        }
+        // Registry lookup replaces the old hardcoded switch (see
+        // RegisterBuiltinSymbolicDerivs above for the ~15 built-in rules,
+        // migrated verbatim). A miss — including Abs/Sqrtabs/Floor/Ceil,
+        // deliberately left unregistered — degrades to Zero exactly like
+        // today's `default: return Zero;` did.
+        auto const* rule = SymbolicDerivRules().TryGet(n.HashValue);
+        if (rule == nullptr) { return Zero; }
+        auto fp = (*rule)(dag, memo, h, i, j); // symbolic f'(j)
 
         if (fp == Zero) { return Zero; }
         return MakeBinary(dag, memo, h, BuiltinOp::Mul, fp, dj);
@@ -438,6 +462,8 @@ auto DifferentiateFirstOrder(
     Operon::Vector<std::size_t>& roots, std::size_t reserveFactor
 ) -> Operon::Vector<std::size_t>
 {
+    RegisterBuiltinSymbolicDerivs();
+
     auto const& orig = tree.Nodes();
     auto const n     = orig.size();
 
@@ -465,6 +491,17 @@ auto DifferentiateFirstOrder(
 }
 
 } // anonymous namespace
+
+void RegisterUnarySymbolicDeriv(Operon::Hash hash, UnarySymbolicDerivRule rule)
+{
+    SymbolicDerivRules().Register(hash, std::move(rule));
+}
+
+auto HasUnarySymbolicDeriv(Operon::Hash hash) -> bool
+{
+    RegisterBuiltinSymbolicDerivs();
+    return SymbolicDerivRules().Contains(hash);
+}
 
 auto BuildJacobianDag(Tree const& tree) -> JacobianDag {
     JacobianDag dag;

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -437,7 +437,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         if (dj == Zero) { return Zero; }
 
         // Registry lookup replaces the old hardcoded switch (see
-        // RegisterBuiltinSymbolicDerivs above for the ~15 built-in rules,
+        // RegisterBuiltinSymbolicDerivs above for the 16 built-in rules,
         // migrated verbatim). A miss — including Abs/Sqrtabs/Floor/Ceil,
         // deliberately left unregistered — degrades to Zero exactly like
         // today's `default: return Zero;` did.
@@ -494,6 +494,7 @@ auto DifferentiateFirstOrder(
 
 void RegisterUnarySymbolicDeriv(Operon::Hash hash, UnarySymbolicDerivRule rule)
 {
+    RegisterBuiltinSymbolicDerivs();
     SymbolicDerivRules().Register(hash, std::move(rule));
 }
 

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -185,9 +185,9 @@ namespace {
             Vec res;
             // Add/Mul/Sub/Div/Fmin/Fmax stay hardcoded: each is an n-ary
             // reduction over however many args were popped above, not a
-            // single-hash unary/binary registry entry (same scope boundary
-            // as PR 8/PR 9). Every other op — unary and binary alike — goes
-            // through the registry, built-in or user-defined.
+            // single-hash unary/binary registry entry. Every other op —
+            // unary and binary alike — goes through the registry, built-in
+            // or user-defined.
             switch (n.HashValue) {
             case Operon::Hash(Operon::BuiltinOp::Add): {
                 res = args[0];
@@ -258,13 +258,26 @@ namespace {
                 break;
             }
             default:
-                if (auto const* unary = JitUnaryCodegenRules().TryGet(n.HashValue)) {
-                    res = (*unary)(cc, args[0]);
-                } else if (auto const* binary = JitBinaryCodegenRules().TryGet(n.HashValue)) {
-                    res = (*binary)(cc, args[0], args[1]);
-                } else {
-                    throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
+                // Gated on the node's actual arity (exactly 1 for unary,
+                // exactly 2 for binary): a hash mistakenly registered under
+                // the wrong registry must fall through to the throw below,
+                // not read a nonexistent operand (arity 1 registered as
+                // binary), silently ignore one (arity 2 registered as
+                // unary), or — for arity 0 / arity >= 3 registered as
+                // binary — read unrelated stack entries or drop operands
+                // beyond the first two.
+                if (arity == 1) {
+                    if (auto const* unary = JitUnaryCodegenRules().TryGet(n.HashValue)) {
+                        res = (*unary)(cc, args[0]);
+                        break;
+                    }
+                } else if (arity == 2) {
+                    if (auto const* binary = JitBinaryCodegenRules().TryGet(n.HashValue)) {
+                        res = (*binary)(cc, args[0], args[1]);
+                        break;
+                    }
                 }
+                throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
             }
 
             nodeVecs[ii] = res;
@@ -274,13 +287,28 @@ namespace {
 
 } // anonymous namespace
 
+namespace {
+void RegisterBuiltinJitCodegens();
+} // anonymous namespace
+
+// Both entry points below must trigger built-in registration before writing
+// — the same reasoning as RegisterIntervalBuiltins()/RegisterAffineBuiltins()
+// (interval_evaluator.hpp / affine_evaluator.hpp): otherwise a user hash
+// colliding with a built-in is accepted here and only discovered later, as a
+// throw from inside RegisterBuiltinJitCodegens() the first time CompileAVX2()
+// or CompileJacobian() runs — and because that throw fires from within a
+// function-local `static` initializer that never completes, every
+// subsequent compile call re-attempts and re-throws, permanently and
+// silently routing every tree to the interpreter with no diagnostic.
 void RegisterUnaryJitCodegen(Operon::Hash hash, JitUnaryCodegenFn fn)
 {
+    RegisterBuiltinJitCodegens();
     JitUnaryCodegenRules().Register(hash, std::move(fn));
 }
 
 void RegisterBinaryJitCodegen(Operon::Hash hash, JitBinaryCodegenFn fn)
 {
+    RegisterBuiltinJitCodegens();
     JitBinaryCodegenRules().Register(hash, std::move(fn));
 }
 

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -22,446 +22,25 @@
 #include <vector>
 
 namespace Operon::JIT {
-namespace {
 
-    using namespace asmjit; // NOLINT(google-build-using-namespace)
-    using namespace asmjit::x86; // NOLINT(google-build-using-namespace)
+using namespace asmjit; // NOLINT(google-build-using-namespace)
+using namespace asmjit::x86; // NOLINT(google-build-using-namespace)
 
-    // Scalar wrappers using EVE functions — match the AVX2 path exactly.
-    // EVE functions are CPOs, not plain function pointers, so each needs a
-    // thin wrapper to produce a concrete address for invokeF1's call instruction.
-    auto ScalarAbs(float x) noexcept -> float { return eve::abs(x); }
-    auto ScalarAcos(float x) noexcept -> float { return eve::acos(x); }
-    auto ScalarAsin(float x) noexcept -> float { return eve::asin(x); }
-    auto ScalarAtan(float x) noexcept -> float { return eve::atan(x); }
-    auto ScalarCbrt(float x) noexcept -> float { return eve::cbrt(x); }
-    auto ScalarCos(float x) noexcept -> float { return eve::cos(x); }
-    auto ScalarCosh(float x) noexcept -> float { return eve::cosh(x); }
-    auto ScalarExp(float x) noexcept -> float
-    {
-        constexpr float MaxExp = 88.72283172607421875F;
-        return eve::exp(eve::clamp(x, -MaxExp, MaxExp)); // matches FastExp
-    }
-    auto ScalarLog(float x) noexcept -> float { return eve::log(x); }
-    auto ScalarLogabs(float x) noexcept -> float { return eve::log(eve::abs(x)); }
-    auto ScalarLog1p(float x) noexcept -> float { return eve::log1p(x); }
-    auto ScalarSin(float x) noexcept -> float { return eve::sin(x); }
-    auto ScalarSinh(float x) noexcept -> float { return eve::sinh(x); }
-    auto ScalarTan(float x) noexcept -> float { return eve::tan(x); }
-    auto ScalarTanh(float x) noexcept -> float
-    {
-        constexpr float MaxTanh = 7.99881172180175781F;
-        return eve::tanh(eve::clamp(x, -MaxTanh, MaxTanh)); // matches FastTanh
-    }
-
-    // Match FastPow semantics: NaN for negative base + non-integer exponent,
-    // sign flip for negative base + odd integer exponent, 0^pos=0, x^0=1.
-    auto ScalarPow(float x, float y) noexcept -> float
-    {
-        if (y == 0.0F) {
-            return 1.0F;
-        }
-        if (x == 0.0F && y > 0.0F) {
-            return 0.0F;
-        }
-        constexpr float MaxExp = 88.72283172607421875F;
-        float z = eve::exp(eve::clamp(y * eve::log(eve::abs(x)), -MaxExp, MaxExp));
-        if (x < 0.0F) {
-            if (!eve::is_flint(y)) {
-                return std::numeric_limits<float>::quiet_NaN();
-            }
-            if (eve::is_odd(y)) {
-                z = -z;
-            }
-        }
-        return z;
-    }
-
-    // Invoke a scalar float→float C function.
-    auto InvokeF1(Compiler& cc, void* fnPtr, const Vec& arg) -> Vec
-    {
-        Vec const result = cc.new_xmm_ss();
-        InvokeNode* inv {};
-        cc.invoke(Out(inv),
-            reinterpret_cast<uint64_t>(fnPtr),
-            FuncSignature::build<float, float>());
-        inv->set_arg(0, arg);
-        inv->set_ret(0, result);
-        return result;
-    }
-
-    // Invoke scalar_pow(a, b) — matches interpreter's FastPow semantics.
-    auto InvokePowf(Compiler& cc, const Vec& a, const Vec& b) -> Vec
-    {
-        Vec const result = cc.new_xmm_ss();
-        InvokeNode* inv {};
-        cc.invoke(Out(inv),
-            reinterpret_cast<uint64_t>(reinterpret_cast<void*>(ScalarPow)), // NOLINT(bugprone-casting-through-void)
-            FuncSignature::build<float, float, float>());
-        inv->set_arg(0, a);
-        inv->set_arg(1, b);
-        inv->set_ret(0, result);
-        return result;
-    }
-
-    // Load a compile-time float constant into a fresh xmm_ss register.
-    auto LoadFloat(Compiler& cc, float val) -> Vec
-    {
-        uint32_t bits {};
-        std::memcpy(&bits, &val, sizeof bits);
-        Gp const tmp = cc.new_gp32();
-        cc.mov(tmp, bits);
-        Vec const reg = cc.new_xmm_ss();
-        cc.vmovd(reg, tmp);
-        return reg;
-    }
-
-    // Emit scalar (xmm_ss) evaluation of `nodes[start..end)` into `stack`.
-    // `nodeVecs[i]` is filled with the result Vec for each processed node i.
-    // `constIdx` tracks the next coefficient index across calls.
-    // All indices into nodeVecs use the global dag index (same as the position in nodes[]).
-    // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-    void EmitNodesScalar(
-        Compiler& cc,
-        std::vector<Node> const& nodes,
-        std::size_t start,
-        std::size_t end,
-        std::vector<Gp> const& colPtrs,
-        std::vector<Vec> const& coeffRegs,
-        std::vector<Operon::Hash> const& varOrder,
-        const Gp& row,
-        std::vector<Vec>& stack,
-        std::vector<Vec>& nodeVecs,
-        int& constIdx)
-    {
-        for (std::size_t ii = start; ii < end; ++ii) {
-            auto const& n = nodes[ii];
-
-            if (n.IsRef()) {
-                ENSURE(n.RefTo < ii);
-                Vec const copy = cc.new_xmm_ss();
-                cc.vmovaps(copy, nodeVecs[n.RefTo]);
-                nodeVecs[ii] = copy;
-                stack.push_back(copy);
-                continue;
-            }
-
-            if (n.IsVariable()) {
-                auto it = std::find(varOrder.begin(), varOrder.end(), n.HashValue);
-                auto colIdx = static_cast<std::size_t>(std::distance(varOrder.begin(), it));
-                Vec const val = cc.new_xmm_ss();
-                cc.vmovss(val, x86::ptr(colPtrs[colIdx], row, 2));
-                Vec weighted;
-                if (n.Optimize) {
-                    weighted = cc.new_xmm_ss();
-                    cc.vmulss(weighted, val, coeffRegs[static_cast<std::size_t>(constIdx++)]);
-                } else if (n.Value != 1.0F) {
-                    Vec const w = LoadFloat(cc, n.Value);
-                    weighted = cc.new_xmm_ss();
-                    cc.vmulss(weighted, val, w);
-                } else {
-                    weighted = val;
-                }
-                nodeVecs[ii] = weighted;
-                stack.push_back(weighted);
-                continue;
-            }
-
-            if (n.IsConstant()) {
-                Vec val;
-                if (n.Optimize) {
-                    val = coeffRegs[static_cast<std::size_t>(constIdx++)];
-                } else {
-                    val = LoadFloat(cc, n.Value);
-                }
-                nodeVecs[ii] = val;
-                stack.push_back(val);
-                continue;
-            }
-
-            // Operator node.
-            auto arity = n.Arity;
-            std::vector<Vec> args(static_cast<std::size_t>(arity));
-            for (int k = 0; std::cmp_less(k, arity); ++k) {
-                args[static_cast<std::size_t>(k)] = stack.back();
-                stack.pop_back();
-            }
-
-            Vec res;
-            switch (n.HashValue) {
-            case Operon::Hash(Operon::BuiltinOp::Add): {
-                res = args[0];
-                for (int k = 1; std::cmp_less(k, arity); ++k) {
-                    Vec const tmp = cc.new_xmm_ss();
-                    cc.vaddss(tmp, res, args[static_cast<std::size_t>(k)]);
-                    res = tmp;
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Mul): {
-                res = args[0];
-                for (int k = 1; std::cmp_less(k, arity); ++k) {
-                    Vec const tmp = cc.new_xmm_ss();
-                    cc.vmulss(tmp, res, args[static_cast<std::size_t>(k)]);
-                    res = tmp;
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sub): {
-                if (arity == 1) {
-                    Vec const zero = LoadFloat(cc, 0.0F);
-                    res = cc.new_xmm_ss();
-                    cc.vsubss(res, zero, args[0]);
-                } else {
-                    res = cc.new_xmm_ss();
-                    cc.vsubss(res, args[0], args[1]);
-                    for (int k = 2; std::cmp_less(k, arity); ++k) {
-                        Vec const tmp = cc.new_xmm_ss();
-                        cc.vsubss(tmp, res, args[static_cast<std::size_t>(k)]);
-                        res = tmp;
-                    }
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Div): {
-                if (arity == 1) {
-                    Vec const one = LoadFloat(cc, 1.0F);
-                    res = cc.new_xmm_ss();
-                    cc.vdivss(res, one, args[0]);
-                } else {
-                    res = cc.new_xmm_ss();
-                    cc.vdivss(res, args[0], args[1]);
-                    for (int k = 2; std::cmp_less(k, arity); ++k) {
-                        Vec const tmp = cc.new_xmm_ss();
-                        cc.vdivss(tmp, res, args[static_cast<std::size_t>(k)]);
-                        res = tmp;
-                    }
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Fmin): {
-                res = args[0];
-                for (int k = 1; std::cmp_less(k, arity); ++k) {
-                    Vec const tmp = cc.new_xmm_ss();
-                    cc.vminss(tmp, res, args[static_cast<std::size_t>(k)]);
-                    res = tmp;
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Fmax): {
-                res = args[0];
-                for (int k = 1; std::cmp_less(k, arity); ++k) {
-                    Vec const tmp = cc.new_xmm_ss();
-                    cc.vmaxss(tmp, res, args[static_cast<std::size_t>(k)]);
-                    res = tmp;
-                }
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Aq): {
-                Vec const b2 = cc.new_xmm_ss();
-                cc.vmulss(b2, args[1], args[1]);
-                Vec const one = LoadFloat(cc, 1.0F);
-                Vec const sum = cc.new_xmm_ss();
-                cc.vaddss(sum, one, b2);
-                Vec const sq = cc.new_xmm_ss();
-                cc.vsqrtss(sq, sq, sum);
-                res = cc.new_xmm_ss();
-                cc.vdivss(res, args[0], sq);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Pow): {
-                res = InvokePowf(cc, args[0], args[1]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Powabs): {
-                Vec const absA = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
-                res = InvokePowf(cc, absA, args[1]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Abs): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Acos): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAcos), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Asin): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAsin), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Atan): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarAtan), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cbrt): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCbrt), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Ceil): {
-                res = cc.new_xmm_ss();
-                cc.vroundss(res, args[0], args[0],
-                    Imm(static_cast<uint8_t>(RoundImm::kUp) | static_cast<uint8_t>(RoundImm::kSuppress)));
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cos): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCos), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cosh): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarCosh), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Exp): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarExp), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Floor): {
-                res = cc.new_xmm_ss();
-                cc.vroundss(res, args[0], args[0],
-                    Imm(static_cast<uint8_t>(RoundImm::kDown) | static_cast<uint8_t>(RoundImm::kSuppress)));
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Log): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLog), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Logabs): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLogabs), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Log1p): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarLog1p), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sin): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarSin), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sinh): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarSinh), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sqrt): {
-                res = cc.new_xmm_ss();
-                cc.vsqrtss(res, args[0], args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sqrtabs): {
-                Vec const absVal = InvokeF1(cc, reinterpret_cast<void*>(ScalarAbs), args[0]);
-                res = cc.new_xmm_ss();
-                cc.vsqrtss(res, absVal, absVal);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Tan): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarTan), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Tanh): {
-                res = InvokeF1(cc, reinterpret_cast<void*>(ScalarTanh), args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Square): {
-                res = cc.new_xmm_ss();
-                cc.vmulss(res, args[0], args[0]);
-                break;
-            }
-            default:
-                throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
-            }
-
-            nodeVecs[ii] = res;
-            stack.push_back(res);
-        }
-    }
-
-} // namespace
-
-auto TreeCompiler::Compile(Operon::Tree const& tree) -> std::unique_ptr<CompileMeta>
+// Registry accessors defined here (before EmitNodesAvx2 below, which reads
+// from them) since a plain function-local static needs its declaration
+// visible at first use — unlike Register{Unary,Binary}JitCodegen further
+// down, which are only called by external registration code, not by
+// EmitNodesAvx2 itself.
+auto JitUnaryCodegenRules() -> JitUnaryCodegenRegistry&
 {
-    auto& rt = pick();
+    static JitUnaryCodegenRegistry registry;
+    return registry;
+}
 
-    auto const& nodes = tree.Nodes();
-    auto varOrder = VarOrder(tree);
-
-    CodeHolder code;
-    code.init(rt.environment(), rt.cpu_features());
-    Compiler cc(&code);
-
-    // void fn(float* out, float const* const* cols, int32_t nRows, float const* consts)
-    FuncNode* fnNode = cc.add_func(
-        FuncSignature::build<void, float*, float const* const*, int32_t, float const*>());
-
-    Gp const outPtr = cc.new_gp_ptr("out");
-    Gp const colsPtr = cc.new_gp_ptr("cols");
-    Gp const nRowsArg = cc.new_gp32("nRows");
-    Gp const constsPtr = cc.new_gp_ptr("consts");
-
-    fnNode->set_arg(0, outPtr);
-    fnNode->set_arg(1, colsPtr);
-    fnNode->set_arg(2, nRowsArg);
-    fnNode->set_arg(3, constsPtr);
-
-    std::vector<Gp> colPtrs(varOrder.size());
-    for (std::size_t i = 0; i < varOrder.size(); ++i) {
-        colPtrs[i] = cc.new_gp_ptr();
-        cc.mov(colPtrs[i], x86::ptr(colsPtr, static_cast<int32_t>(i * sizeof(void*))));
-    }
-
-    int nConsts = 0;
-    for (auto const& n : nodes) {
-        if (n.Optimize) {
-            ++nConsts;
-        }
-    }
-    std::vector<Vec> coeffRegs(static_cast<std::size_t>(nConsts));
-    for (int j = 0; j < nConsts; ++j) {
-        coeffRegs[static_cast<std::size_t>(j)] = cc.new_xmm_ss();
-        cc.vmovss(coeffRegs[static_cast<std::size_t>(j)],
-            x86::ptr(constsPtr, static_cast<int32_t>(j * static_cast<int>(sizeof(float)))));
-    }
-
-    Gp const row = cc.new_gp64("row");
-    cc.xor_(row.r32(), row.r32());
-
-    Label const loopBegin = cc.new_label();
-    Label const loopEnd = cc.new_label();
-
-    cc.bind(loopBegin);
-    cc.cmp(row.r32(), nRowsArg);
-    cc.jge(loopEnd);
-
-    {
-        std::vector<Vec> stack;
-        std::vector<Vec> nodeVecs(nodes.size());
-        int constIdx = 0;
-        stack.reserve(32);
-        EmitNodesScalar(cc, nodes, 0, nodes.size(), colPtrs, coeffRegs, varOrder, row, stack, nodeVecs, constIdx);
-        cc.vmovss(x86::ptr(outPtr, row, 2), stack.back());
-    }
-
-    cc.inc(row);
-    cc.jmp(loopBegin);
-    cc.bind(loopEnd);
-
-    cc.ret();
-    cc.end_func();
-
-    if (auto err = cc.finalize(); err != Error::kOk) {
-        return nullptr;
-    }
-
-    EvalFn fnPtr = nullptr;
-    if (auto err = rt.add(&fnPtr, &code); err != Error::kOk) {
-        return nullptr;
-    }
-
-    auto result = std::make_unique<CompileMeta>();
-    result->rtTree = &rt;
-    result->fn = fnPtr;
-    result->nVars = static_cast<int>(varOrder.size());
-    result->nConsts = nConsts;
-    return result;
+auto JitBinaryCodegenRules() -> JitBinaryCodegenRegistry&
+{
+    static JitBinaryCodegenRegistry registry;
+    return registry;
 }
 
 // =============================================================================
@@ -604,6 +183,11 @@ namespace {
             }
 
             Vec res;
+            // Add/Mul/Sub/Div/Fmin/Fmax stay hardcoded: each is an n-ary
+            // reduction over however many args were popped above, not a
+            // single-hash unary/binary registry entry (same scope boundary
+            // as PR 8/PR 9). Every other op — unary and binary alike — goes
+            // through the registry, built-in or user-defined.
             switch (n.HashValue) {
             case Operon::Hash(Operon::BuiltinOp::Add): {
                 res = args[0];
@@ -673,117 +257,14 @@ namespace {
                 }
                 break;
             }
-            case Operon::Hash(Operon::BuiltinOp::Aq): {
-                Vec const b2 = cc.new_ymm_ps();
-                cc.vmulps(b2, args[1], args[1]);
-                Vec const one = BroadcastFloat(cc, 1.0F);
-                Vec const sum = cc.new_ymm_ps();
-                cc.vaddps(sum, one, b2);
-                Vec const sq = cc.new_ymm_ps();
-                cc.vsqrtps(sq, sum);
-                res = cc.new_ymm_ps();
-                cc.vdivps(res, args[0], sq);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Pow): {
-                res = InvokePowfPs(cc, args[0], args[1]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Powabs): {
-                Vec const absA = InvokeF1Ps(cc, VecFabsf, args[0]);
-                res = InvokePowfPs(cc, absA, args[1]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Abs): {
-                res = InvokeF1Ps(cc, VecFabsf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Acos): {
-                res = InvokeF1Ps(cc, VecAcosf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Asin): {
-                res = InvokeF1Ps(cc, VecAsinf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Atan): {
-                res = InvokeF1Ps(cc, VecAtanf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cbrt): {
-                res = InvokeF1Ps(cc, VecCbrtf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Ceil): {
-                res = cc.new_ymm_ps();
-                cc.vroundps(res, args[0],
-                    Imm(static_cast<uint8_t>(RoundImm::kUp) | static_cast<uint8_t>(RoundImm::kSuppress)));
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cos): {
-                res = InvokeF1Ps(cc, VecCosf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Cosh): {
-                res = InvokeF1Ps(cc, VecCoshf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Exp): {
-                res = InvokeF1Ps(cc, VecExpf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Floor): {
-                res = cc.new_ymm_ps();
-                cc.vroundps(res, args[0],
-                    Imm(static_cast<uint8_t>(RoundImm::kDown) | static_cast<uint8_t>(RoundImm::kSuppress)));
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Log): {
-                res = InvokeF1Ps(cc, VecLogf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Logabs): {
-                res = InvokeF1Ps(cc, VecLogabsf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Log1p): {
-                res = InvokeF1Ps(cc, VecLog1pf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sin): {
-                res = InvokeF1Ps(cc, VecSinf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sinh): {
-                res = InvokeF1Ps(cc, VecSinhf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sqrt): {
-                res = cc.new_ymm_ps();
-                cc.vsqrtps(res, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Sqrtabs): {
-                Vec const absVal = InvokeF1Ps(cc, VecFabsf, args[0]);
-                res = cc.new_ymm_ps();
-                cc.vsqrtps(res, absVal);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Tan): {
-                res = InvokeF1Ps(cc, VecTanf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Tanh): {
-                res = InvokeF1Ps(cc, VecTanhf, args[0]);
-                break;
-            }
-            case Operon::Hash(Operon::BuiltinOp::Square): {
-                res = cc.new_ymm_ps();
-                cc.vmulps(res, args[0], args[0]);
-                break;
-            }
             default:
-                throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
+                if (auto const* unary = JitUnaryCodegenRules().TryGet(n.HashValue)) {
+                    res = (*unary)(cc, args[0]);
+                } else if (auto const* binary = JitBinaryCodegenRules().TryGet(n.HashValue)) {
+                    res = (*binary)(cc, args[0], args[1]);
+                } else {
+                    throw std::runtime_error(fmt::format("JIT: no codegen for hash {} (not a built-in op)\n", n.HashValue));
+                }
             }
 
             nodeVecs[ii] = res;
@@ -792,6 +273,108 @@ namespace {
     }
 
 } // anonymous namespace
+
+void RegisterUnaryJitCodegen(Operon::Hash hash, JitUnaryCodegenFn fn)
+{
+    JitUnaryCodegenRules().Register(hash, std::move(fn));
+}
+
+void RegisterBinaryJitCodegen(Operon::Hash hash, JitBinaryCodegenFn fn)
+{
+    JitBinaryCodegenRules().Register(hash, std::move(fn));
+}
+
+namespace {
+
+// Registers the built-in unary/binary AVX2 codegen rules exactly once,
+// mirroring StandardLibrary::RegisterNames()'s lazy-static-lambda-once
+// pattern. Every rule is lifted verbatim out of the old switch above.
+void RegisterBuiltinJitCodegens()
+{
+    static auto const registered = [] {
+        auto& unary  = JitUnaryCodegenRules();
+        auto& binary = JitBinaryCodegenRules();
+
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Abs),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecFabsf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Acos),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecAcosf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Asin),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecAsinf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Atan),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecAtanf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Cbrt),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecCbrtf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Ceil),    [](Compiler& cc, Vec const& a) {
+            Vec res = cc.new_ymm_ps();
+            cc.vroundps(res, a, Imm(static_cast<uint8_t>(RoundImm::kUp) | static_cast<uint8_t>(RoundImm::kSuppress)));
+            return res;
+        });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Cos),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecCosf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Cosh),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecCoshf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Exp),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecExpf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Floor),   [](Compiler& cc, Vec const& a) {
+            Vec res = cc.new_ymm_ps();
+            cc.vroundps(res, a, Imm(static_cast<uint8_t>(RoundImm::kDown) | static_cast<uint8_t>(RoundImm::kSuppress)));
+            return res;
+        });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Log),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecLogf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Logabs),  [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecLogabsf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Log1p),   [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecLog1pf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Sin),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecSinf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Sinh),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecSinhf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Sqrt),    [](Compiler& cc, Vec const& a) {
+            Vec res = cc.new_ymm_ps();
+            cc.vsqrtps(res, a);
+            return res;
+        });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Sqrtabs), [](Compiler& cc, Vec const& a) {
+            Vec const absVal = InvokeF1Ps(cc, VecFabsf, a);
+            Vec res = cc.new_ymm_ps();
+            cc.vsqrtps(res, absVal);
+            return res;
+        });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Tan),     [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecTanf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Tanh),    [](Compiler& cc, Vec const& a) { return InvokeF1Ps(cc, VecTanhf, a); });
+        unary.Register(Operon::Hash(Operon::BuiltinOp::Square),  [](Compiler& cc, Vec const& a) {
+            Vec res = cc.new_ymm_ps();
+            cc.vmulps(res, a, a);
+            return res;
+        });
+
+        binary.Register(Operon::Hash(Operon::BuiltinOp::Pow), [](Compiler& cc, Vec const& a, Vec const& b) {
+            return InvokePowfPs(cc, a, b);
+        });
+        binary.Register(Operon::Hash(Operon::BuiltinOp::Powabs), [](Compiler& cc, Vec const& a, Vec const& b) {
+            Vec const absA = InvokeF1Ps(cc, VecFabsf, a);
+            return InvokePowfPs(cc, absA, b);
+        });
+        binary.Register(Operon::Hash(Operon::BuiltinOp::Aq), [](Compiler& cc, Vec const& a, Vec const& b) {
+            Vec const b2 = cc.new_ymm_ps();
+            cc.vmulps(b2, b, b);
+            Vec const one = BroadcastFloat(cc, 1.0F);
+            Vec const sum = cc.new_ymm_ps();
+            cc.vaddps(sum, one, b2);
+            Vec const sq = cc.new_ymm_ps();
+            cc.vsqrtps(sq, sum);
+            Vec res = cc.new_ymm_ps();
+            cc.vdivps(res, a, sq);
+            return res;
+        });
+
+        return true;
+    }();
+    static_cast<void>(registered);
+}
+
+} // anonymous namespace
+
+auto HasUnaryJitCodegen(Operon::Hash hash) -> bool
+{
+    RegisterBuiltinJitCodegens();
+    return JitUnaryCodegenRules().Contains(hash);
+}
+
+auto HasBinaryJitCodegen(Operon::Hash hash) -> bool
+{
+    RegisterBuiltinJitCodegens();
+    return JitBinaryCodegenRules().Contains(hash);
+}
 
 auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<CompileMeta>
 {
@@ -803,6 +386,8 @@ auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<Comp
     if (!rt.cpu_features().x86().has(CpuFeatures::X86::kAVX2)) {
         return nullptr;
     }
+
+    RegisterBuiltinJitCodegens();
 
     auto const& nodes = tree.Nodes();
     auto varOrder = VarOrder(tree);
@@ -821,6 +406,14 @@ auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<Comp
     FuncNode* fnNode = cc.add_func(
         FuncSignature::build<void, float*, float const* const*, int32_t, float const*>());
     fnNode->frame().set_avx_enabled();
+
+    // A registry miss inside EmitNodesAvx2 (an op with no codegen callback,
+    // built-in or user-defined) throws; caught here and converted into the
+    // same "return nullptr" every other compile failure below already uses
+    // — JitEvaluator's caller already treats a nullptr CompileMeta as "fall
+    // back to interpreting this tree," so an unmapped op degrades exactly
+    // like an asmjit finalize/runtime-add failure would.
+    try {
 
     Gp const outPtr = cc.new_gp_ptr("out");
     Gp const colsPtr = cc.new_gp_ptr("cols");
@@ -891,6 +484,9 @@ auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<Comp
     result->nVars = static_cast<int>(varOrder.size());
     result->nConsts = nConsts;
     return result;
+    } catch (std::exception const&) {
+        return nullptr;
+    }
 }
 
 auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<CompileMeta>
@@ -910,6 +506,10 @@ auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<Co
     if (nRoots == 0) {
         return nullptr;
     }
+
+    RegisterBuiltinJitCodegens();
+
+    try {
 
     // Build var order from all dag nodes (original + derivative).
     std::vector<Operon::Hash> varOrder;
@@ -1042,6 +642,9 @@ auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<Co
     result->rtJac = &rt;
     result->jacFn = fnPtr;
     return result;
+    } catch (std::exception const&) {
+        return nullptr;
+    }
 }
 
 } // namespace Operon::JIT

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -63,9 +63,12 @@ auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMet
     if (visits < minVisits_) { ++misses_; return nullptr; }
 
     // Compile outside the map lock so cc.finalize() runs in parallel.
+    // AVX2-only: no scalar/SSE fallback attempt (see jit_compiler.hpp) — a
+    // CompileAVX2 failure here (hardware, an unmapped op, or any other
+    // asmjit failure) falls straight through to interpreter evaluation via
+    // the nullptr compiled result below.
     auto compiled = compiler_.CompileAVX2(tree);
-    if (!compiled) { ++avx2Fails_; compiled = compiler_.Compile(tree); }
-    if (!compiled) { ++compileFails_; }
+    if (!compiled) { ++avx2Fails_; ++compileFails_; }
 
     zobrist_->JitCache().ModifyIf(hash, [&](JitEntry& e) -> void {
         if (!e.meta) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(operon_test
     source/implementation/jit.cpp
     source/implementation/pappus_backend.cpp
     source/implementation/pappus_nsgp.cpp
+    source/implementation/registry_coverage.cpp
     )
 target_link_libraries(operon_test PRIVATE operon::operon Catch2::Catch2WithMain scn::scn nanobench::nanobench)
 if(vdt_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(operon_test
     source/implementation/pappus_backend.cpp
     source/implementation/pappus_nsgp.cpp
     source/implementation/registry_coverage.cpp
+    source/implementation/user_defined_registries.cpp
     )
 target_link_libraries(operon_test PRIVATE operon::operon Catch2::Catch2WithMain scn::scn nanobench::nanobench)
 if(vdt_FOUND)

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -125,11 +125,20 @@ TEST_CASE("JIT AVX2 correctness", "[jit][avx2]")
     SECTION("Abs")         { check("abs(X1 - X2)"); }
     SECTION("Sin")         { check("sin(X1)"); }
     SECTION("Cos")         { check("cos(X1)"); }
+    SECTION("Tan")         { check("tan(X1)"); }
+    SECTION("Asin")        { check("asin(X1)"); }
+    SECTION("Acos")        { check("acos(X1)"); }
+    SECTION("Atan")        { check("atan(X1)"); }
+    SECTION("Sinh")        { check("sinh(X1)"); }
+    SECTION("Cosh")        { check("cosh(X1)"); }
+    SECTION("Cbrt")        { check("cbrt(X1)"); }
+    SECTION("Log1p")       { check("log1p(abs(X1))"); }
     SECTION("Exp")         { check("exp(X1)"); }
     SECTION("Log")         { check("log(X1)"); }
     SECTION("Logabs")      { check("log(abs(X1))"); }
     SECTION("Tanh")        { check("tanh(X1)"); }
     SECTION("Aq")          { check("X1 / sqrt(1 + X2 * X2)"); }
+    SECTION("Powabs")      { check("powabs(X1, 2)"); }
     SECTION("Composite")   { check("sin(X1) * cos(X2) + exp(0 - X3 * X3)"); }
     SECTION("Pow")         { check("X1 ^ X2"); }
     // Rows=201: 25 full AVX2 iterations (200 rows) + 1 scalar tail row
@@ -140,6 +149,38 @@ TEST_CASE("JIT AVX2 correctness", "[jit][avx2]")
         check("sin(X1) * cos(X2) + exp(X3) * tanh(X4) + log(abs(X5)) * sin(X6)");
         check("(sin(X1) + cos(X2)) * (exp(X3) + tanh(X4)) + (log(abs(X5)) * sin(X6) + cos(X7))");
     }
+}
+
+// Floor/Ceil have no infix syntax (infix-parser's node_type enum has no
+// floor/ceil variant, a pre-existing gap unrelated to the JIT registry), so
+// unlike the other unary ops above they can't go through check()'s
+// InfixParser::Parse path — built directly instead.
+TEST_CASE("JIT AVX2 correctness: floor/ceil", "[jit][avx2]")
+{
+    auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto range = Range{0, 201};
+
+    JIT::JitRuntimePool compilerPool;
+    JIT::TreeCompiler compiler{&compilerPool};
+    if (!compiler.HasAVX2()) { SKIP("AVX2 not available"); }
+
+    auto x1Hash = ds.GetVariable("X1").value().Hash;
+
+    auto checkOp = [&](Operon::BuiltinOp op) {
+        Node v1(NodeType::Variable); v1.HashValue = v1.CalculatedHashValue = x1Hash; v1.Value = 1.0F;
+        auto tree = Tree({v1, Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes();
+        auto ref  = EvalRef(tree, ds, range);
+        auto avx2 = EvalJIT_AVX2(compiler, tree, ds, range);
+
+        REQUIRE(ref.size() == avx2.size());
+        for (std::size_t i = 0; i < ref.size(); ++i) {
+            INFO("row " << i << ": ref=" << ref[i] << " avx2=" << avx2[i]);
+            CHECK(avx2[i] == Catch::Approx(ref[i]).epsilon(Tol));
+        }
+    };
+
+    SECTION("Floor") { checkOp(Operon::BuiltinOp::Floor); }
+    SECTION("Ceil")  { checkOp(Operon::BuiltinOp::Ceil); }
 }
 
 // Smoke test for Ref node handling in the JIT compiler. The explicit register

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -57,16 +57,6 @@ auto EvalCompiled(JIT::CompileMeta const& compiled,
     return {scratch.begin(), scratch.begin() + nRows};
 }
 
-// Evaluate tree via JIT; returns vector of nRows results.
-auto EvalJIT(JIT::TreeCompiler& compiler, Operon::Tree const& tree,
-             Operon::Dataset const& ds, Operon::Range range) -> std::vector<float>
-{
-    auto compiled = compiler.Compile(tree);
-    REQUIRE(compiled != nullptr);
-    REQUIRE(compiled->fn != nullptr);
-    return EvalCompiled(*compiled, tree, ds, range);
-}
-
 auto EvalJIT_AVX2(JIT::TreeCompiler& compiler, Operon::Tree const& tree,
                   Operon::Dataset const& ds, Operon::Range range) -> std::vector<float>
 {
@@ -88,56 +78,6 @@ auto EvalRef(Operon::Tree& tree, Operon::Dataset const& ds, Operon::Range range)
 constexpr float Tol = 1e-4f;
 
 } // namespace
-
-TEST_CASE("JIT scalar correctness", "[jit]")
-{
-    auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
-    auto range = Range{0, std::min(ds.Rows<std::size_t>(), std::size_t{200})};
-
-    JIT::JitRuntimePool compilerPool;
-    JIT::TreeCompiler compiler{&compilerPool};
-
-    auto check = [&](std::string_view expr) {
-        INFO("expression: " << expr);
-        auto tree = InfixParser::Parse(std::string(expr), ds);
-        auto ref  = EvalRef(tree, ds, range);
-        auto jit  = EvalJIT(compiler, tree, ds, range);
-
-        REQUIRE(ref.size() == jit.size());
-        for (std::size_t i = 0; i < ref.size(); ++i) {
-            INFO("row " << i << ": ref=" << ref[i] << " jit=" << jit[i]);
-            if (std::isnan(ref[i])) {
-                CHECK(std::isnan(jit[i]));
-            } else if (std::isinf(ref[i])) {
-                CHECK(std::isinf(jit[i]));
-                CHECK((ref[i] > 0) == (jit[i] > 0));
-            } else {
-                CHECK(jit[i] == Catch::Approx(ref[i]).epsilon(Tol));
-            }
-        }
-    };
-
-    SECTION("Add")         { check("X1 + X2 + X3"); }
-    SECTION("Sub")         { check("X1 - X2"); }
-    SECTION("Mul")         { check("X1 * X2 * X3"); }
-    SECTION("Div")         { check("X1 / X2"); }
-    SECTION("Nested")      { check("X1 + X2 * X3 - X4"); }
-    SECTION("Square")      { check("X1 * X1 + X2 * X2"); }
-    SECTION("Unary neg")   { check("0 - X1"); }
-    SECTION("Constant")    { check("X1 + X2"); }
-    SECTION("Sin")         { check("sin(X1)"); }
-    SECTION("Cos")         { check("cos(X1)"); }
-    SECTION("Exp")         { check("exp(X1)"); }
-    SECTION("Log")         { check("log(X1)"); }
-    SECTION("Logabs")      { check("log(abs(X1))"); }
-    SECTION("Sqrt")        { check("sqrt(X1 * X1)"); }
-    SECTION("Sqrtabs")     { check("sqrt(abs(X1))"); }
-    SECTION("Abs")         { check("abs(X1 - X2)"); }
-    SECTION("Tanh")        { check("tanh(X1)"); }
-    SECTION("Aq")          { check("X1 / sqrt(1 + X2 * X2)"); }
-    SECTION("Pow")         { check("X1 ^ X2"); }
-    SECTION("Composite")   { check("sin(X1) * cos(X2) + exp(0 - X3 * X3)"); }
-}
 
 TEST_CASE("JIT AVX2 correctness", "[jit][avx2]")
 {
@@ -266,15 +206,6 @@ TEST_CASE("JIT Ref node forward-pass correctness", "[jit][ref]")
             auto expected = s * (s - x3[i]);
             INFO("row " << i << ": expected=" << expected << " ref=" << ref[i]);
             CHECK(ref[i] == Catch::Approx(expected).epsilon(Tol));
-        }
-    }
-
-    SECTION("scalar") {
-        auto jit = EvalJIT(compiler, tree, ds, range);
-        REQUIRE(ref.size() == jit.size());
-        for (std::size_t i = 0; i < ref.size(); ++i) {
-            INFO("row " << i << ": ref=" << ref[i] << " jit=" << jit[i]);
-            CHECK(jit[i] == Catch::Approx(ref[i]).epsilon(Tol));
         }
     }
 
@@ -534,7 +465,6 @@ TEST_CASE("JitEvaluator vs interpreter on random population", "[jit][evaluator][
     JIT::TreeCompiler compiler{&compilerPool};
     std::size_t fitMismatch = 0;
     std::size_t compileFailAVX2 = 0;
-    std::size_t compileFailScalar = 0;
     for (int i = 0; i < 200; ++i) {
         auto tree = creator(rng, MaxLength, 1, 1000);
         tree.Reduce();
@@ -542,8 +472,6 @@ TEST_CASE("JitEvaluator vs interpreter on random population", "[jit][evaluator][
         // Check compilation directly.
         auto avx2 = compiler.CompileAVX2(tree);
         if (!avx2) { ++compileFailAVX2; }
-        auto scalar = compiler.Compile(tree);
-        if (!scalar) { ++compileFailScalar; }
 
         Individual refInd(1), jitInd(1);
         refInd.Genotype = jitInd.Genotype = tree;
@@ -561,9 +489,8 @@ TEST_CASE("JitEvaluator vs interpreter on random population", "[jit][evaluator][
             ++fitMismatch;
         }
     }
-    INFO("compile failures: AVX2=" << compileFailAVX2 << " scalar=" << compileFailScalar);
+    INFO("compile failures: AVX2=" << compileFailAVX2);
     CHECK(compileFailAVX2 == 0);
-    CHECK(compileFailScalar == 0);
     CHECK(fitMismatch == 0);
 }
 

--- a/test/source/implementation/pappus_backend.cpp
+++ b/test/source/implementation/pappus_backend.cpp
@@ -178,6 +178,117 @@ TEST_CASE("Interval backend: unary transcendentals", "[pappus][interval]")
     }
 }
 
+// Distinguishing-value coverage for the trig/hyperbolic registry entries not
+// exercised elsewhere in this file: a hash-preserving swap between any two of
+// these (e.g. Sin's lambda registered under Cos's slot) would not be caught
+// by registry_coverage.cpp's presence-only check, but is caught here since
+// each op's true range over its chosen monotonic domain is distinct.
+TEST_CASE("Interval backend: trig and hyperbolic transcendentals", "[pappus][interval]")
+{
+    constexpr Operon::Hash X1{1};
+
+    auto make = [&](IE::Domain dom, Operon::BuiltinOp op) -> IE::Interval {
+        auto tree = Operon::Tree({Var(X1), Operon::Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes();
+        auto dm = Domains();
+        dm[X1] = {S{dom.first}, S{dom.second}};
+        IE eval(&tree, std::move(dm));
+        return eval.Evaluate(tree.GetCoefficients());
+    };
+
+    constexpr double Pi = 3.14159265358979323846;
+
+    SECTION("sin([0, pi/6]) -> [0, 0.5]") {
+        auto r = make({0, Pi / 6.0}, Operon::BuiltinOp::Sin);
+        REQUIRE(Contains(r, 0.0, 0.5, 1e-3));
+    }
+    SECTION("cos([0, pi/3]) -> [0.5, 1]") {
+        auto r = make({0, Pi / 3.0}, Operon::BuiltinOp::Cos);
+        REQUIRE(Contains(r, 0.5, 1.0, 1e-3));
+    }
+    SECTION("tan([0, pi/4]) -> [0, 1]") {
+        auto r = make({0, Pi / 4.0}, Operon::BuiltinOp::Tan);
+        REQUIRE(Contains(r, 0.0, 1.0, 1e-3));
+    }
+    SECTION("asin([0, 0.5]) -> [0, pi/6]") {
+        auto r = make({0, 0.5}, Operon::BuiltinOp::Asin);
+        REQUIRE(Contains(r, 0.0, Pi / 6.0, 1e-3));
+    }
+    SECTION("acos([0, 0.5]) -> [pi/3, pi/2]") {
+        auto r = make({0, 0.5}, Operon::BuiltinOp::Acos);
+        REQUIRE(Contains(r, Pi / 3.0, Pi / 2.0, 1e-3));
+    }
+    SECTION("atan([0, 1]) -> [0, pi/4]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Atan);
+        REQUIRE(Contains(r, 0.0, Pi / 4.0, 1e-3));
+    }
+    SECTION("sinh([0, 1]) -> [0, sinh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Sinh);
+        REQUIRE(Contains(r, 0.0, std::sinh(1.0), 1e-3));
+    }
+    SECTION("cosh([0, 1]) -> [1, cosh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Cosh);
+        REQUIRE(Contains(r, 1.0, std::cosh(1.0), 1e-3));
+    }
+    SECTION("tanh([0, 1]) -> [0, tanh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Tanh);
+        REQUIRE(Contains(r, 0.0, std::tanh(1.0), 1e-3));
+    }
+}
+
+// Affine analog of the interval test above, same distinguishing-domain
+// rationale.
+TEST_CASE("Affine backend: trig and hyperbolic transcendentals", "[pappus][affine]")
+{
+    constexpr Operon::Hash X1{1};
+
+    auto make = [&](IE::Domain dom, Operon::BuiltinOp op) -> AE::Affine {
+        auto tree = Operon::Tree({Var(X1), Operon::Node::Function(static_cast<Operon::Hash>(op), 1)}).UpdateNodes();
+        auto d = Domains();
+        d[X1] = {S{dom.first}, S{dom.second}};
+        AE eval(&tree, std::move(d));
+        return eval.Evaluate(tree.GetCoefficients());
+    };
+
+    constexpr double Pi = 3.14159265358979323846;
+
+    SECTION("sin([0, pi/6]) -> contains [0, 0.5]") {
+        auto r = make({0, Pi / 6.0}, Operon::BuiltinOp::Sin);
+        REQUIRE(Contains(r, 0.0, 0.5, 1e-2));
+    }
+    SECTION("cos([0, pi/3]) -> contains [0.5, 1]") {
+        auto r = make({0, Pi / 3.0}, Operon::BuiltinOp::Cos);
+        REQUIRE(Contains(r, 0.5, 1.0, 1e-2));
+    }
+    SECTION("tan([0, pi/4]) -> contains [0, 1]") {
+        auto r = make({0, Pi / 4.0}, Operon::BuiltinOp::Tan);
+        REQUIRE(Contains(r, 0.0, 1.0, 1e-2));
+    }
+    SECTION("asin([0, 0.5]) -> contains [0, pi/6]") {
+        auto r = make({0, 0.5}, Operon::BuiltinOp::Asin);
+        REQUIRE(Contains(r, 0.0, Pi / 6.0, 1e-2));
+    }
+    SECTION("acos([0, 0.5]) -> contains [pi/3, pi/2]") {
+        auto r = make({0, 0.5}, Operon::BuiltinOp::Acos);
+        REQUIRE(Contains(r, Pi / 3.0, Pi / 2.0, 1e-2));
+    }
+    SECTION("atan([0, 1]) -> contains [0, pi/4]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Atan);
+        REQUIRE(Contains(r, 0.0, Pi / 4.0, 1e-2));
+    }
+    SECTION("sinh([0, 1]) -> contains [0, sinh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Sinh);
+        REQUIRE(Contains(r, 0.0, std::sinh(1.0), 1e-2));
+    }
+    SECTION("cosh([0, 1]) -> contains [1, cosh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Cosh);
+        REQUIRE(Contains(r, 1.0, std::cosh(1.0), 1e-2));
+    }
+    SECTION("tanh([0, 1]) -> contains [0, tanh(1)]") {
+        auto r = make({0, 1}, Operon::BuiltinOp::Tanh);
+        REQUIRE(Contains(r, 0.0, std::tanh(1.0), 1e-2));
+    }
+}
+
 TEST_CASE("Interval backend: nested tree", "[pappus][interval]")
 {
     constexpr Operon::Hash X1{1}, X2{2}, X3{3};

--- a/test/source/implementation/registry_coverage.cpp
+++ b/test/source/implementation/registry_coverage.cpp
@@ -3,11 +3,14 @@
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
 
 #include <string>
 #include <vector>
 
+#include "operon/core/hash_registry.hpp"
 #include "operon/core/node.hpp"
+#include "operon/core/tree.hpp"
 #include "operon/core/tree_diff.hpp"
 #include "operon/interpreter/interval_evaluator.hpp"
 #include "operon/interpreter/affine_evaluator.hpp"
@@ -16,14 +19,18 @@
 #include "operon/interpreter/backend/jit/jit_compiler.hpp"
 #endif
 
+#include "../operon_test.hpp"
+
 // Cross-registry coverage: nothing structurally guarantees the symbolic-diff,
 // interval, affine, and JIT-codegen registries all cover the same set of
 // BuiltinOps. A BuiltinOp missing from one of them silently degrades (Zero
 // for diff, a throw for interval/affine/JIT) — indistinguishable from a
-// legitimately-unsupported op unless asserted explicitly. This test is the
-// deliverable flagged (but not built) in the registry redesign's planning
-// notes: assert every BuiltinOp is either registered, or on the explicit
-// "deliberately absent" allowlist below, for each registry.
+// legitimately-unsupported op unless asserted explicitly. These tests assert
+// every BuiltinOp is either registered, or on the explicit "deliberately
+// absent" allowlist below, for each registry — plus behavioral coverage for
+// the public Register*()/Has*() API surface itself: round-trip lookup,
+// write-once duplicate rejection, the register-before-first-evaluate
+// ordering fix, and each registry's end-to-end miss behavior.
 
 namespace Operon::Test {
 
@@ -117,6 +124,141 @@ TEST_CASE("Cross-registry coverage: JIT codegen registry", "[registry][coverage]
         INFO("op: " << OpName(op));
         CHECK(inJit == !expectAbsent);
     }
+}
+#endif
+
+// --- HashRegistry<Fn> itself: the write-once contract every domain above
+// builds on. Tested directly (not through a domain's Fn type) so the
+// contract is verified independent of any one consumer.
+TEST_CASE("HashRegistry: round-trip and write-once contract", "[registry][hash_registry]")
+{
+    Operon::HashRegistry<int> reg;
+    constexpr Operon::Hash hash{0x1111111111111111ULL};
+
+    CHECK_FALSE(reg.Contains(hash));
+    CHECK(reg.TryGet(hash) == nullptr);
+
+    reg.Register(hash, 42);
+    REQUIRE(reg.Contains(hash));
+    REQUIRE(reg.TryGet(hash) != nullptr);
+    CHECK(*reg.TryGet(hash) == 42);
+
+    // Write-once: a second Register() for the same hash throws rather than
+    // overwriting, even with a different value.
+    CHECK_THROWS_AS(reg.Register(hash, 99), std::invalid_argument);
+    CHECK(*reg.TryGet(hash) == 42); // unchanged by the failed second write
+}
+
+// --- Regression coverage for the TOCTOU fix: every public Register*() now
+// triggers its domain's built-in lazy-init before writing, so registering a
+// hash that collides with a built-in always throws immediately at the call
+// site — regardless of whether anything in this process happened to already
+// force that domain's built-in registration. Pre-fix, this was
+// order-dependent (silently accepted if the built-ins hadn't been touched
+// yet, only surfacing as a confusing throw later, from a different call,
+// the first time the domain was actually used). Split one per domain
+// (rather than one TEST_CASE with a SECTION each) so each domain's own PR
+// carries its own regression coverage independently.
+TEST_CASE("RegisterUnarySymbolicDeriv: colliding with a built-in hash always throws", "[registry][toctou]")
+{
+    CHECK_THROWS_AS(
+        Operon::RegisterUnarySymbolicDeriv(Operon::Hash(BuiltinOp::Log),
+            [](Operon::Vector<Operon::Node>&, Operon::Map<Operon::Hash, std::size_t>&,
+               Operon::Vector<Operon::Hash>&, std::size_t, std::size_t) -> std::size_t { return 0; }),
+        std::invalid_argument);
+}
+
+TEST_CASE("RegisterUnaryInterval/RegisterUnaryAffine: colliding with a built-in hash always throws", "[registry][toctou]")
+{
+    auto const logHash = Operon::Hash(BuiltinOp::Log);
+
+    CHECK_THROWS_AS(
+        Operon::RegisterUnaryInterval(logHash, [](Operon::IntervalEvaluator::Interval const& v) { return v; }),
+        std::invalid_argument);
+    CHECK_THROWS_AS(
+        Operon::RegisterUnaryAffine(logHash,
+            [](Operon::AffineEvaluator::Context const&, Operon::AffineEvaluator::Affine const& v) { return v; }),
+        std::invalid_argument);
+}
+
+#ifdef HAVE_ASMJIT
+TEST_CASE("RegisterUnaryJitCodegen: colliding with a built-in hash always throws", "[registry][toctou][jit]")
+{
+    CHECK_THROWS_AS(
+        Operon::JIT::RegisterUnaryJitCodegen(Operon::Hash(BuiltinOp::Log),
+            [](asmjit::x86::Compiler&, asmjit::x86::Vec const& a) { return a; }),
+        std::invalid_argument);
+}
+#endif
+
+// --- Round-trip: a genuinely new (non-built-in) hash registers cleanly,
+// is invoked by the consumer, and a second registration under the same
+// hash throws.
+TEST_CASE("IntervalEvaluator: user-registered unary op round-trips and rejects duplicates", "[registry][interval]")
+{
+    constexpr Operon::Hash customHash{0x2222222222222222ULL};
+    // static: the lambda is stored permanently in the global IntervalUnaryRules()
+    // registry (there's no way to unregister it), so it must not capture a
+    // reference to something with the TEST_CASE's own (shorter) lifetime.
+    static bool invoked = false;
+    invoked = false;
+    Operon::RegisterUnaryInterval(customHash, [](Operon::IntervalEvaluator::Interval const& v) {
+        invoked = true;
+        return v;
+    });
+    REQUIRE(Operon::IntervalUnaryRules().Contains(customHash));
+
+    CHECK_THROWS_AS(
+        Operon::RegisterUnaryInterval(customHash, [](Operon::IntervalEvaluator::Interval const& v) { return v; }),
+        std::invalid_argument);
+
+    auto constNode = Node::Constant(1.0F);
+    constNode.Optimize = false;
+    Tree const tree = Tree({ constNode, Node::Function(customHash, 1) }).UpdateNodes();
+    Operon::IntervalEvaluator::DomainMap noDomains;
+    static_cast<void>(IntervalEvaluator{&tree, noDomains}.Evaluate({}));
+    CHECK(invoked);
+}
+
+// --- End-to-end miss behavior: a genuinely unmapped hash (not registered
+// anywhere) must still throw for interval/affine, matching the unchanged
+// contract documented on Register{Unary,Binary}{Interval,Affine}.
+TEST_CASE("IntervalEvaluator/AffineEvaluator: unmapped op throws at Evaluate()", "[registry][miss]")
+{
+    constexpr Operon::Hash unmappedHash{0x3333333333333333ULL};
+    auto constNode = Node::Constant(1.0F);
+    constNode.Optimize = false;
+    Tree const tree = Tree({ constNode, Node::Function(unmappedHash, 1) }).UpdateNodes();
+    Operon::IntervalEvaluator::DomainMap noDomains;
+
+    CHECK_THROWS_AS(IntervalEvaluator(&tree, noDomains).Evaluate({}), std::runtime_error);
+    CHECK_THROWS_AS(AffineEvaluator(&tree, noDomains).Evaluate({}), std::runtime_error);
+}
+
+#ifdef HAVE_ASMJIT
+// --- The JIT-specific miss behavior this commit changes: CompileAVX2()
+// returns nullptr (not a propagating throw) for an unmapped op, so
+// JitEvaluator can fall back to the interpreter. Also confirms the fix
+// doesn't regress into the retry-forever bug: a second CompileAVX2() call
+// (of an all-built-in tree) still succeeds afterward.
+TEST_CASE("JIT CompileAVX2: unmapped op degrades to nullptr, doesn't brick later compiles", "[registry][jit][miss]")
+{
+    constexpr Operon::Hash unmappedHash{0x4444444444444444ULL};
+    JIT::JitRuntimePool pool;
+    if (!pool.HasAVX2()) { return; } // matches CompileAVX2's own guard
+
+    auto constNode = Node::Constant(1.0F);
+    constNode.Optimize = false;
+    Tree const badTree = Tree({ constNode, Node::Function(unmappedHash, 1) }).UpdateNodes();
+
+    JIT::TreeCompiler compiler(&pool);
+    auto compiled = compiler.CompileAVX2(badTree);
+    CHECK(compiled == nullptr);
+
+    auto expNode = Util::MakeOp<BuiltinOp::Exp>();
+    Tree const goodTree = Tree({ constNode, expNode }).UpdateNodes();
+    auto compiledGood = compiler.CompileAVX2(goodTree);
+    CHECK(compiledGood != nullptr);
 }
 #endif
 

--- a/test/source/implementation/registry_coverage.cpp
+++ b/test/source/implementation/registry_coverage.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+#include <vector>
+
+#include "operon/core/node.hpp"
+#include "operon/core/tree_diff.hpp"
+#include "operon/interpreter/interval_evaluator.hpp"
+#include "operon/interpreter/affine_evaluator.hpp"
+
+#ifdef HAVE_ASMJIT
+#include "operon/interpreter/backend/jit/jit_compiler.hpp"
+#endif
+
+// Cross-registry coverage: nothing structurally guarantees the symbolic-diff,
+// interval, affine, and JIT-codegen registries all cover the same set of
+// BuiltinOps. A BuiltinOp missing from one of them silently degrades (Zero
+// for diff, a throw for interval/affine/JIT) — indistinguishable from a
+// legitimately-unsupported op unless asserted explicitly. This test is the
+// deliverable flagged (but not built) in the registry redesign's planning
+// notes: assert every BuiltinOp is either registered, or on the explicit
+// "deliberately absent" allowlist below, for each registry.
+
+namespace Operon::Test {
+
+namespace {
+
+auto OpName(BuiltinOp op) -> std::string
+{
+    return Node::Function(static_cast<Operon::Hash>(op), 1).Name();
+}
+
+// n-ary reductions (Add/Mul/Sub/Div/Fmin/Fmax) are handled directly as
+// structural cases in each consumer (Deriv(), Evaluate(), EmitNodesAvx2) —
+// never through a single-hash unary/binary registry entry. Shared by the
+// interval/affine/JIT checks below (all three have the identical boundary).
+auto NaryFolds() -> std::vector<BuiltinOp> const&
+{
+    static std::vector<BuiltinOp> const ops {
+        BuiltinOp::Add, BuiltinOp::Mul, BuiltinOp::Sub, BuiltinOp::Div,
+        BuiltinOp::Fmin, BuiltinOp::Fmax,
+    };
+    return ops;
+}
+
+} // namespace
+
+TEST_CASE("Cross-registry coverage: symbolic-diff registry", "[registry][coverage]")
+{
+    // Structural (n-ary, or Pow's two-term chain rule — handled directly in
+    // Deriv(), never through the unary registry) or genuinely not-yet-
+    // implemented — see tree_diff.cpp's Deriv() and
+    // RegisterBuiltinSymbolicDerivs().
+    std::vector<BuiltinOp> deliberatelyAbsent = NaryFolds();
+    deliberatelyAbsent.insert(deliberatelyAbsent.end(), {
+        BuiltinOp::Aq, BuiltinOp::Pow, BuiltinOp::Powabs, // Pow: structural (two terms); Aq/Powabs: not yet differentiated
+        BuiltinOp::Abs, BuiltinOp::Sqrtabs, BuiltinOp::Floor, BuiltinOp::Ceil, // non-smooth
+    });
+
+    for (std::size_t i = 0; i < Operon::BuiltinOpCount; ++i) {
+        auto const op = static_cast<BuiltinOp>(i);
+        auto const hash = static_cast<Operon::Hash>(op);
+        bool const present = HasUnarySymbolicDeriv(hash);
+        bool const expectAbsent = std::ranges::find(deliberatelyAbsent, op) != deliberatelyAbsent.end();
+        INFO("op: " << OpName(op));
+        CHECK(present == !expectAbsent);
+    }
+}
+
+TEST_CASE("Cross-registry coverage: interval/affine registries", "[registry][coverage]")
+{
+    // Force built-in registration (each evaluator populates its registries
+    // lazily on first Evaluate() call). Optimize=false so Evaluate({}) needs
+    // no coefficient span (Node::Constant() defaults Optimize=true as a leaf).
+    auto constNode = Node::Constant(1.0F);
+    constNode.Optimize = false;
+    Operon::Tree dummy{{constNode}};
+    Operon::IntervalEvaluator::DomainMap noDomains;
+    static_cast<void>(IntervalEvaluator{&dummy, noDomains}.Evaluate({}));
+    static_cast<void>(AffineEvaluator{&dummy, noDomains}.Evaluate({}));
+
+    auto const& deliberatelyAbsent = NaryFolds();
+
+    for (std::size_t i = 0; i < Operon::BuiltinOpCount; ++i) {
+        auto const op = static_cast<BuiltinOp>(i);
+        auto const hash = static_cast<Operon::Hash>(op);
+        bool const expectAbsent = std::ranges::find(deliberatelyAbsent, op) != deliberatelyAbsent.end();
+
+        bool const inInterval = Operon::IntervalUnaryRules().Contains(hash)
+            || Operon::IntervalBinaryRules().Contains(hash);
+        bool const inAffine = Operon::AffineUnaryRules().Contains(hash)
+            || Operon::AffineBinaryRules().Contains(hash);
+
+        INFO("op: " << OpName(op));
+        CHECK(inInterval == !expectAbsent);
+        CHECK(inAffine == !expectAbsent);
+    }
+}
+
+#ifdef HAVE_ASMJIT
+TEST_CASE("Cross-registry coverage: JIT codegen registry", "[registry][coverage][jit]")
+{
+    auto const& deliberatelyAbsent = NaryFolds();
+
+    for (std::size_t i = 0; i < Operon::BuiltinOpCount; ++i) {
+        auto const op = static_cast<BuiltinOp>(i);
+        auto const hash = static_cast<Operon::Hash>(op);
+        bool const expectAbsent = std::ranges::find(deliberatelyAbsent, op) != deliberatelyAbsent.end();
+
+        bool const inJit = Operon::JIT::HasUnaryJitCodegen(hash)
+            || Operon::JIT::HasBinaryJitCodegen(hash);
+
+        INFO("op: " << OpName(op));
+        CHECK(inJit == !expectAbsent);
+    }
+}
+#endif
+
+} // namespace Operon::Test

--- a/test/source/implementation/user_defined_registries.cpp
+++ b/test/source/implementation/user_defined_registries.cpp
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+// Exercises the "non-built-in functions participate in diff/interval-affine/
+// JIT for the first time" claim from an actual external-caller perspective,
+// not just by reading the migrated built-in rules: registers a single
+// user-defined function ("recip", f(x) = 1/x) through all four registries
+// (numeric DispatchTable, symbolic diff, interval, affine, and — if built —
+// JIT codegen) and checks each path independently against a known reference.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cmath>
+
+#include "operon/core/dataset.hpp"
+#include "operon/core/dispatch.hpp"
+#include "operon/core/pset.hpp"
+#include "operon/core/symbol_library.hpp"
+#include "operon/core/tree.hpp"
+#include "operon/core/tree_diff.hpp"
+#include "operon/interpreter/interpreter.hpp"
+#include "operon/interpreter/affine_evaluator.hpp"
+#include "operon/interpreter/interval_evaluator.hpp"
+
+#ifdef HAVE_ASMJIT
+#include "operon/interpreter/backend/jit/jit_compiler.hpp"
+#endif
+
+namespace Operon::Test {
+
+namespace {
+
+// Hash-consing convention private to tree_diff.cpp (MakeUnary/MakeBinary/
+// GetConst are anonymous-namespace, not exported) hand-rolled here using
+// only the public Node factories — this is exactly the amount of protocol
+// knowledge an external caller needs: children are appended as Ref nodes
+// (never inlined subtrees, so Node::Function(hash, arity)'s arity == the
+// node's Length with no further bookkeeping), a binary op's farther child
+// is appended before its nearer child, and any literal constant must have
+// Optimize forced to false (a leaf's default ctor sets Optimize=true,
+// which would make the derivative-DAG's own synthetic constant look like a
+// tunable coefficient to anything counting them). The parallel hash vector
+// `h` is read only by Deriv()'s own memo lookups within the same call
+// (verified: `grep h\[ source/core/tree_diff.cpp` shows exactly three
+// reads, all feeding Mix() for a memo key) — never compared against
+// anything outside this one Deriv() invocation — so any distinct
+// placeholder value here (dag.size() at push time) is safe; it costs
+// missed CSE opportunities, not correctness.
+struct HandRolledDagBuilder {
+    Operon::Vector<Node>& dag;
+    Operon::Vector<Operon::Hash>& h;
+
+    auto PushRef(std::size_t target) -> std::size_t {
+        dag.push_back(Node::Ref(static_cast<uint16_t>(target)));
+        h.push_back(static_cast<Operon::Hash>(dag.size()));
+        return dag.size() - 1;
+    }
+    auto PushConst(Scalar v) -> std::size_t {
+        auto n = Node::Constant(v);
+        n.Optimize = false;
+        dag.push_back(n);
+        h.push_back(static_cast<Operon::Hash>(dag.size()));
+        return dag.size() - 1;
+    }
+    auto PushUnary(BuiltinOp op, std::size_t a) -> std::size_t {
+        PushRef(a);
+        dag.push_back(Node::Function(static_cast<Operon::Hash>(op), 1));
+        h.push_back(static_cast<Operon::Hash>(dag.size()));
+        return dag.size() - 1;
+    }
+    auto PushBinary(BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t {
+        PushRef(b); // farther child first — matches MakeBinary's documented layout
+        PushRef(a); // nearer child second
+        dag.push_back(Node::Function(static_cast<Operon::Hash>(op), 2));
+        h.push_back(static_cast<Operon::Hash>(dag.size()));
+        return dag.size() - 1;
+    }
+};
+
+} // namespace
+
+TEST_CASE("User-defined function via registries: recip(x) = 1/x", "[registry][user-defined]")
+{
+    auto const hash = Operon::Hasher{}("recip");
+    REQUIRE(hash >= Operon::BuiltinOpCount); // sanity: lands outside the built-in range
+
+    // 1. Numeric evaluation — RegisterUnaryFunction (existing DispatchTable
+    // API, pre-dates this PR); registers with no explicit derivative, so
+    // Jet<T,1> auto-diff backs coefficient optimization if this function is
+    // ever tuned — independent of the symbolic-diff registry tested below.
+    Operon::ScalarDispatch dtable;
+    PrimitiveSet pset;
+    pset.SetConfig(NodeType::Constant | NodeType::Variable | BuiltinOp::Add | BuiltinOp::Mul);
+    RegisterUnaryFunction<Operon::ScalarDispatch, Operon::Scalar>(
+        dtable, pset, { .Name = "recip", .Desc = "f(x) = 1/x", .Arity = 1, .Frequency = 1 },
+        [](auto v) { return decltype(v){1} / v; });
+
+    auto tree = Tree({ Node::Constant(2.0), Node::Function(hash, 1) }).UpdateNodes();
+    tree.Nodes()[0].Optimize = true;
+
+    Dataset const ds(std::vector<std::string>{ "dummy" }, std::vector<std::vector<Operon::Scalar>>{ { 0.0F } });
+    Interpreter<Operon::Scalar, Operon::ScalarDispatch> interp(&dtable, &ds, &tree);
+    auto result = interp.Evaluate(tree.GetCoefficients(), Range{ 0, 1 });
+    CHECK(result[0] == Catch::Approx(0.5).epsilon(1e-5)); // 1/2
+
+    // 2. Symbolic differentiation — RegisterUnarySymbolicDeriv, the
+    // registry this PR adds. d(1/x)/dx = -1/x^2, built by hand per the
+    // HandRolledDagBuilder rationale above (no private helper needed).
+    RegisterUnarySymbolicDeriv(hash,
+        [](Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& /*memo*/,
+           Operon::Vector<Operon::Hash>& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+            HandRolledDagBuilder b{ dag, h };
+            auto negOne = b.PushConst(Scalar{ -1 });
+            auto sq     = b.PushUnary(BuiltinOp::Square, j);
+            return b.PushBinary(BuiltinOp::Div, negOne, sq); // -1 / x^2, non-commutative — exercises binary child ordering
+        });
+    REQUIRE(HasUnarySymbolicDeriv(hash));
+
+    auto jdag = BuildJacobianDag(tree);
+    REQUIRE(jdag.Roots.size() == 1);
+    REQUIRE(jdag.Roots[0] != std::numeric_limits<std::size_t>::max()); // not Zero
+
+    // The dag's flat Node array follows the same postfix/Ref convention a
+    // plain Tree does (original tree at [0, OriginalSize), derivative
+    // subtrees appended after) — sliceable into a standalone, directly
+    // evaluable Tree.
+    Operon::Vector<Node> sliced(jdag.Nodes.begin(), jdag.Nodes.begin() + static_cast<std::ptrdiff_t>(jdag.Roots[0]) + 1);
+    Tree derivTree(std::move(sliced));
+    derivTree.UpdateNodes();
+    auto derivCoeff = derivTree.GetCoefficients(); // the constant's Optimize flag was preserved from the original tree
+    Interpreter<Operon::Scalar, Operon::ScalarDispatch> derivInterp(&dtable, &ds, &derivTree);
+    auto derivResult = derivInterp.Evaluate(derivCoeff, Range{ 0, 1 });
+    CHECK(derivResult[0] == Catch::Approx(-0.25).epsilon(1e-4)); // -1/2^2
+
+    // 3. Interval bound propagation — RegisterUnaryInterval.
+    RegisterUnaryInterval(hash, [](IntervalEvaluator::Interval const& v) {
+        return IntervalEvaluator::Interval{ Scalar{1} } / v;
+    });
+    {
+        // Interval/affine evaluators don't consult a Dataset for hash
+        // assignment (unlike the JIT section below) — any self-chosen
+        // hash is fine as long as the Variable node and DomainMap key agree.
+        auto varHash = Operon::Hash{ 1 };
+        Node var(NodeType::Variable, varHash); var.Value = 1.0F;
+        auto ivTree = Tree({ var, Node::Function(hash, 1) }).UpdateNodes();
+        IntervalEvaluator::DomainMap dm;
+        dm[varHash] = { Scalar{ 1 }, Scalar{ 4 } };
+        IntervalEvaluator ivEval(&ivTree, std::move(dm));
+        auto iv = ivEval.Evaluate(ivTree.GetCoefficients());
+        CHECK(iv.inf() <= 0.25 + 1e-4);
+        CHECK(iv.sup() + 1e-4 >= 1.0);
+    }
+
+    // 4. Affine bound propagation — RegisterUnaryAffine. Unlike interval's
+    // pappus::interval (which has a scalar-value ctor), affine_form has no
+    // context-free literal constructor (every affine_form is tied to the
+    // affine_context that allocated its epsilon terms) — but its friend
+    // `operator/(T, affine_form const&)` exists precisely to avoid needing
+    // one here, so the ctx parameter genuinely goes unused for this rule.
+    RegisterUnaryAffine(hash,
+        [](AffineEvaluator::Context const&, AffineEvaluator::Affine const& v) {
+            return Scalar{1} / v;
+        });
+    {
+        auto varHash = Operon::Hash{ 2 };
+        Node var(NodeType::Variable, varHash); var.Value = 1.0F;
+        auto afTree = Tree({ var, Node::Function(hash, 1) }).UpdateNodes();
+        AffineEvaluator::DomainMap dm;
+        dm[varHash] = { Scalar{ 1 }, Scalar{ 4 } };
+        AffineEvaluator afEval(&afTree, std::move(dm));
+        auto af = afEval.Evaluate(afTree.GetCoefficients());
+        auto ivFromAffine = af.to_interval();
+        CHECK(ivFromAffine.inf() <= 0.25 + 1e-2);
+        CHECK(ivFromAffine.sup() + 1e-2 >= 1.0);
+    }
+
+#ifdef HAVE_ASMJIT
+    // 5. JIT codegen — RegisterUnaryJitCodegen. jit_compiler.cpp has its
+    // own private BroadcastFloat() helper for exactly this pattern
+    // (mov bit-pattern -> GP32, vmovd -> xmm, vbroadcastss -> ymm) but it's
+    // anonymous-namespace, not exported — replicated here with only public
+    // asmjit::x86::Compiler calls (the virtual-register API only, never
+    // raw Assembler, per the registry's documented safety contract).
+    JIT::RegisterUnaryJitCodegen(hash, [](asmjit::x86::Compiler& cc, asmjit::x86::Vec const& a) {
+        uint32_t bits{};
+        float const one = 1.0F;
+        std::memcpy(&bits, &one, sizeof bits);
+        auto tmp = cc.new_gp32();
+        cc.mov(tmp, bits);
+        auto xmm = cc.new_xmm_ss();
+        cc.vmovd(xmm, tmp);
+        auto ones = cc.new_ymm_ps();
+        cc.vbroadcastss(ones, xmm);
+        auto res = cc.new_ymm_ps();
+        cc.vdivps(res, ones, a);
+        return res;
+    });
+    REQUIRE(JIT::HasUnaryJitCodegen(hash));
+
+    {
+        // End-to-end: compile a tree using the custom op and compare its
+        // AVX2-JIT output against the interpreter, across a small batch.
+        JIT::JitRuntimePool pool;
+        if (pool.HasAVX2()) {
+            // Dataset assigns each named variable's hash itself (Hasher{}
+            // applied to the name) — read it back rather than assume one,
+            // so the tree's Variable node and the dataset's column lookup
+            // agree.
+            Dataset const jitDs(std::vector<std::string>{ "V" },
+                std::vector<std::vector<Operon::Scalar>>{ { 1.0F, 2.0F, 4.0F, 0.5F } });
+            auto varHash = jitDs.GetVariable("V").value().Hash;
+            Node var(NodeType::Variable, varHash); var.Value = 1.0F;
+            auto jitTree = Tree({ var, Node::Function(hash, 1) }).UpdateNodes();
+
+            Interpreter<Operon::Scalar, Operon::ScalarDispatch> refInterp(&dtable, &jitDs, &jitTree);
+            auto ref = refInterp.Evaluate(jitTree.GetCoefficients(), Range{ 0, jitDs.Rows<std::size_t>() });
+
+            JIT::TreeCompiler compiler(&pool);
+            auto compiled = compiler.CompileAVX2(jitTree);
+            REQUIRE(compiled != nullptr);
+            REQUIRE(compiled->fn != nullptr);
+
+            // Invoke the compiled function directly (same calling
+            // convention jit.cpp's own tests use — nRows padded to a
+            // multiple of 8, columns in JIT::VarOrder(tree)'s order).
+            Range const jitRange{ 0, jitDs.Rows<std::size_t>() };
+            auto const nRows    = static_cast<int32_t>(jitRange.Size());
+            auto const nRowsPad = (nRows + 7) & ~7;
+            auto const varOrder = JIT::VarOrder(jitTree);
+            std::vector<float const*> colPtrs(varOrder.size());
+            for (std::size_t i = 0; i < varOrder.size(); ++i) {
+                colPtrs[i] = jitDs.GetPaddedValues(varOrder[i]) + jitRange.Start();
+            }
+            auto jitCoeff = jitTree.GetCoefficients();
+            std::vector<float> scratch(static_cast<std::size_t>(nRowsPad));
+            compiled->fn(scratch.data(), colPtrs.data(), nRowsPad,
+                         jitCoeff.empty() ? nullptr : jitCoeff.data());
+
+            REQUIRE(ref.size() == static_cast<std::size_t>(nRows));
+            for (std::size_t i = 0; i < ref.size(); ++i) {
+                INFO("row " << i << " ref=" << ref[i] << " jit=" << scratch[i]);
+                CHECK(scratch[i] == Catch::Approx(ref[i]).epsilon(1e-4));
+            }
+        }
+    }
+#endif
+}
+
+} // namespace Operon::Test


### PR DESCRIPTION
## Summary

Replaces four hardcoded `switch (node.HashValue) { case Operon::Hash(BuiltinOp::X): ... }` statements with runtime hash-keyed registry lookups, so non-built-in (user-registered) functions can participate in symbolic differentiation, interval/affine bound propagation, and JIT codegen — not just the 29 built-in math ops.

A small shared template, `HashRegistry<Fn>` (`include/operon/core/hash_registry.hpp`), backs four registry families:

- **`tree_diff.cpp`** — `SymbolicDerivRegistry`, ~16 unary derivative rules migrated verbatim out of `Deriv()`'s old switch. `Add/Mul/Sub/Div/Pow` and non-smooth ops (`Abs/Sqrtabs/Floor/Ceil`) stay hardcoded/unregistered by design — a registry miss degrades to the `Zero` sentinel, unchanged from today.
- **`interval_evaluator.hpp`** / **`affine_evaluator.hpp`** — unary + binary (`Pow`/`Aq`/`Powabs`) registries; `Add/Mul/Sub/Div/Fmin/Fmax` stay hardcoded n-ary folds. A registry miss still throws, unchanged from today.
- **`jit_compiler.cpp`** — codegen callbacks emit asmjit `x86::Compiler` instructions via the virtual-register API only (never raw `Assembler`). AVX2-only: the old scalar/SSE codegen path (`EmitNodesScalar`, `TreeCompiler::Compile()`) is deleted outright rather than ported to a registry, since operon's own build unconditionally requires AVX2 (`-march=x86-64-v3` / `/arch:AVX2`), making that path dead code on every officially-built platform. A registry miss now returns `nullptr` instead of throwing, so `JitEvaluator` falls back to interpreter evaluation per-tree.

All registries share `HashRegistry::Register()`'s write-once contract (throws on a duplicate hash), and every public `Register*` entry point triggers its domain's built-in registration before writing, so a user hash colliding with a built-in throws immediately at the call site rather than being silently accepted.

`registry_coverage.cpp` adds cross-registry coverage tests asserting every `BuiltinOp` is registered (or deliberately excluded) in each registry, plus round-trip/write-once/miss-behavior tests for the public API. `jit.cpp` and `pappus_backend.cpp` add distinguishing-value correctness tests for every previously-untested op (trig/hyperbolic across interval/affine/JIT, plus JIT floor/ceil) so a hash-preserving lambda swap between two ops would fail, not just a missing registration.

## Test plan

- [x] Static build (`build-ws`, `BUILD_SHARED_LIBS=OFF`): full suite green (10897 assertions / 59 cases on `[jit],[pappus],[registry]`; library itself builds — the CLI executables fail to statically link `scnlib`, a pre-existing, unrelated environment issue reproducible on pre-PR `main`)
- [x] Shared build (`build-ws-shared`): full suite green, including all CLI executables (19697 assertions / 280 cases overall)
- [x] Reviewed independently via `opencode`/`glm-5.2` (read-only pass) in addition to direct inspection — no correctness bugs found in either pass