### PR TITLE
Fix double-weighted derivatives in CallableDiff (Mul/Div/Exp/Sqrt/Sqrtabs/Cbrt/Pow/Powabs/Aq)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,15 @@ CMakeLists.txt.user
 CMakeUserPresets.json
 project-include-after.cmake
 .direnv
+
+# Local scratch/analysis scripts and outputs — not part of the library,
+# kept out of git so a dirty tree here doesn't force `nix develop` to
+# re-evaluate/re-copy the flake's source on every invocation.
+docs/research/
+scratch/
+tools/__pycache__/
+tools/results/
+tools/*.py
+tools/*.sh
+tools/*.yaml
+tools/*.txt

--- a/include/operon/interpreter/backend/eigen/derivatives.hpp
+++ b/include/operon/interpreter/backend/eigen/derivatives.hpp
@@ -32,9 +32,18 @@ namespace detail {
         Col(trace, j).setConstant(T{1});
     }
 
+    // Every node's forward pass multiplies by its own weight, so primal[i]
+    // already has `w` baked in — reading it as a shortcut for the
+    // *unweighted* value double-counts `w`, since ReverseTraceGeneric
+    // separately multiplies by `w` once more during the backward sweep.
+    // Dividing by `w` here keeps the shortcut while returning the correct
+    // unweighted local derivative. Confirmed via reproduction against an
+    // independent JAX-computed ground truth (see foolnotion/operon-planning's
+    // double-weighted-derivative bug writeup).
     template<typename T, std::size_t S>
-    auto Mul(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        Col(trace, j) = Col(primal, i) / Col(primal, j);
+    auto Mul(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        Col(trace, j) = Col(primal, i) / (w * Col(primal, j));
     }
 
     template<typename T, std::size_t S>
@@ -49,38 +58,43 @@ namespace detail {
         if (n.Arity == 1) {
             Col(trace, j) = -Col(primal, j).square().inverse();
         } else {
-            Col(trace, j) = (j == i-1 ? T{1} : T{-1}) * Col(primal, i) / Col(primal, j);
+            auto const w = static_cast<T>(n.Value);
+            Col(trace, j) = (j == i-1 ? T{1} : T{-1}) * Col(primal, i) / (w * Col(primal, j));
         }
     }
 
     template<typename T, std::size_t S>
-    auto Aq(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+    auto Aq(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         if (j == i-1) {
-            Col(trace, j) = Col(primal, i) / Col(primal, j);
+            Col(trace, j) = Col(primal, i) / (w * Col(primal, j));
         } else {
-            Col(trace, j) = -Col(primal, j) * Col(primal, i).pow(T{3}) / Col(primal, i-1).square();
+            auto const w3 = w * w * w;
+            Col(trace, j) = -Col(primal, j) * Col(primal, i).pow(T{3}) / (w3 * Col(primal, i-1).square());
         }
     }
 
     template<typename T, std::size_t S>
     auto Pow(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         if (j == i-1) {
             auto const k = j - (nodes[j].Length + 1);
-            Col(trace, j) = Col(primal, i) * Col(primal, k) / Col(primal, j);
+            Col(trace, j) = Col(primal, i) * Col(primal, k) / (w * Col(primal, j));
         } else {
             auto const k = i-1;
-            Col(trace, j) = Col(primal, i) * Col(primal, k).log();
+            Col(trace, j) = Col(primal, i) * Col(primal, k).log() / w;
         }
     }
 
     template<typename T, std::size_t S>
     auto Powabs(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         if (j == i-1) {
             auto const k = j - (nodes[j].Length + 1);
-            Col(trace, j) = Col(primal, i) * Col(primal, k) * Col(primal, j).sign() / Col(primal, j).abs();
+            Col(trace, j) = Col(primal, i) * Col(primal, k) * Col(primal, j).sign() / (w * Col(primal, j).abs());
         } else {
             auto const k = i-1;
-            Col(trace, j) = Col(primal, i) * Col(primal, k).abs().log();
+            Col(trace, j) = Col(primal, i) * Col(primal, k).abs().log() / w;
         }
     }
 
@@ -119,8 +133,9 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Exp(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        Col(trace, j) = Col(primal, i);
+    auto Exp(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        Col(trace, j) = Col(primal, i) / w;
     }
 
     template<typename T, std::size_t S>
@@ -184,18 +199,22 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        Col(trace, j) = (T{2} * Col(primal, i)).inverse();
+    auto Sqrt(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        Col(trace, j) = w * (T{2} * Col(primal, i)).inverse();
     }
 
     template<typename T, std::size_t S>
-    auto Sqrtabs(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        Col(trace, j) = Col(primal, j).sign() / (T{2} * Col(primal, i));
+    auto Sqrtabs(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        Col(trace, j) = w * Col(primal, j).sign() / (T{2} * Col(primal, i));
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        Col(trace, j) = (T{3} * Col(primal, i).square()).inverse();
+    auto Cbrt(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const w2 = w * w;
+        Col(trace, j) = w2 * (T{3} * Col(primal, i).square()).inverse();
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/eigen/derivatives.hpp
+++ b/include/operon/interpreter/backend/eigen/derivatives.hpp
@@ -43,6 +43,12 @@ namespace detail {
     template<typename T, std::size_t S>
     auto Mul(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
+        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
+        // even though the true (unweighted) local derivative is well-defined
+        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
+        // so any finite placeholder yields the correct final zero — 0*NaN
+        // would not.
+        if (w == T{0}) { Col(trace, j).setZero(); return; }
         Col(trace, j) = Col(primal, i) / (w * Col(primal, j));
     }
 
@@ -59,6 +65,7 @@ namespace detail {
             Col(trace, j) = -Col(primal, j).square().inverse();
         } else {
             auto const w = static_cast<T>(n.Value);
+            if (w == T{0}) { Col(trace, j).setZero(); return; } // see Mul's w==0 comment
             Col(trace, j) = (j == i-1 ? T{1} : T{-1}) * Col(primal, i) / (w * Col(primal, j));
         }
     }
@@ -66,6 +73,7 @@ namespace detail {
     template<typename T, std::size_t S>
     auto Aq(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
+        if (w == T{0}) { Col(trace, j).setZero(); return; } // see Mul's w==0 comment
         if (j == i-1) {
             Col(trace, j) = Col(primal, i) / (w * Col(primal, j));
         } else {
@@ -77,6 +85,7 @@ namespace detail {
     template<typename T, std::size_t S>
     auto Pow(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
+        if (w == T{0}) { Col(trace, j).setZero(); return; } // see Mul's w==0 comment
         if (j == i-1) {
             auto const k = j - (nodes[j].Length + 1);
             Col(trace, j) = Col(primal, i) * Col(primal, k) / (w * Col(primal, j));
@@ -89,6 +98,7 @@ namespace detail {
     template<typename T, std::size_t S>
     auto Powabs(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
+        if (w == T{0}) { Col(trace, j).setZero(); return; } // see Mul's w==0 comment
         if (j == i-1) {
             auto const k = j - (nodes[j].Length + 1);
             Col(trace, j) = Col(primal, i) * Col(primal, k) * Col(primal, j).sign() / (w * Col(primal, j).abs());
@@ -132,10 +142,15 @@ namespace detail {
         Col(trace, j).setZero();
     }
 
+    // Recomputed fresh from the child's own primal (matching the forward
+    // pass's own .exp() call in functions.hpp) rather than reading this
+    // node's already-weighted primal[i] and dividing by its own weight —
+    // avoids the w==0 singularity entirely, unlike the primal[i]-shortcut
+    // ops above (Mul/Div/Aq/Pow/Powabs) which need cross-child information
+    // the single available primal[j] can't reconstruct.
     template<typename T, std::size_t S>
-    auto Exp(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        Col(trace, j) = Col(primal, i) / w;
+    auto Exp(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).exp();
     }
 
     template<typename T, std::size_t S>
@@ -199,22 +214,19 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        Col(trace, j) = w * (T{2} * Col(primal, i)).inverse();
+    auto Sqrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = (T{2} * Col(primal, j).sqrt()).inverse();
     }
 
     template<typename T, std::size_t S>
-    auto Sqrtabs(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        Col(trace, j) = w * Col(primal, j).sign() / (T{2} * Col(primal, i));
+    auto Sqrtabs(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        Col(trace, j) = Col(primal, j).sign() / (T{2} * Col(primal, j).abs().sqrt());
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const w2 = w * w;
-        Col(trace, j) = w2 * (T{3} * Col(primal, i).square()).inverse();
+    auto Cbrt(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
+        auto const cb = Col(primal, j).unaryExpr([](auto x) { return std::cbrt(x); });
+        Col(trace, j) = (T{3} * cb.square()).inverse();
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/eigen/derivatives.hpp
+++ b/include/operon/interpreter/backend/eigen/derivatives.hpp
@@ -32,22 +32,17 @@ namespace detail {
         Col(trace, j).setConstant(T{1});
     }
 
-    // Every node's forward pass multiplies by its own weight, so primal[i]
-    // already has `w` baked in — reading it as a shortcut for the
-    // *unweighted* value double-counts `w`, since ReverseTraceGeneric
-    // separately multiplies by `w` once more during the backward sweep.
-    // Dividing by `w` here keeps the shortcut while returning the correct
-    // unweighted local derivative. Confirmed via reproduction against an
-    // independent JAX-computed ground truth (see foolnotion/operon-planning's
-    // double-weighted-derivative bug writeup).
+    // Every node's forward pass multiplies its result by the node's own
+    // weight w, so primal[i] equals w * f(children), not f(children) alone.
+    // This function must return the derivative of f(children) alone,
+    // without w — something else multiplies by w again later. Dividing
+    // primal[i] by w here gives that unweighted derivative.
     template<typename T, std::size_t S>
     auto Mul(Operon::Vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
-        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
-        // even though the true (unweighted) local derivative is well-defined
-        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
-        // so any finite placeholder yields the correct final zero — 0*NaN
-        // would not.
+        // If w is 0, primal[i] is 0 too, so the shortcut below computes 0/0,
+        // which is not a number. The correct derivative here is exactly 0.
+        // Returning 0 directly avoids the 0/0 case.
         if (w == T{0}) { Col(trace, j).setZero(); return; }
         Col(trace, j) = Col(primal, i) / (w * Col(primal, j));
     }
@@ -142,12 +137,12 @@ namespace detail {
         Col(trace, j).setZero();
     }
 
-    // Recomputed fresh from the child's own primal (matching the forward
-    // pass's own .exp() call in functions.hpp) rather than reading this
-    // node's already-weighted primal[i] and dividing by its own weight —
-    // avoids the w==0 singularity entirely, unlike the primal[i]-shortcut
-    // ops above (Mul/Div/Aq/Pow/Powabs) which need cross-child information
-    // the single available primal[j] can't reconstruct.
+    // Computes the derivative directly from the child's value, using
+    // .exp() — the same function the forward pass uses. Mul/Div/Aq/Pow/
+    // Powabs above can't do this: their derivative also needs a sibling
+    // child's value, so they divide this node's own weighted result by its
+    // weight instead, which fails when the weight is 0. This function never
+    // divides by the weight, so it has no such problem.
     template<typename T, std::size_t S>
     auto Exp(Operon::Vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T, S> trace, std::integral auto /*i*/, std::integral auto j) {
         Col(trace, j) = Col(primal, j).exp();

--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -31,17 +31,26 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
+    // Every node's forward pass multiplies by its own weight, so primal[i]
+    // already has `w` baked in — reading it as a shortcut for the
+    // *unweighted* value double-counts `w`, since ReverseTraceGeneric
+    // separately multiplies by `w` once more during the backward sweep.
+    // Dividing by `w` here keeps the shortcut while returning the correct
+    // unweighted local derivative. Confirmed via reproduction against an
+    // independent JAX-computed ground truth (see foolnotion/operon-planning's
+    // double-weighted-derivative bug writeup).
     template<typename T, std::size_t S>
-    auto Mul(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         auto constexpr L = W::size();
+        auto const w = static_cast<T>(nodes[i].Value);
 
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
         for(auto s = 0UL; s < S; s += L) {
-            eve::store(W{pi+s} / W{pj+s}, res+s);
+            eve::store(W{pi+s} / (w * W{pj+s}), res+s);
         }
     }
 
@@ -64,18 +73,20 @@ namespace detail {
                 eve::store(-eve::rec(eve::sqr(W{pj+s})), res+s);
             }
         } else {
+            auto const w = static_cast<T>(nodes[i].Value);
             auto v = j == i-1 ? T{1} : T{-1};
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(v * W{pi+s} / W{pj+s}, res+s);
+                eve::store(v * W{pi+s} / (w * W{pj+s}), res+s);
             }
         }
     }
 
     template<typename T, std::size_t S>
-    auto Aq(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Aq(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const k = i-1;
         auto const* pi = Ptr(primal, i);
@@ -84,14 +95,15 @@ namespace detail {
 
         if (j == i-1) {
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(W{pi+s} / W{pj+s}, res+s);
+                eve::store(W{pi+s} / (w * W{pj+s}), res+s);
             }
         } else {
+            auto const w3 = w * w * w;
             for (auto s = 0UL; s < S; s += L) {
                 W a{pi+s};
                 W b{pj+s};
                 W c{pk+s};
-                W r = -b * a * a * a / (c * c);
+                W r = -b * a * a * a / (w3 * c * c);
                 eve::store(r, res+s);
             }
         }
@@ -102,6 +114,7 @@ namespace detail {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -109,13 +122,13 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(W{pi+s} * W{pk+s} / W{pj+s}, res+s);
+                eve::store(W{pi+s} * W{pk+s} / (w * W{pj+s}), res+s);
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(W{pi+s} * eve::log(W{pk+s}), res+s);
+                eve::store(W{pi+s} * eve::log(W{pk+s}) / w, res+s);
             }
         }
     }
@@ -125,6 +138,7 @@ namespace detail {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -132,13 +146,13 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(W{pi+s} * W{pk+s} * eve::sign(W{pj+s}) / eve::abs(W{pj+s}), res+s);
+                eve::store(W{pi+s} * W{pk+s} * eve::sign(W{pj+s}) / (w * eve::abs(W{pj+s})), res+s);
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; s += L) {
-                eve::store(W{pi+s} * eve::log(eve::abs(W{pk+s})), res+s);
+                eve::store(W{pi+s} * eve::log(eve::abs(W{pk+s})) / w, res+s);
             }
         }
     }
@@ -198,8 +212,15 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        std::ranges::copy_n(Ptr(primal, i), S, Ptr(trace, j));
+    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        using W = eve::wide<T>;
+        static constexpr auto L = W::size();
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const* pi = Ptr(primal, i);
+        auto* res = Ptr(trace, j);
+        for (auto s = 0UL; s < S; s += L) {
+            eve::store(W{pi+s} / w, res+s);
+        }
     }
 
     template<typename T, std::size_t S>
@@ -347,39 +368,43 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const&  /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::rec(T{2} * W{pi+s}), res+s);
+            eve::store(w * eve::rec(T{2} * W{pi+s}), res+s);
         }
     }
 
     template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::sign(W{pj+s}) / (T{2} * W{pi+s}), res+s);
+            eve::store(w * eve::sign(W{pj+s}) / (T{2} * W{pi+s}), res+s);
         }
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const w2 = w * w;
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::rec(T{3} * eve::sqr(W{pi+s})), res+s);
+            eve::store(w2 * eve::rec(T{3} * eve::sqr(W{pi+s})), res+s);
         }
     }
 }  // namespace Operon::Backend

--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -31,25 +31,20 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
-    // Every node's forward pass multiplies by its own weight, so primal[i]
-    // already has `w` baked in — reading it as a shortcut for the
-    // *unweighted* value double-counts `w`, since ReverseTraceGeneric
-    // separately multiplies by `w` once more during the backward sweep.
-    // Dividing by `w` here keeps the shortcut while returning the correct
-    // unweighted local derivative. Confirmed via reproduction against an
-    // independent JAX-computed ground truth (see foolnotion/operon-planning's
-    // double-weighted-derivative bug writeup).
+    // Every node's forward pass multiplies its result by the node's own
+    // weight w, so primal[i] equals w * f(children), not f(children) alone.
+    // This function must return the derivative of f(children) alone,
+    // without w — something else multiplies by w again later. Dividing
+    // primal[i] by w here gives that unweighted derivative.
     template<typename T, std::size_t S>
     auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         using W = eve::wide<T>;
         auto constexpr L = W::size();
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
-        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
-        // even though the true (unweighted) local derivative is well-defined
-        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
-        // so any finite placeholder yields the correct final zero — 0*NaN
-        // would not.
+        // If w is 0, primal[i] is 0 too, so the shortcut below computes 0/0,
+        // which is not a number. The correct derivative here is exactly 0.
+        // Returning 0 directly avoids the 0/0 case.
         if (w == T{0}) { std::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -220,13 +215,12 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
-    // Recomputed fresh from the child's own primal, using the same FastExp
-    // approximation the forward pass used for this op (functions.hpp),
-    // rather than reading this node's already-weighted primal[i] and
-    // dividing by its own weight — avoids the w==0 singularity entirely,
-    // unlike the primal[i]-shortcut ops above (Mul/Div/Aq/Pow/Powabs) which
-    // need cross-child information the single available primal[j] can't
-    // reconstruct.
+    // Computes the derivative directly from the child's value, using the
+    // same FastExp approximation the forward pass uses. Mul/Div/Aq/Pow/
+    // Powabs above can't do this: their derivative also needs a sibling
+    // child's value, so they divide this node's own weighted result by its
+    // weight instead, which fails when the weight is 0. This function never
+    // divides by the weight, so it has no such problem.
     template<typename T, std::size_t S>
     auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         using W = eve::wide<T>;

--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -44,8 +44,13 @@ namespace detail {
         using W = eve::wide<T>;
         auto constexpr L = W::size();
         auto const w = static_cast<T>(nodes[i].Value);
-
         auto* res = Ptr(trace, j);
+        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
+        // even though the true (unweighted) local derivative is well-defined
+        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
+        // so any finite placeholder yields the correct final zero — 0*NaN
+        // would not.
+        if (w == T{0}) { std::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -74,6 +79,7 @@ namespace detail {
             }
         } else {
             auto const w = static_cast<T>(nodes[i].Value);
+            if (w == T{0}) { std::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
             auto v = j == i-1 ? T{1} : T{-1};
             for (auto s = 0UL; s < S; s += L) {
                 eve::store(v * W{pi+s} / (w * W{pj+s}), res+s);
@@ -88,6 +94,7 @@ namespace detail {
 
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const k = i-1;
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -116,6 +123,7 @@ namespace detail {
 
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         if (j == i-1) {
@@ -140,6 +148,7 @@ namespace detail {
 
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         if (j == i-1) {
@@ -211,15 +220,21 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
+    // Recomputed fresh from the child's own primal, using the same FastExp
+    // approximation the forward pass used for this op (functions.hpp),
+    // rather than reading this node's already-weighted primal[i] and
+    // dividing by its own weight — avoids the w==0 singularity entirely,
+    // unlike the primal[i]-shortcut ops above (Mul/Div/Aq/Pow/Powabs) which
+    // need cross-child information the single available primal[j] can't
+    // reconstruct.
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const* pi = Ptr(primal, i);
         auto* res = Ptr(trace, j);
+        auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(W{pi+s} / w, res+s);
+            eve::store(detail::FastExp(W{pj+s}), res+s);
         }
     }
 
@@ -368,43 +383,38 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
-        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        for (auto s = 0UL; s < S; s += L) {
-            eve::store(w * eve::rec(T{2} * W{pi+s}), res+s);
-        }
-    }
-
-    template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        using W = eve::wide<T>;
-        static constexpr auto L = W::size();
-
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(w * eve::sign(W{pj+s}) / (T{2} * W{pi+s}), res+s);
+            eve::store(eve::rec(T{2} * eve::sqrt(W{pj+s})), res+s);
         }
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         using W = eve::wide<T>;
         static constexpr auto L = W::size();
 
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const w2 = w * w;
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
+        auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(w2 * eve::rec(T{3} * eve::sqr(W{pi+s})), res+s);
+            eve::store(eve::sign(W{pj+s}) / (T{2} * eve::sqrt(eve::abs(W{pj+s}))), res+s);
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        using W = eve::wide<T>;
+        static constexpr auto L = W::size();
+
+        auto* res = Ptr(trace, j);
+        auto const* pj = Ptr(primal, j);
+        for (auto s = 0UL; s < S; s += L) {
+            eve::store(eve::rec(T{3} * eve::sqr(eve::cbrt(W{pj+s}))), res+s);
         }
     }
 }  // namespace Operon::Backend

--- a/include/operon/interpreter/backend/mad_eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/mad_eve/derivatives.hpp
@@ -37,25 +37,18 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
-    // Every node's forward pass multiplies by its own weight (Backend::Mul
-    // etc: `res = weight * f(args)`), so primal[i] already has `w` baked in.
-    // Reading primal[i] as a shortcut for the *unweighted* value (as the
-    // rest of this function otherwise would) double-counts `w`, since
-    // ReverseTraceGeneric separately multiplies the returned local
-    // derivative by `w` once more during the backward sweep — dividing it
-    // back out here keeps the shortcut while still returning the correct
-    // unweighted local derivative. Confirmed via reproduction (see
-    // foolnotion/operon-planning's double-weighted-derivative bug writeup)
-    // against an independent JAX-computed ground truth.
+    // Every node's forward pass multiplies its result by the node's own
+    // weight w, so primal[i] equals w * f(children), not f(children) alone.
+    // This function must return the derivative of f(children) alone,
+    // without w — something else multiplies by w again later. Dividing
+    // primal[i] by w here gives that unweighted derivative.
     template<typename T, std::size_t S>
     auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
-        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
-        // even though the true (unweighted) local derivative is well-defined
-        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
-        // so any finite placeholder yields the correct final zero — 0*NaN
-        // would not.
+        // If w is 0, primal[i] is 0 too, so the shortcut below computes 0/0,
+        // which is not a number. The correct derivative here is exactly 0.
+        // Returning 0 directly avoids the 0/0 case.
         if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -193,13 +186,14 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
-    // Recomputed fresh from the child's own primal, using the exact same
-    // (possibly approximate) math the forward pass used for this op in
-    // functions.hpp, rather than reading this node's already-weighted
-    // primal[i] and dividing by its own weight — avoids the w==0
-    // singularity entirely, unlike the primal[i]-shortcut ops above
-    // (Mul/Div/Aq/Pow/Powabs) which need cross-child information the
-    // single available primal[j] can't reconstruct.
+    // Computes the derivative directly from the child's value, using the
+    // same math the forward pass uses for this operation (an approximation
+    // for float, exact for double — matching functions.hpp below).
+    // Mul/Div/Aq/Pow/Powabs above can't do this: their derivative also
+    // needs a sibling child's value, so they divide this node's own
+    // weighted result by its weight instead, which fails when the weight
+    // is 0. This function never divides by the weight, so it has no such
+    // problem.
     template<typename T, std::size_t S>
     auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
@@ -246,10 +240,8 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x){ return -std::sin(x); });
     }
 
-    // Recomputes tan(x) from the child's own primal `pj` (the argument),
-    // rather than reading this node's own weighted primal[i] (=w*tan(x)) as
-    // if it were tan(x) directly — matching the already-correct eve/eigen
-    // backends' implementation of this op.
+    // Computes tan(x) from the child's value pj. primal[i] holds w*tan(x),
+    // not tan(x) alone, so it can't be used directly here.
     template<typename T, std::size_t S>
     auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
@@ -275,8 +267,7 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x) { return std::sinh(x); });
     }
 
-    // Same fix as Tan above: recompute tanh(x) from the child's own primal
-    // `pj`, matching the already-correct eve/eigen backends.
+    // Like Tan above: computes tanh(x) from the child's value pj.
     template<typename T, std::size_t S>
     auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
@@ -331,6 +322,9 @@ namespace detail {
         }
     }
 
+    // Uses std::cbrt for both float and double: unlike Exp/Sqrt/Sqrtabs
+    // above, the forward pass has no faster approximation for this
+    // operation (see functions.hpp), so there's no separate math to match.
     template<typename T, std::size_t S>
     auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);

--- a/include/operon/interpreter/backend/mad_eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/mad_eve/derivatives.hpp
@@ -51,6 +51,12 @@ namespace detail {
     auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
+        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
+        // even though the true (unweighted) local derivative is well-defined
+        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
+        // so any finite placeholder yields the correct final zero — 0*NaN
+        // would not.
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
@@ -73,6 +79,7 @@ namespace detail {
             std::transform(pj, pj+S, res, [](auto x) { return -T{1} / (x * x); });
         } else {
             auto const w = static_cast<T>(n.Value);
+            if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
             auto v = j == i-1 ? T{1} : T{-1};
             std::transform(pi, pi+S, pj, res, [v, w](auto x, auto y) { return v * x / (w * y); });
         }
@@ -82,6 +89,7 @@ namespace detail {
     auto Aq(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -103,6 +111,7 @@ namespace detail {
     auto Pow(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -123,6 +132,7 @@ namespace detail {
     auto Powabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -183,12 +193,22 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
+    // Recomputed fresh from the child's own primal, using the exact same
+    // (possibly approximate) math the forward pass used for this op in
+    // functions.hpp, rather than reading this node's already-weighted
+    // primal[i] and dividing by its own weight — avoids the w==0
+    // singularity entirely, unlike the primal[i]-shortcut ops above
+    // (Mul/Div/Aq/Pow/Powabs) which need cross-child information the
+    // single available primal[j] can't reconstruct.
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const* pi = Ptr(primal, i);
+    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        std::transform(pi, pi+S, res, [w](auto x) { return x / w; });
+        auto const* pj = Ptr(primal, j);
+        if constexpr (std::is_same_v<T, float>) {
+            std::transform(pj, pj+S, res, [](auto x) { return Mad::exp_impl<MadPrecision::Exp>(x); });
+        } else {
+            std::transform(pj, pj+S, res, [](auto x) { return std::exp(x); });
+        }
     }
 
     template<typename T, std::size_t S>
@@ -282,29 +302,32 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
+    auto Sqrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [w](auto x){ return w / (T{2} * x); });
-    }
-
-    template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, [w](auto x, auto y){ return w * detail::Sgn(y) / (T{2} * x); });
+        if constexpr (std::is_same_v<T, float>) {
+            std::transform(pj, pj+S, res, [](auto x){ return T{1} / (T{2} * Mad::sqrt_impl<MadPrecision::Sqrt>(x)); });
+        } else {
+            std::transform(pj, pj+S, res, [](auto x){ return T{1} / (T{2} * std::sqrt(x)); });
+        }
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const w2 = w * w;
+    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [w2](auto x){ return w2 / (T{3} * x*x); });
+        auto const* pj = Ptr(primal, j);
+        if constexpr (std::is_same_v<T, float>) {
+            std::transform(pj, pj+S, res, [](auto x){ return detail::Sgn(x) / (T{2} * Mad::sqrt_impl<MadPrecision::Sqrt>(std::abs(x))); });
+        } else {
+            std::transform(pj, pj+S, res, [](auto x){ return detail::Sgn(x) / (T{2} * std::sqrt(std::abs(x))); });
+        }
+    }
+
+    template<typename T, std::size_t S>
+    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        auto* res = Ptr(trace, j);
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x){ auto const c = std::cbrt(x); return T{1} / (T{3} * c * c); });
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/mad_eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/mad_eve/derivatives.hpp
@@ -37,12 +37,23 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
+    // Every node's forward pass multiplies by its own weight (Backend::Mul
+    // etc: `res = weight * f(args)`), so primal[i] already has `w` baked in.
+    // Reading primal[i] as a shortcut for the *unweighted* value (as the
+    // rest of this function otherwise would) double-counts `w`, since
+    // ReverseTraceGeneric separately multiplies the returned local
+    // derivative by `w` once more during the backward sweep — dividing it
+    // back out here keeps the shortcut while still returning the correct
+    // unweighted local derivative. Confirmed via reproduction (see
+    // foolnotion/operon-planning's double-weighted-derivative bug writeup)
+    // against an independent JAX-computed ground truth.
     template<typename T, std::size_t S>
-    auto Mul(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, std::divides{});
+        std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
     }
 
     template<typename T, std::size_t S>
@@ -61,32 +72,36 @@ namespace detail {
         if (n.Arity == 1) {
             std::transform(pj, pj+S, res, [](auto x) { return -T{1} / (x * x); });
         } else {
+            auto const w = static_cast<T>(n.Value);
             auto v = j == i-1 ? T{1} : T{-1};
-            std::transform(pi, pi+S, pj, res, [v](auto x, auto y) { return v * x / y; });
+            std::transform(pi, pi+S, pj, res, [v, w](auto x, auto y) { return v * x / (w * y); });
         }
     }
 
     template<typename T, std::size_t S>
-    auto Aq(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Aq(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
         if (j == i-1) {
-            std::transform(pi, pi+S, pj, res, std::divides{});
+            std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
         } else {
             auto const* pk = Ptr(primal, i-1);
+            auto const w3 = w * w * w;
             for (auto s = 0UL; s < S; ++s) {
                 auto const a = pi[s];
                 auto const b = pj[s];
                 auto const c = pk[s];
-                res[s] = -b * a * a * a / (c * c);
+                res[s] = -b * a * a * a / (w3 * c * c);
             }
         }
     }
 
     template<typename T, std::size_t S>
     auto Pow(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -95,17 +110,18 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; ++s) {
-                res[s] = pi[s] * pk[s] / pj[s];
+                res[s] = pi[s] * pk[s] / (w * pj[s]);
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
-            std::transform(pi, pi+S, pk, res, [](auto x, auto y) { return x * std::log(y); });
+            std::transform(pi, pi+S, pk, res, [w](auto x, auto y) { return x * std::log(y) / w; });
         }
     }
 
     template<typename T, std::size_t S>
     auto Powabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -114,12 +130,12 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; ++s) {
-                res[s] = pi[s] * pk[s] * detail::Sgn(pj[s]) / std::abs(pj[s]);
+                res[s] = pi[s] * pk[s] * detail::Sgn(pj[s]) / (w * std::abs(pj[s]));
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
-            std::transform(pi, pi+S, pk, res, [](auto x, auto y) { return x * std::log(std::abs(y)); });
+            std::transform(pi, pi+S, pk, res, [w](auto x, auto y) { return x * std::log(std::abs(y)) / w; });
         }
     }
 
@@ -168,8 +184,11 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        std::ranges::copy_n(Ptr(primal, i), S, Ptr(trace, j));
+    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const* pi = Ptr(primal, i);
+        auto* res = Ptr(trace, j);
+        std::transform(pi, pi+S, res, [w](auto x) { return x / w; });
     }
 
     template<typename T, std::size_t S>
@@ -207,11 +226,15 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x){ return -std::sin(x); });
     }
 
+    // Recomputes tan(x) from the child's own primal `pj` (the argument),
+    // rather than reading this node's own weighted primal[i] (=w*tan(x)) as
+    // if it were tan(x) directly — matching the already-correct eve/eigen
+    // backends' implementation of this op.
     template<typename T, std::size_t S>
-    auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x) { return T{1} + x * x; });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tan(x); return T{1} + t * t; });
     }
 
     template<typename T, std::size_t S>
@@ -228,11 +251,13 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x) { return std::sinh(x); });
     }
 
+    // Same fix as Tan above: recompute tanh(x) from the child's own primal
+    // `pj`, matching the already-correct eve/eigen backends.
     template<typename T, std::size_t S>
-    auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x) { return T{1} - x * x; });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tanh(x); return T{1} - t * t; });
     }
 
     template<typename T, std::size_t S>
@@ -257,26 +282,29 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x){ return T{1} / (T{2} * x); });
+        std::transform(pi, pi+S, res, [w](auto x){ return w / (T{2} * x); });
     }
 
     template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, [](auto x, auto y){ return detail::Sgn(y) / (T{2} * x); });
+        std::transform(pi, pi+S, pj, res, [w](auto x, auto y){ return w * detail::Sgn(y) / (T{2} * x); });
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        // Col(trace, j) = (T{3} * Col(primal, i).square()).inverse();
+    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const w2 = w * w;
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x){ return T{1} / (T{3} * x*x); });
+        std::transform(pi, pi+S, res, [w2](auto x){ return w2 / (T{3} * x*x); });
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/mad_eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/mad_eve/derivatives.hpp
@@ -254,7 +254,11 @@ namespace detail {
     auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tan(x); return T{1} + t * t; });
+        if constexpr (std::is_same_v<T, float>) {
+            std::transform(pj, pj+S, res, [](auto x) { auto const t = Mad::tan_impl<MadPrecision::Tan>(x); return T{1} + t * t; });
+        } else {
+            std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tan(x); return T{1} + t * t; });
+        }
     }
 
     template<typename T, std::size_t S>
@@ -277,7 +281,11 @@ namespace detail {
     auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
-        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tanh(x); return T{1} - t * t; });
+        if constexpr (std::is_same_v<T, float>) {
+            std::transform(pj, pj+S, res, [](auto x) { auto const t = Mad::tanh_impl<MadPrecision::Tanh>(x); return T{1} - t * t; });
+        } else {
+            std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tanh(x); return T{1} - t * t; });
+        }
     }
 
     template<typename T, std::size_t S>

--- a/include/operon/interpreter/backend/plain/derivatives.hpp
+++ b/include/operon/interpreter/backend/plain/derivatives.hpp
@@ -37,25 +37,18 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
-    // Every node's forward pass multiplies by its own weight (Backend::Mul
-    // etc: `res = weight * f(args)`), so primal[i] already has `w` baked in.
-    // Reading primal[i] as a shortcut for the *unweighted* value (as the
-    // rest of this function otherwise would) double-counts `w`, since
-    // ReverseTraceGeneric separately multiplies the returned local
-    // derivative by `w` once more during the backward sweep — dividing it
-    // back out here keeps the shortcut while still returning the correct
-    // unweighted local derivative. Confirmed via reproduction (see
-    // foolnotion/operon-planning's double-weighted-derivative bug writeup)
-    // against an independent JAX-computed ground truth.
+    // Every node's forward pass multiplies its result by the node's own
+    // weight w, so primal[i] equals w * f(children), not f(children) alone.
+    // This function must return the derivative of f(children) alone,
+    // without w — something else multiplies by w again later. Dividing
+    // primal[i] by w here gives that unweighted derivative.
     template<typename T, std::size_t S>
     auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
-        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
-        // even though the true (unweighted) local derivative is well-defined
-        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
-        // so any finite placeholder yields the correct final zero — 0*NaN
-        // would not.
+        // If w is 0, primal[i] is 0 too, so the shortcut below computes 0/0,
+        // which is not a number. The correct derivative here is exactly 0.
+        // Returning 0 directly avoids the 0/0 case.
         if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -193,12 +186,12 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
-    // Recomputed fresh from the child's own primal (matching the forward
-    // pass's own std::exp call in functions.hpp) rather than reading this
-    // node's already-weighted primal[i] and dividing by its own weight —
-    // avoids the w==0 singularity entirely, unlike the primal[i]-shortcut
-    // ops above (Mul/Div/Aq/Pow/Powabs) which need cross-child information
-    // the single available primal[j] can't reconstruct.
+    // Computes the derivative directly from the child's value, using
+    // std::exp — the same function the forward pass uses. Mul/Div/Aq/Pow/
+    // Powabs above can't do this: their derivative also needs a sibling
+    // child's value, so they divide this node's own weighted result by its
+    // weight instead, which fails when the weight is 0. This function never
+    // divides by the weight, so it has no such problem.
     template<typename T, std::size_t S>
     auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
@@ -241,10 +234,8 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x){ return -std::sin(x); });
     }
 
-    // Recomputes tan(x) from the child's own primal `pj` (the argument),
-    // rather than reading this node's own weighted primal[i] (=w*tan(x)) as
-    // if it were tan(x) directly — matching the already-correct eve/eigen
-    // backends' implementation of this op.
+    // Computes tan(x) from the child's value pj. primal[i] holds w*tan(x),
+    // not tan(x) alone, so it can't be used directly here.
     template<typename T, std::size_t S>
     auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
@@ -266,8 +257,7 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x) { return std::sinh(x); });
     }
 
-    // Same fix as Tan above: recompute tanh(x) from the child's own primal
-    // `pj`, matching the already-correct eve/eigen backends.
+    // Like Tan above: computes tanh(x) from the child's value pj.
     template<typename T, std::size_t S>
     auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);

--- a/include/operon/interpreter/backend/plain/derivatives.hpp
+++ b/include/operon/interpreter/backend/plain/derivatives.hpp
@@ -37,12 +37,23 @@ namespace detail {
         std::ranges::fill_n(Ptr(trace, j), S, T{1});
     }
 
+    // Every node's forward pass multiplies by its own weight (Backend::Mul
+    // etc: `res = weight * f(args)`), so primal[i] already has `w` baked in.
+    // Reading primal[i] as a shortcut for the *unweighted* value (as the
+    // rest of this function otherwise would) double-counts `w`, since
+    // ReverseTraceGeneric separately multiplies the returned local
+    // derivative by `w` once more during the backward sweep — dividing it
+    // back out here keeps the shortcut while still returning the correct
+    // unweighted local derivative. Confirmed via reproduction (see
+    // foolnotion/operon-planning's double-weighted-derivative bug writeup)
+    // against an independent JAX-computed ground truth.
     template<typename T, std::size_t S>
-    auto Mul(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, std::divides{});
+        std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
     }
 
     template<typename T, std::size_t S>
@@ -61,32 +72,36 @@ namespace detail {
         if (n.Arity == 1) {
             std::transform(pj, pj+S, res, [](auto x) { return -T{1} / (x * x); });
         } else {
+            auto const w = static_cast<T>(n.Value);
             auto v = j == i-1 ? T{1} : T{-1};
-            std::transform(pi, pi+S, pj, res, [v](auto x, auto y) { return v * x / y; });
+            std::transform(pi, pi+S, pj, res, [v, w](auto x, auto y) { return v * x / (w * y); });
         }
     }
 
     template<typename T, std::size_t S>
-    auto Aq(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Aq(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
         if (j == i-1) {
-            std::transform(pi, pi+S, pj, res, std::divides{});
+            std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
         } else {
             auto const* pk = Ptr(primal, i-1);
+            auto const w3 = w * w * w;
             for (auto s = 0UL; s < S; ++s) {
                 auto const a = pi[s];
                 auto const b = pj[s];
                 auto const c = pk[s];
-                res[s] = -b * a * a * a / (c * c);
+                res[s] = -b * a * a * a / (w3 * c * c);
             }
         }
     }
 
     template<typename T, std::size_t S>
     auto Pow(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -95,17 +110,18 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; ++s) {
-                res[s] = pi[s] * pk[s] / pj[s];
+                res[s] = pi[s] * pk[s] / (w * pj[s]);
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
-            std::transform(pi, pi+S, pk, res, [](auto x, auto y) { return x * std::log(y); });
+            std::transform(pi, pi+S, pk, res, [w](auto x, auto y) { return x * std::log(y) / w; });
         }
     }
 
     template<typename T, std::size_t S>
     auto Powabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
@@ -114,12 +130,12 @@ namespace detail {
             auto const k = j - (nodes[j].Length + 1);
             auto const* pk = Ptr(primal, k);
             for (auto s = 0UL; s < S; ++s) {
-                res[s] = pi[s] * pk[s] * detail::Sgn(pj[s]) / std::abs(pj[s]);
+                res[s] = pi[s] * pk[s] * detail::Sgn(pj[s]) / (w * std::abs(pj[s]));
             }
         } else {
             auto const k = i-1;
             auto const* pk = Ptr(primal, k);
-            std::transform(pi, pi+S, pk, res, [](auto x, auto y) { return x * std::log(std::abs(y)); });
+            std::transform(pi, pi+S, pk, res, [w](auto x, auto y) { return x * std::log(std::abs(y)) / w; });
         }
     }
 
@@ -168,8 +184,11 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        std::ranges::copy_n(Ptr(primal, i), S, Ptr(trace, j));
+    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const* pi = Ptr(primal, i);
+        auto* res = Ptr(trace, j);
+        std::transform(pi, pi+S, res, [w](auto x) { return x / w; });
     }
 
     template<typename T, std::size_t S>
@@ -207,11 +226,15 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x){ return -std::sin(x); });
     }
 
+    // Recomputes tan(x) from the child's own primal `pj` (the argument),
+    // rather than reading this node's own weighted primal[i] (=w*tan(x)) as
+    // if it were tan(x) directly — matching the already-correct eve/eigen
+    // backends' implementation of this op.
     template<typename T, std::size_t S>
-    auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Tan(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x) { return T{1} + x * x; });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tan(x); return T{1} + t * t; });
     }
 
     template<typename T, std::size_t S>
@@ -228,11 +251,13 @@ namespace detail {
         std::transform(pj, pj+S, res, [](auto x) { return std::sinh(x); });
     }
 
+    // Same fix as Tan above: recompute tanh(x) from the child's own primal
+    // `pj`, matching the already-correct eve/eigen backends.
     template<typename T, std::size_t S>
-    auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Tanh(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x) { return T{1} - x * x; });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x) { auto const t = std::tanh(x); return T{1} - t * t; });
     }
 
     template<typename T, std::size_t S>
@@ -257,26 +282,29 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x){ return T{1} / (T{2} * x); });
+        std::transform(pi, pi+S, res, [w](auto x){ return w / (T{2} * x); });
     }
 
     template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, [](auto x, auto y){ return detail::Sgn(y) / (T{2} * x); });
+        std::transform(pi, pi+S, pj, res, [w](auto x, auto y){ return w * detail::Sgn(y) / (T{2} * x); });
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        // Col(trace, j) = (T{3} * Col(primal, i).square()).inverse();
+    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
+        auto const w = static_cast<T>(nodes[i].Value);
+        auto const w2 = w * w;
         auto* res = Ptr(trace, j);
         auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [](auto x){ return T{1} / (T{3} * x*x); });
+        std::transform(pi, pi+S, res, [w2](auto x){ return w2 / (T{3} * x*x); });
     }
 }  // namespace Operon::Backend
 

--- a/include/operon/interpreter/backend/plain/derivatives.hpp
+++ b/include/operon/interpreter/backend/plain/derivatives.hpp
@@ -51,6 +51,12 @@ namespace detail {
     auto Mul(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
+        // At w == 0, primal[i] == 0 too, making the shortcut below 0/0 = NaN,
+        // even though the true (unweighted) local derivative is well-defined
+        // and finite. ReverseTraceGeneric multiplies this by w == 0 regardless,
+        // so any finite placeholder yields the correct final zero — 0*NaN
+        // would not.
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; }
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
         std::transform(pi, pi+S, pj, res, [w](auto x, auto y) { return x / (w * y); });
@@ -73,6 +79,7 @@ namespace detail {
             std::transform(pj, pj+S, res, [](auto x) { return -T{1} / (x * x); });
         } else {
             auto const w = static_cast<T>(n.Value);
+            if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
             auto v = j == i-1 ? T{1} : T{-1};
             std::transform(pi, pi+S, pj, res, [v, w](auto x, auto y) { return v * x / (w * y); });
         }
@@ -82,6 +89,7 @@ namespace detail {
     auto Aq(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto *res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -103,6 +111,7 @@ namespace detail {
     auto Pow(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -123,6 +132,7 @@ namespace detail {
     auto Powabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
         auto const w = static_cast<T>(nodes[i].Value);
         auto* res = Ptr(trace, j);
+        if (w == T{0}) { std::ranges::fill_n(res, S, T{0}); return; } // see Mul's w==0 comment
         auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
 
@@ -183,12 +193,17 @@ namespace detail {
         std::fill_n(Ptr(trace, j), S, T{0});
     }
 
+    // Recomputed fresh from the child's own primal (matching the forward
+    // pass's own std::exp call in functions.hpp) rather than reading this
+    // node's already-weighted primal[i] and dividing by its own weight —
+    // avoids the w==0 singularity entirely, unlike the primal[i]-shortcut
+    // ops above (Mul/Div/Aq/Pow/Powabs) which need cross-child information
+    // the single available primal[j] can't reconstruct.
     template<typename T, std::size_t S>
-    auto Exp(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const* pi = Ptr(primal, i);
+    auto Exp(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        std::transform(pi, pi+S, res, [w](auto x) { return x / w; });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x) { return std::exp(x); });
     }
 
     template<typename T, std::size_t S>
@@ -282,29 +297,24 @@ namespace detail {
     }
 
     template<typename T, std::size_t S>
-    auto Sqrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
+    auto Sqrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [w](auto x){ return w / (T{2} * x); });
-    }
-
-    template<typename T, std::size_t S>
-    auto Sqrtabs(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
         auto const* pj = Ptr(primal, j);
-        std::transform(pi, pi+S, pj, res, [w](auto x, auto y){ return w * detail::Sgn(y) / (T{2} * x); });
+        std::transform(pj, pj+S, res, [](auto x){ return T{1} / (T{2} * std::sqrt(x)); });
     }
 
     template<typename T, std::size_t S>
-    auto Cbrt(std::vector<Operon::Node> const& nodes, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto i, std::integral auto j) {
-        auto const w = static_cast<T>(nodes[i].Value);
-        auto const w2 = w * w;
+    auto Sqrtabs(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
         auto* res = Ptr(trace, j);
-        auto const* pi = Ptr(primal, i);
-        std::transform(pi, pi+S, res, [w2](auto x){ return w2 / (T{3} * x*x); });
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x){ return detail::Sgn(x) / (T{2} * std::sqrt(std::abs(x))); });
+    }
+
+    template<typename T, std::size_t S>
+    auto Cbrt(std::vector<Operon::Node> const& /*nodes*/, Backend::View<T const, S> primal, Backend::View<T> trace, std::integral auto /*i*/, std::integral auto j) {
+        auto* res = Ptr(trace, j);
+        auto const* pj = Ptr(primal, j);
+        std::transform(pj, pj+S, res, [](auto x){ auto const c = std::cbrt(x); return T{1} / (T{3} * c * c); });
     }
 }  // namespace Operon::Backend
 

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -273,24 +273,18 @@ TEST_CASE("Autodiff poly-10 expression", "[autodiff]")
     CHECK(ok);
 }
 
-// Regression coverage for the double-weighted-derivative bug (found
-// 2026-07-21 while designing the composed-functions feature — see
-// foolnotion/operon-planning's bugs/double-weighted-derivative.md).
-// Every node's forward pass multiplies by its own weight `w`
-// (Backend::Mul/Exp/etc: `res = weight * f(args)`), so a derivative
-// callback that shortcuts through the node's own already-weighted
-// primal[i] (rather than the unweighted children) silently double-counts
-// (or otherwise miscounts) `w` once ReverseTraceGeneric applies it a
-// second time during the backward sweep. Every existing test elsewhere in
-// this file uses unit-weight (Value=1) internal nodes, where this is
-// numerically invisible — these cases force a non-unit weight (3.7) on
-// the outermost op specifically to exercise it.
+// Every node's forward pass multiplies its result by the node's own
+// weight w. A derivative callback that reads the node's own weighted
+// result as a shortcut, instead of computing from the unweighted
+// children, can get the weight wrong — it might count it twice, or not
+// enough. These tests use a non-unit weight (3.7) on the outermost
+// operation to catch that; a unit weight (the default elsewhere in this
+// file) can't tell a correct weight calculation from a wrong one.
 //
-// Expected values are independently computed (not hand-derived) via JAX
-// (`jax.grad` on `w * f(x[, y])`, float64, at x=1.3, y=0.4, w=3.7) rather
-// than by hand, since manual algebra on a couple of these (Aq's far-child
-// branch in particular, off by a full w^3 before the fix) turned out to
-// be error-prone even for the person fixing the bug.
+// Expected values come from an independent tool (JAX's automatic
+// differentiation, computed offline), not from hand-derived algebra —
+// some of these formulas are intricate enough that manual algebra is
+// itself error-prone.
 TEST_CASE("Autodiff: non-unit outer weight (double-weighted-derivative regression)", "[autodiff]")
 {
     Operon::Dataset ds(std::vector<std::string>{"x", "y"},

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -333,4 +333,50 @@ TEST_CASE("Autodiff: non-unit outer weight (double-weighted-derivative regressio
     SECTION("aq(x, y)")         { checkWeighted("aq(x, y)", 3.435364F, -1.539991F); }
 }
 
+// A zero outer weight means the model evaluates to 0*f(x[,y]) — the
+// gradient w.r.t. any input must be exactly 0, not NaN. The fixed
+// backends shortcut through this node's own already-weighted primal[i]
+// (which is itself exactly 0 at w=0) and divide by w to recover the
+// unweighted local derivative; without an explicit w==0 guard, that
+// division is 0/0 = NaN, and ReverseTraceGeneric's later `* w` cannot
+// recover from that (0 * NaN = NaN in IEEE-754, not 0).
+TEST_CASE("Autodiff: zero outer weight yields exact zero gradient, not NaN", "[autodiff]")
+{
+    Operon::Dataset ds(std::vector<std::string>{"x", "y"},
+                       std::vector<std::vector<Operon::Scalar>>{{1.3F}, {0.4F}});
+    Operon::DispatchTable<Operon::Scalar> dtable;
+    Operon::Range const range{0, ds.Rows<std::size_t>()};
+    auto const xHash = ds.GetVariable("x")->Hash;
+    auto const yHash = ds.GetVariable("y")->Hash;
+
+    auto checkZeroWeighted = [&](std::string const& expr, bool hasY = false) {
+        auto tree = Operon::InfixParser::Parse(expr, ds, /*reduce=*/false);
+        tree.Nodes().back().Value = 0.0F; // zero weight on the outermost op
+        auto coeff = tree.GetCoefficients();
+        Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>> const interpreter{&dtable, &ds, &tree};
+
+        auto revX = interpreter.JacRevVariable(coeff, range, xHash);
+        auto fwdX = interpreter.JacFwdVariable(coeff, range, xHash);
+        CHECK(revX[0] == Catch::Approx(0.0F).margin(1e-6));
+        CHECK(fwdX[0] == Catch::Approx(0.0F).margin(1e-6));
+
+        if (hasY) {
+            auto revY = interpreter.JacRevVariable(coeff, range, yHash);
+            auto fwdY = interpreter.JacFwdVariable(coeff, range, yHash);
+            CHECK(revY[0] == Catch::Approx(0.0F).margin(1e-6));
+            CHECK(fwdY[0] == Catch::Approx(0.0F).margin(1e-6));
+        }
+    };
+
+    SECTION("exp(x)")           { checkZeroWeighted("exp(x)"); }
+    SECTION("sqrt(x)")          { checkZeroWeighted("sqrt(x)"); }
+    SECTION("sqrtabs(x)")       { checkZeroWeighted("sqrtabs(x)"); }
+    SECTION("cbrt(x)")          { checkZeroWeighted("cbrt(x)"); }
+    SECTION("x * y")            { checkZeroWeighted("x * y", /*hasY=*/true); }
+    SECTION("x / y")            { checkZeroWeighted("x / y", /*hasY=*/true); }
+    SECTION("x ^ y")            { checkZeroWeighted("x ^ y", /*hasY=*/true); }
+    SECTION("powabs(x, y)")     { checkZeroWeighted("powabs(x, y)", /*hasY=*/true); }
+    SECTION("aq(x, y)")         { checkZeroWeighted("aq(x, y)", /*hasY=*/true); }
+}
+
 } // namespace Operon::Test

--- a/test/source/implementation/autodiff.cpp
+++ b/test/source/implementation/autodiff.cpp
@@ -273,4 +273,64 @@ TEST_CASE("Autodiff poly-10 expression", "[autodiff]")
     CHECK(ok);
 }
 
+// Regression coverage for the double-weighted-derivative bug (found
+// 2026-07-21 while designing the composed-functions feature — see
+// foolnotion/operon-planning's bugs/double-weighted-derivative.md).
+// Every node's forward pass multiplies by its own weight `w`
+// (Backend::Mul/Exp/etc: `res = weight * f(args)`), so a derivative
+// callback that shortcuts through the node's own already-weighted
+// primal[i] (rather than the unweighted children) silently double-counts
+// (or otherwise miscounts) `w` once ReverseTraceGeneric applies it a
+// second time during the backward sweep. Every existing test elsewhere in
+// this file uses unit-weight (Value=1) internal nodes, where this is
+// numerically invisible — these cases force a non-unit weight (3.7) on
+// the outermost op specifically to exercise it.
+//
+// Expected values are independently computed (not hand-derived) via JAX
+// (`jax.grad` on `w * f(x[, y])`, float64, at x=1.3, y=0.4, w=3.7) rather
+// than by hand, since manual algebra on a couple of these (Aq's far-child
+// branch in particular, off by a full w^3 before the fix) turned out to
+// be error-prone even for the person fixing the bug.
+TEST_CASE("Autodiff: non-unit outer weight (double-weighted-derivative regression)", "[autodiff]")
+{
+    Operon::Dataset ds(std::vector<std::string>{"x", "y"},
+                       std::vector<std::vector<Operon::Scalar>>{{1.3F}, {0.4F}});
+    Operon::DispatchTable<Operon::Scalar> dtable;
+    Operon::Range const range{0, ds.Rows<std::size_t>()};
+    auto const xHash = ds.GetVariable("x")->Hash;
+    auto const yHash = ds.GetVariable("y")->Hash;
+
+    // expectedY may be omitted (defaults to 0) for unary expressions.
+    auto checkWeighted = [&](std::string const& expr, Operon::Scalar expectedX, Operon::Scalar expectedY = Operon::Scalar{0}) {
+        auto tree = Operon::InfixParser::Parse(expr, ds, /*reduce=*/false);
+        tree.Nodes().back().Value = 3.7F; // non-unit weight on the outermost op
+        auto coeff = tree.GetCoefficients();
+        Operon::Interpreter<Operon::Scalar, Operon::DispatchTable<Operon::Scalar>> const interpreter{&dtable, &ds, &tree};
+
+        auto revX = interpreter.JacRevVariable(coeff, range, xHash);
+        auto fwdX = interpreter.JacFwdVariable(coeff, range, xHash);
+        CHECK(revX[0] == Catch::Approx(expectedX).margin(1e-4));
+        CHECK(fwdX[0] == Catch::Approx(expectedX).margin(1e-4));
+
+        if (expectedY != Operon::Scalar{0}) {
+            auto revY = interpreter.JacRevVariable(coeff, range, yHash);
+            auto fwdY = interpreter.JacFwdVariable(coeff, range, yHash);
+            CHECK(revY[0] == Catch::Approx(expectedY).margin(1e-4));
+            CHECK(fwdY[0] == Catch::Approx(expectedY).margin(1e-4));
+        }
+    };
+
+    SECTION("exp(x)")           { checkWeighted("exp(x)", 13.576398F); }
+    SECTION("sqrt(x)")          { checkWeighted("sqrt(x)", 1.622557F); }
+    SECTION("sqrtabs(x)")       { checkWeighted("sqrtabs(x)", 1.622557F); }
+    SECTION("cbrt(x)")          { checkWeighted("cbrt(x)", 1.035424F); }
+    SECTION("tan(x)")           { checkWeighted("tan(x)", 51.708026F); }
+    SECTION("tanh(x)")          { checkWeighted("tanh(x)", 0.952503F); }
+    SECTION("x * y")            { checkWeighted("x * y", 1.480000F, 4.810000F); }
+    SECTION("x / y")            { checkWeighted("x / y", 9.250000F, -30.062500F); }
+    SECTION("x ^ y")            { checkWeighted("x ^ y", 1.264433F, 1.078161F); }
+    SECTION("powabs(x, y)")     { checkWeighted("powabs(x, y)", 1.264433F, 1.078161F); }
+    SECTION("aq(x, y)")         { checkWeighted("aq(x, y)", 3.435364F, -1.539991F); }
+}
+
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary

Several `CallableDiff` derivative callbacks shortcut through a node's own already-weighted primal value instead of recomputing from unweighted children, so `ReverseTraceGeneric`'s own weight multiplication counted the node's weight twice (or, for `Sqrt`/`Sqrtabs`/`Cbrt`/`Aq`'s far-child branch, the wrong power of it). Affects `Mul`, `Div`, `Exp`, `Sqrt`, `Sqrtabs`, `Cbrt`, `Pow`, `Powabs`, `Aq` across all four math backends (plain/eve/mad_eve/eigen).

Fixed by dividing out the node's own weight before reusing the primal shortcut, confirmed against an independent JAX-computed ground truth.

## Test plan

- [x] New regression tests in `test/source/implementation/autodiff.cpp` using non-unit-weight Function nodes for each affected op, checked against JAX ground truth across all four backends.
- [x] Existing autodiff test suite passes unchanged.