### PR TITLE
Fix symbolic-diff (Deriv()) omitting a Function node's own weight

### DIFF
--- a/include/operon/core/composed_function.hpp
+++ b/include/operon/core/composed_function.hpp
@@ -634,13 +634,9 @@ auto MakeComposedCallableDiff(DTable const& dt, Tree const& body, std::size_t ar
         }
 
         // Reverse pass: seed the body root's trace to 1, walk backward,
-        // consulting each constituent op's own already-registered
-        // CallableDiff for the *unweighted* local derivative (matching the
-        // confirmed-correct Log/Sin convention, never the buggy
-        // Mul/Exp-style shortcut through a node's own weighted primal — see
-        // the double-weighted-derivative bug writeup), then applying that
-        // node's own weight once while propagating, exactly mirroring
-        // Interpreter::ReverseTraceGeneric.
+        // consulting each constituent op's own CallableDiff for the
+        // unweighted local derivative, then applying that node's own weight
+        // once while propagating — mirroring Interpreter::ReverseTraceGeneric.
         Backend::Buffer<T, S> traceBuf(S, nNodes);
         Backend::View<T, S> traceView{traceBuf};
         std::fill_n(traceBuf.data(), static_cast<std::size_t>(S * nNodes), T{0});

--- a/include/operon/core/composed_function.hpp
+++ b/include/operon/core/composed_function.hpp
@@ -424,10 +424,11 @@ namespace detail {
         }
         if (n.IsPow()) {
             // bodyToLive[k] below is the live dag index DiffCopyBody copied
-            // this Pow node's own primal into — mirrors Deriv()'s hardcoded
-            // Pow case in tree_diff.cpp, which uses `i` (the outer Pow
-            // node's own dag index) the same way, for the same k*ln(j)/j and
-            // ln(j) terms.
+            // this Pow node's own primal into — already an unweighted fresh
+            // node (DiffMakeBinary(Pow, ...) from DiffCopyBody), semantically
+            // equivalent to Deriv()'s own hardcoded Pow case in tree_diff.cpp,
+            // which recomputes an unweighted Pow(j, k) fresh from children for
+            // the same k*ln(j)/j and ln(j) terms.
             auto j  = bodyToLive[children[0]];
             auto k2 = bodyToLive[children[1]];
             auto dj = DiffParam(dag, memo, h, bodyNodes, bodyToLive, children[0], targetParam);

--- a/include/operon/core/tree_diff.hpp
+++ b/include/operon/core/tree_diff.hpp
@@ -21,9 +21,12 @@ namespace Operon {
 // Deriv()'s own helpers in tree_diff.cpp thread them, for hash-consing),
 // this node's own dag index `i`, and its argument's dag index `j`, returns
 // the dag index of f'(j) — or Operon::Vector<Node>::size_type(-1)
-// (tree_diff.cpp's `Zero` sentinel) if no derivative is computable. Several
-// rules need `i` (e.g. Exp: f'(j) = exp(j) = the node's own result, at `i`),
-// not just `j`, hence both are threaded through.
+// (tree_diff.cpp's `Zero` sentinel) if no derivative is computable. `i` is
+// threaded through for rules that might need it, but no built-in rule
+// currently does — every one of them builds f'(j) purely from `j` (e.g.
+// Exp registers a fresh MakeUnary(Exp, j), not a reuse of `i`), matching
+// the outer applyWeight() step in Deriv() that supplies this node's own
+// weight exactly once regardless of which rule fired.
 using UnarySymbolicDerivRule = std::function<std::size_t(
     Operon::Vector<Node>& dag,
     Operon::Map<Operon::Hash, std::size_t>& memo,

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -123,22 +123,6 @@ auto AddTerms(Nodes& dag, Memo& memo, Hashes& h,
     return result;
 }
 
-// Some rules below shortcut through node `i`'s own dag value (e.g. Sqrt's
-// derivative reuses `i` = sqrt(j) instead of recomputing it) instead of
-// building the local derivative purely from `j`. Since forward evaluation
-// bakes this node's own weight into `i` (dag[i] = w * op(j)), that shortcut
-// carries `w` along for free — harmless when Deriv() itself never applied
-// `w` (the historical bug), but double-counts it now that Deriv() applies
-// `w` once, uniformly, at every branch's return (see Deriv()'s applyWeight).
-// This unwinds the baked-in weight before such a rule reuses `i`, mirroring
-// the identical fix already applied to CallableDiff's numeric derivatives
-// (dividing the weighted primal shortcut by `w`).
-auto Unweight(Nodes& dag, Memo& memo, Hashes& h, std::size_t i) -> std::size_t {
-    auto const w = dag[i].Value;
-    if (w == Scalar{1}) { return i; }
-    return MakeBinary(dag, memo, h, BuiltinOp::Div, i, GetConst(dag, memo, h, w));
-}
-
 // Registry of symbolic derivative rules for unary functions, keyed by
 // Node::HashValue. A global, function-local-static singleton (mirroring
 // Node::RegisterName/Descriptions() in node.cpp) so BuildJacobianDag/
@@ -185,8 +169,8 @@ void RegisterBuiltinSymbolicDerivs()
         auto& reg = SymbolicDerivRules();
 
         reg.Register(Operon::Hash(BuiltinOp::Exp),
-            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
-                return Unweight(dag, memo, h, i); // d exp(j)/dj = exp(j) = result (unweighted)
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                return MakeUnary(dag, memo, h, BuiltinOp::Exp, j); // d exp(j)/dj = exp(j), recomputed fresh from j
             });
 
         UnarySymbolicDerivRule logRule =
@@ -217,11 +201,11 @@ void RegisterBuiltinSymbolicDerivs()
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Tan),
-            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
-                auto c1  = GetConst(dag, memo, h, Scalar{1});
-                auto iu  = Unweight(dag, memo, h, i);
-                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, iu);
-                return MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqI);
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1   = GetConst(dag, memo, h, Scalar{1});
+                auto tanJ = MakeUnary(dag, memo, h, BuiltinOp::Tan, j); // recomputed fresh from j
+                auto sqJ  = MakeUnary(dag, memo, h, BuiltinOp::Square, tanJ);
+                return MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqJ);
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Acos),
@@ -263,27 +247,34 @@ void RegisterBuiltinSymbolicDerivs()
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Tanh),
-            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
-                auto c1  = GetConst(dag, memo, h, Scalar{1});
-                auto iu  = Unweight(dag, memo, h, i);
-                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, iu);
-                return MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqI);
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1    = GetConst(dag, memo, h, Scalar{1});
+                auto tanhJ = MakeUnary(dag, memo, h, BuiltinOp::Tanh, j); // recomputed fresh from j
+                auto sqJ   = MakeUnary(dag, memo, h, BuiltinOp::Square, tanhJ);
+                return MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqJ);
             });
 
+        // 1/(2*sqrt(j)), not sqrt(j)/(2*j) — the latter is algebraically
+        // equal but introduces a spurious 0/0 at j == 0 that this form
+        // (a true +inf singularity, matching real calculus) does not.
         reg.Register(Operon::Hash(BuiltinOp::Sqrt),
-            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
-                auto c2   = GetConst(dag, memo, h, Scalar{2});
-                auto twoJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
-                auto iu   = Unweight(dag, memo, h, i);
-                return MakeBinary(dag, memo, h, BuiltinOp::Div, iu, twoJ);
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1    = GetConst(dag, memo, h, Scalar{1});
+                auto c2    = GetConst(dag, memo, h, Scalar{2});
+                auto sqrtJ = MakeUnary(dag, memo, h, BuiltinOp::Sqrt, j); // recomputed fresh from j
+                auto denom = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, sqrtJ);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, denom);
             });
 
+        // 1/(3*cbrt(j)^2), same singularity-avoidance reasoning as Sqrt above.
         reg.Register(Operon::Hash(BuiltinOp::Cbrt),
-            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
-                auto c3     = GetConst(dag, memo, h, Scalar{3});
-                auto threeJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, j);
-                auto iu     = Unweight(dag, memo, h, i);
-                return MakeBinary(dag, memo, h, BuiltinOp::Div, iu, threeJ);
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
+                auto c1      = GetConst(dag, memo, h, Scalar{1});
+                auto c3      = GetConst(dag, memo, h, Scalar{3});
+                auto cbrtJ   = MakeUnary(dag, memo, h, BuiltinOp::Cbrt, j); // recomputed fresh from j
+                auto sqCbrtJ = MakeUnary(dag, memo, h, BuiltinOp::Square, cbrtJ);
+                auto denom   = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, sqCbrtJ);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, c1, denom);
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Square),
@@ -344,9 +335,10 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
     auto const w = n.Value;
     auto applyWeight = [&](std::size_t x) -> std::size_t {
         // w == 0 short-circuits to Zero rather than emitting Mul(0, x): d(0*f)/dc
-        // is exactly 0 regardless of x, and x may itself be a rule that divides by
-        // w (see Unweight below) and would otherwise evaluate to 0/0 = NaN, which
-        // Mul(0, NaN) would then propagate as NaN instead of the correct 0.
+        // is exactly 0 regardless of x. Every rule below builds its local
+        // derivative purely from children (never dividing by this node's own
+        // weight), so x is always finite here — this is defense-in-depth, not
+        // a fix for a reachable NaN.
         if (x == Zero || w == Scalar{0}) { return Zero; }
         if (w == Scalar{1}) { return x; }
         auto c = GetConst(dag, memo, h, w);
@@ -473,20 +465,20 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto dj = Deriv(orig, dag, memo, h, j, targetC);
         auto dk = Deriv(orig, dag, memo, h, k, targetC);
         if (dj == Zero && dk == Zero) { return Zero; }
-        // i = w * j^k; unweight it once so both terms below use the plain
-        // j^k, letting applyWeight (below) supply w exactly once overall.
-        auto iu = Unweight(dag, memo, h, i);
+        // Fresh, unweighted j^k — recomputed from children rather than
+        // unweighting i, since Deriv() already has both j and k in scope here.
+        auto powJK = MakeBinary(dag, memo, h, BuiltinOp::Pow, j, k);
         Operon::Vector<std::size_t> terms;
         if (dj != Zero) {
             // d/dj: k * j^k / j = k * result / j
-            auto ki   = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, iu); // k * result
+            auto ki   = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, powJK); // k * result
             auto term = MakeBinary(dag, memo, h, BuiltinOp::Div, ki, j);
             terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dj, term));
         }
         if (dk != Zero) {
             // d/dk: j^k * ln(j) = result * log(j)
             auto logJ = MakeUnary(dag, memo, h, BuiltinOp::Log, j);
-            auto t     = MakeBinary(dag, memo, h, BuiltinOp::Mul, iu, logJ);
+            auto t     = MakeBinary(dag, memo, h, BuiltinOp::Mul, powJK, logJ);
             terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dk, t));
         }
         return applyWeight(AddTerms(dag, memo, h, terms));

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -160,9 +160,8 @@ auto BinaryDerivRules() -> BinarySymbolicDerivRegistry&
 // (rather than in StandardLibrary, which has no visibility into this TU's
 // private hash-consing helpers MakeUnary/MakeBinary/GetConst) mirroring
 // StandardLibrary::RegisterNames()'s lazy-static-lambda-once pattern.
-// Every rule below is lifted verbatim out of Deriv()'s old unary switch;
 // Abs/Sqrtabs/Floor/Ceil are intentionally left unregistered (non-smooth or
-// not-yet-implemented), degrading to Zero exactly like today's `default:`.
+// not yet implemented); an unregistered op yields Zero.
 void RegisterBuiltinSymbolicDerivs()
 {
     static auto const registered = [] {
@@ -379,24 +378,16 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
 
     // --- Sub ---
     if (n.IsSubtraction()) {
-        auto dj = Deriv(orig, dag, memo, h, children[0], targetC);
         if (arity == 1) {
             // Unary minus: -a. d(-a)/dc = -da
+            auto dj = Deriv(orig, dag, memo, h, children[0], targetC);
             if (dj == Zero) { return Zero; }
             auto neg1 = GetConst(dag, memo, h, Scalar{-1});
             return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj));
         }
-        if (arity == 2) {
-            auto dk = Deriv(orig, dag, memo, h, children[1], targetC);
-            if (dj == Zero && dk == Zero) { return Zero; }
-            if (dk == Zero) { return applyWeight(dj); }
-            if (dj == Zero) {
-                auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-                return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dk));
-            }
-            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Sub, dj, dk));
-        }
-        // arity > 2: treat as +first - rest
+        // arity >= 2: treat as +first - rest (this covers plain binary
+        // subtraction too: with only two children, "the rest" is just the
+        // second child).
         Operon::Vector<std::size_t> pos;
         Operon::Vector<std::size_t> neg;
         for (std::size_t m = 0; m < arity; ++m) {
@@ -520,11 +511,10 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto dj = Deriv(orig, dag, memo, h, j, targetC);
         if (dj == Zero) { return Zero; }
 
-        // Registry lookup replaces the old hardcoded switch (see
-        // RegisterBuiltinSymbolicDerivs above for the 16 built-in rules,
-        // migrated verbatim). A miss — including Abs/Sqrtabs/Floor/Ceil,
-        // deliberately left unregistered — degrades to Zero exactly like
-        // today's `default: return Zero;` did.
+        // Look up this operation's derivative rule (see
+        // RegisterBuiltinSymbolicDerivs above for the 16 built-in rules). A
+        // miss — including Abs/Sqrtabs/Floor/Ceil, which are deliberately
+        // left unregistered — yields Zero.
         auto const* rule = SymbolicDerivRules().TryGet(n.HashValue);
         if (rule == nullptr) { return Zero; }
         auto fp = (*rule)(dag, memo, h, i, j); // symbolic f'(j)

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -123,6 +123,22 @@ auto AddTerms(Nodes& dag, Memo& memo, Hashes& h,
     return result;
 }
 
+// Some rules below shortcut through node `i`'s own dag value (e.g. Sqrt's
+// derivative reuses `i` = sqrt(j) instead of recomputing it) instead of
+// building the local derivative purely from `j`. Since forward evaluation
+// bakes this node's own weight into `i` (dag[i] = w * op(j)), that shortcut
+// carries `w` along for free — harmless when Deriv() itself never applied
+// `w` (the historical bug), but double-counts it now that Deriv() applies
+// `w` once, uniformly, at every branch's return (see Deriv()'s applyWeight).
+// This unwinds the baked-in weight before such a rule reuses `i`, mirroring
+// the identical fix already applied to CallableDiff's numeric derivatives
+// (dividing the weighted primal shortcut by `w`).
+auto Unweight(Nodes& dag, Memo& memo, Hashes& h, std::size_t i) -> std::size_t {
+    auto const w = dag[i].Value;
+    if (w == Scalar{1}) { return i; }
+    return MakeBinary(dag, memo, h, BuiltinOp::Div, i, GetConst(dag, memo, h, w));
+}
+
 // Registry of symbolic derivative rules for unary functions, keyed by
 // Node::HashValue. A global, function-local-static singleton (mirroring
 // Node::RegisterName/Descriptions() in node.cpp) so BuildJacobianDag/
@@ -169,8 +185,8 @@ void RegisterBuiltinSymbolicDerivs()
         auto& reg = SymbolicDerivRules();
 
         reg.Register(Operon::Hash(BuiltinOp::Exp),
-            [](Nodes& /*dag*/, Memo& /*memo*/, Hashes& /*h*/, std::size_t i, std::size_t /*j*/) -> std::size_t {
-                return i; // d exp(j)/dj = exp(j) = result
+            [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
+                return Unweight(dag, memo, h, i); // d exp(j)/dj = exp(j) = result (unweighted)
             });
 
         UnarySymbolicDerivRule logRule =
@@ -203,7 +219,8 @@ void RegisterBuiltinSymbolicDerivs()
         reg.Register(Operon::Hash(BuiltinOp::Tan),
             [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
                 auto c1  = GetConst(dag, memo, h, Scalar{1});
-                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+                auto iu  = Unweight(dag, memo, h, i);
+                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, iu);
                 return MakeBinary(dag, memo, h, BuiltinOp::Add, c1, sqI);
             });
 
@@ -248,7 +265,8 @@ void RegisterBuiltinSymbolicDerivs()
         reg.Register(Operon::Hash(BuiltinOp::Tanh),
             [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t /*j*/) -> std::size_t {
                 auto c1  = GetConst(dag, memo, h, Scalar{1});
-                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, i);
+                auto iu  = Unweight(dag, memo, h, i);
+                auto sqI = MakeUnary(dag, memo, h, BuiltinOp::Square, iu);
                 return MakeBinary(dag, memo, h, BuiltinOp::Sub, c1, sqI);
             });
 
@@ -256,14 +274,16 @@ void RegisterBuiltinSymbolicDerivs()
             [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
                 auto c2   = GetConst(dag, memo, h, Scalar{2});
                 auto twoJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c2, j);
-                return MakeBinary(dag, memo, h, BuiltinOp::Div, i, twoJ);
+                auto iu   = Unweight(dag, memo, h, i);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, iu, twoJ);
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Cbrt),
             [](Nodes& dag, Memo& memo, Hashes& h, std::size_t i, std::size_t j) -> std::size_t {
                 auto c3     = GetConst(dag, memo, h, Scalar{3});
                 auto threeJ = MakeBinary(dag, memo, h, BuiltinOp::Mul, c3, j);
-                return MakeBinary(dag, memo, h, BuiltinOp::Div, i, threeJ);
+                auto iu     = Unweight(dag, memo, h, i);
+                return MakeBinary(dag, memo, h, BuiltinOp::Div, iu, threeJ);
             });
 
         reg.Register(Operon::Hash(BuiltinOp::Square),
@@ -312,6 +332,22 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         return Deriv(orig, dag, memo, h, orig[i].RefTo, targetC);
     }
 
+    // Every Function node's forward evaluation multiplies its op result by
+    // its own weight (Backend::Add/Mul/.../Pow all take a `weight` factor;
+    // see functions.hpp), and the numeric reverse-mode sweep
+    // (ReverseTraceGeneric) applies this same node's weight exactly once,
+    // uniformly across every op type, when propagating into any child. The
+    // per-op rules below (hardcoded Add/Mul/Sub/Div/Pow and the unary/binary
+    // registries) all compute the *unweighted* local derivative — this
+    // wrapper applies the node's own weight once at each branch's return,
+    // mirroring that same uniform step instead of leaving it to each rule.
+    auto const w = n.Value;
+    auto applyWeight = [&](std::size_t x) -> std::size_t {
+        if (x == Zero || w == Scalar{1}) { return x; }
+        auto c = GetConst(dag, memo, h, w);
+        return MakeBinary(dag, memo, h, BuiltinOp::Mul, c, x);
+    };
+
     auto const children = ChildIndices(orig, i);
     auto const arity    = static_cast<std::size_t>(n.Arity);
 
@@ -322,7 +358,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             auto dc = Deriv(orig, dag, memo, h, c, targetC);
             if (dc != Zero) { terms.push_back(dc); }
         }
-        return AddTerms(dag, memo, h, terms);
+        return applyWeight(AddTerms(dag, memo, h, terms));
     }
 
     // --- n-ary Mul: product rule ---
@@ -341,7 +377,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             }
             terms.push_back((prod == Zero) ? dm : MakeBinary(dag, memo, h, BuiltinOp::Mul, dm, prod));
         }
-        return AddTerms(dag, memo, h, terms);
+        return applyWeight(AddTerms(dag, memo, h, terms));
     }
 
     // --- Sub ---
@@ -351,17 +387,17 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             // Unary minus: -a. d(-a)/dc = -da
             if (dj == Zero) { return Zero; }
             auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-            return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj);
+            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj));
         }
         if (arity == 2) {
             auto dk = Deriv(orig, dag, memo, h, children[1], targetC);
             if (dj == Zero && dk == Zero) { return Zero; }
-            if (dk == Zero) { return dj; }
+            if (dk == Zero) { return applyWeight(dj); }
             if (dj == Zero) {
                 auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-                return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dk);
+                return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dk));
             }
-            return MakeBinary(dag, memo, h, BuiltinOp::Sub, dj, dk);
+            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Sub, dj, dk));
         }
         // arity > 2: treat as +first - rest
         Operon::Vector<std::size_t> pos;
@@ -374,12 +410,12 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto p = AddTerms(dag, memo, h, pos);
         auto q = AddTerms(dag, memo, h, neg);
         if (p == Zero && q == Zero) { return Zero; }
-        if (q == Zero) { return p; }
+        if (q == Zero) { return applyWeight(p); }
         if (p == Zero) {
             auto neg1 = GetConst(dag, memo, h, Scalar{-1});
-            return MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, q);
+            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, q));
         }
-        return MakeBinary(dag, memo, h, BuiltinOp::Sub, p, q);
+        return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Sub, p, q));
     }
 
     // --- Div ---
@@ -392,7 +428,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             auto j2     = MakeBinary(dag, memo, h, BuiltinOp::Mul, j, j);
             auto neg1   = GetConst(dag, memo, h, Scalar{-1});
             auto negDj = MakeBinary(dag, memo, h, BuiltinOp::Mul, neg1, dj);
-            return MakeBinary(dag, memo, h, BuiltinOp::Div, negDj, j2);
+            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Div, negDj, j2));
         }
         if (arity == 2) {
             // a/b: d = (da*b - a*db) / b^2
@@ -404,7 +440,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             // When only the numerator depends on x, simplify da/b directly.
             // Avoids (da*b)/b^2 which produces 0*Inf=NaN when b=Inf.
             if (dk == Zero) {
-                return MakeBinary(dag, memo, h, BuiltinOp::Div, dj, k);
+                return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Div, dj, k));
             }
             auto k2 = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, k);
             std::size_t num = Zero;
@@ -420,7 +456,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
                     num = MakeBinary(dag, memo, h, BuiltinOp::Sub, num, term);
                 }
             }
-            return MakeBinary(dag, memo, h, BuiltinOp::Div, num, k2);
+            return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Div, num, k2));
         }
         return Zero; // arity > 2 not yet supported
     }
@@ -432,20 +468,23 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto dj = Deriv(orig, dag, memo, h, j, targetC);
         auto dk = Deriv(orig, dag, memo, h, k, targetC);
         if (dj == Zero && dk == Zero) { return Zero; }
+        // i = w * j^k; unweight it once so both terms below use the plain
+        // j^k, letting applyWeight (below) supply w exactly once overall.
+        auto iu = Unweight(dag, memo, h, i);
         Operon::Vector<std::size_t> terms;
         if (dj != Zero) {
             // d/dj: k * j^k / j = k * result / j
-            auto ki   = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, i); // k * result
+            auto ki   = MakeBinary(dag, memo, h, BuiltinOp::Mul, k, iu); // k * result
             auto term = MakeBinary(dag, memo, h, BuiltinOp::Div, ki, j);
             terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dj, term));
         }
         if (dk != Zero) {
             // d/dk: j^k * ln(j) = result * log(j)
             auto logJ = MakeUnary(dag, memo, h, BuiltinOp::Log, j);
-            auto t     = MakeBinary(dag, memo, h, BuiltinOp::Mul, i, logJ);
+            auto t     = MakeBinary(dag, memo, h, BuiltinOp::Mul, iu, logJ);
             terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, dk, t));
         }
-        return AddTerms(dag, memo, h, terms);
+        return applyWeight(AddTerms(dag, memo, h, terms));
     }
 
     // --- Aq, Powabs, Fmin, Fmax: not yet differentiated ---
@@ -475,7 +514,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
             if (dk != Zero && fpk != Zero) {
                 terms.push_back(MakeBinary(dag, memo, h, BuiltinOp::Mul, fpk, dk));
             }
-            return AddTerms(dag, memo, h, terms);
+            return applyWeight(AddTerms(dag, memo, h, terms));
         }
     }
 
@@ -495,7 +534,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto fp = (*rule)(dag, memo, h, i, j); // symbolic f'(j)
 
         if (fp == Zero) { return Zero; }
-        return MakeBinary(dag, memo, h, BuiltinOp::Mul, fp, dj);
+        return applyWeight(MakeBinary(dag, memo, h, BuiltinOp::Mul, fp, dj));
     }
 
     return Zero;

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -343,7 +343,12 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
     // mirroring that same uniform step instead of leaving it to each rule.
     auto const w = n.Value;
     auto applyWeight = [&](std::size_t x) -> std::size_t {
-        if (x == Zero || w == Scalar{1}) { return x; }
+        // w == 0 short-circuits to Zero rather than emitting Mul(0, x): d(0*f)/dc
+        // is exactly 0 regardless of x, and x may itself be a rule that divides by
+        // w (see Unweight below) and would otherwise evaluate to 0/0 = NaN, which
+        // Mul(0, NaN) would then propagate as NaN instead of the correct 0.
+        if (x == Zero || w == Scalar{0}) { return Zero; }
+        if (w == Scalar{1}) { return x; }
         auto c = GetConst(dag, memo, h, w);
         return MakeBinary(dag, memo, h, BuiltinOp::Mul, c, x);
     };

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -335,10 +335,10 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
     auto const w = n.Value;
     auto applyWeight = [&](std::size_t x) -> std::size_t {
         // w == 0 short-circuits to Zero rather than emitting Mul(0, x): d(0*f)/dc
-        // is exactly 0 regardless of x. Every rule below builds its local
-        // derivative purely from children (never dividing by this node's own
-        // weight), so x is always finite here — this is defense-in-depth, not
-        // a fix for a reachable NaN.
+        // is exactly 0 regardless of x, but x can still evaluate to Inf at a
+        // domain singularity (e.g. Sqrt/Log at j == 0), and Mul(Const(0), Inf)
+        // is NaN under IEEE-754, not 0 — this check is load-bearing, not mere
+        // defense-in-depth.
         if (x == Zero || w == Scalar{0}) { return Zero; }
         if (w == Scalar{1}) { return x; }
         auto c = GetConst(dag, memo, h, w);
@@ -465,8 +465,7 @@ auto Deriv(Nodes const& orig, Nodes& dag, Memo& memo, Hashes& h,
         auto dj = Deriv(orig, dag, memo, h, j, targetC);
         auto dk = Deriv(orig, dag, memo, h, k, targetC);
         if (dj == Zero && dk == Zero) { return Zero; }
-        // Fresh, unweighted j^k — recomputed from children rather than
-        // unweighting i, since Deriv() already has both j and k in scope here.
+        // Fresh, unweighted j^k, recomputed from children.
         auto powJK = MakeBinary(dag, memo, h, BuiltinOp::Pow, j, k);
         Operon::Vector<std::size_t> terms;
         if (dj != Zero) {

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -236,6 +236,44 @@ TEST_CASE("BuildJacobianDag - Mul(c1,c2) product rule", "[tree_diff]")
     CHECK(dag.Nodes[dag.Roots[1]].IsOp<BuiltinOp::Mul>());
 }
 
+TEST_CASE("BuildJacobianDag - zero-weight Function node yields exact zero gradient", "[tree_diff]")
+{
+    // d(0 * f(c))/dc must be exactly 0, not NaN. Exp/Sqrt/Cbrt/Tan/Tanh/Pow's
+    // symbolic rules shortcut through this node's own already-weighted dag
+    // value via Unweight() (dividing by the node's own weight to recover the
+    // unweighted local derivative) -- at weight == 0 that division is 0/0,
+    // which applyWeight's w == 0 short-circuit must catch before it can
+    // propagate as NaN (0 * NaN = NaN in IEEE-754, not 0).
+    for (auto op : {BuiltinOp::Exp, BuiltinOp::Sqrt, BuiltinOp::Cbrt, BuiltinOp::Tan, BuiltinOp::Tanh}) {
+        Operon::Vector<Node> nodes;
+        auto c = Node::Constant(2.0F); c.Optimize = true;
+        auto fn = Node::Function(static_cast<Operon::Hash>(op), 1);
+        fn.Value = 0.0F;
+        nodes.push_back(c); nodes.push_back(fn);
+        Tree tree{nodes};
+
+        auto dag = BuildJacobianDag(tree);
+        REQUIRE(dag.Roots.size() == 1);
+        CHECK(dag.Roots[0] == NoGrad); // exactly zero, not a NaN-producing expression
+    }
+
+    // Pow(base, exponent) is a hardcoded binary case, also Unweight()-shortcut.
+    {
+        Operon::Vector<Node> nodes;
+        auto base = Node::Constant(2.0F); base.Optimize = true;
+        auto exp  = Node::Constant(3.0F); exp.Optimize = true;
+        auto pow  = Node::Function(static_cast<Operon::Hash>(BuiltinOp::Pow), 2);
+        pow.Value = 0.0F;
+        nodes.push_back(exp); nodes.push_back(base); nodes.push_back(pow);
+        Tree tree{nodes};
+
+        auto dag = BuildJacobianDag(tree);
+        REQUIRE(dag.Roots.size() == 2);
+        CHECK(dag.Roots[0] == NoGrad);
+        CHECK(dag.Roots[1] == NoGrad);
+    }
+}
+
 TEST_CASE("BuildJacobianDag - Sin(c) root is Mul", "[tree_diff]")
 {
     Operon::Vector<Node> nodes;

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -112,11 +112,9 @@ auto GenerateTrees(
     return trees;
 }
 
-// Same as GenerateTrees, but also assigns a random non-unit weight to every
-// Function node (BalancedTreeCreator/Node's ctor otherwise always leaves
-// Function nodes at Value=1.0 — the case GenerateTrees exercises, and the
-// case tree_diff.cpp's Deriv() historically got wrong: see
-// foolnotion/operon-planning's symbolic-diff-weight-omission bug writeup).
+// Same as GenerateTrees, but assigns a random non-unit weight to every
+// Function node. GenerateTrees leaves them at 1.0, so this exercises the
+// weight factor in each node's derivative.
 auto GenerateWeightedTrees(
     RandomGenerator& rng,
     PrimitiveSet& pset,

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -112,6 +112,31 @@ auto GenerateTrees(
     return trees;
 }
 
+// Same as GenerateTrees, but also assigns a random non-unit weight to every
+// Function node (BalancedTreeCreator/Node's ctor otherwise always leaves
+// Function nodes at Value=1.0 — the case GenerateTrees exercises, and the
+// case tree_diff.cpp's Deriv() historically got wrong: see
+// foolnotion/operon-planning's symbolic-diff-weight-omission bug writeup).
+auto GenerateWeightedTrees(
+    RandomGenerator& rng,
+    PrimitiveSet& pset,
+    Dataset const& ds,
+    int n,
+    std::size_t maxLen
+) -> std::vector<Tree>
+{
+    std::uniform_real_distribution<Operon::Scalar> weightDist(0.5F, 2.F);
+    auto trees = GenerateTrees(rng, pset, ds, n, maxLen);
+    for (auto& tree : trees) {
+        for (auto& nd : tree.Nodes()) {
+            if (!nd.IsLeaf() && !nd.IsRef()) {
+                nd.Value = weightDist(rng) * (std::bernoulli_distribution{0.5}(rng) ? Operon::Scalar{1} : Operon::Scalar{-1});
+            }
+        }
+    }
+    return trees;
+}
+
 } // namespace
 
 // ============================================================
@@ -286,6 +311,59 @@ TEST_CASE("BuildJacobianDag correctness vs JacRev - random trees", "[tree_diff]"
     for (auto const& tree : trees) {
         auto const coeff = tree.GetCoefficients();
         if (coeff.empty()) { continue; } // tree has no constants
+
+        Interp const interp{&dtable, &ds, &tree};
+        auto const jrev = interp.JacRev(coeff, range);
+
+        auto const dag  = BuildJacobianDag(tree);
+        auto const jdag = EvalDagJacobian(dag, coeff, ds, range, dtable);
+
+        auto const nk = jrev.cols();
+        totalCols += static_cast<std::size_t>(nk);
+
+        for (Eigen::Index k = 0; k < nk; ++k) {
+            auto const colRev = jrev.col(k);
+            auto const colDag = jdag.col(k);
+            bool const revFin = std::isfinite(colRev.sum());
+            bool const dagFin = std::isfinite(colDag.sum());
+            if (revFin && !dagFin) {
+                ++finiteMismatch;
+            } else if (revFin && dagFin && !colRev.isApprox(colDag, eps)) {
+                ++finiteDiverge;
+            }
+        }
+    }
+
+    INFO("finite mismatch: " << finiteMismatch << " / " << totalCols);
+    INFO("finite diverge:  " << finiteDiverge  << " / " << totalCols);
+    CHECK(finiteMismatch == 0);
+    CHECK(static_cast<double>(finiteDiverge) / static_cast<double>(std::max(totalCols, std::size_t{1})) < maxDivergeRate);
+}
+
+TEST_CASE("BuildJacobianDag correctness vs JacRev - weighted Function nodes", "[tree_diff]")
+{
+    constexpr auto nRows  = 100;
+    constexpr auto nCols  = 5;
+    constexpr auto nTrees = 1000;
+    constexpr auto maxLen = 30;
+    constexpr auto eps    = 1e-3F; // relaxed for potential numerical differences
+    constexpr auto maxDivergeRate = 0.02; // allow 2% divergence due to numerics
+
+    Operon::RandomGenerator rng(43UL);
+    auto ds = Operon::Test::Util::RandomDataset(rng, nRows, nCols);
+    DTable dtable;
+    Range const range{0, ds.Rows<std::size_t>()};
+
+    auto pset = MakeSupportedPset();
+    auto const trees = GenerateWeightedTrees(rng, pset, ds, nTrees, maxLen);
+
+    std::size_t finiteMismatch = 0;
+    std::size_t finiteDiverge  = 0;
+    std::size_t totalCols      = 0;
+
+    for (auto const& tree : trees) {
+        auto const coeff = tree.GetCoefficients();
+        if (coeff.empty()) { continue; }
 
         Interp const interp{&dtable, &ds, &tree};
         auto const jrev = interp.JacRev(coeff, range);
@@ -837,6 +915,77 @@ TEST_CASE("BuildHessianDag correctness vs finite differences - random trees", "[
 
     auto rate = static_cast<double>(failedEntries) / static_cast<double>(std::max(totalEntries, std::size_t{1}));
     fmt::print("FD Hessian: {} / {} entries failed ({:.2f}%)\n", failedEntries, totalEntries, rate * 100.0);
+    CHECK(rate < maxFailRate);
+}
+
+TEST_CASE("BuildHessianDag correctness vs finite differences - weighted Function nodes", "[tree_diff][hessian]")
+{
+    constexpr auto nRows  = 50;
+    constexpr auto nCols  = 5;
+    constexpr auto nTrees = 500;
+    constexpr auto maxLen = 20;
+    constexpr auto fdEps  = 1e-3F;
+    constexpr auto tol    = 5e-2F;
+    constexpr auto maxFailRate = 0.15;
+
+    Operon::RandomGenerator rng(100UL);
+    auto ds = Operon::Test::Util::RandomDataset(rng, nRows, nCols);
+    DTable dtable;
+    Range const range{0, ds.Rows<std::size_t>()};
+
+    auto pset = MakeSupportedPset();
+    auto const trees = GenerateWeightedTrees(rng, pset, ds, nTrees, maxLen);
+
+    std::size_t totalEntries = 0;
+    std::size_t failedEntries = 0;
+
+    for (auto const& tree : trees) {
+        auto coeff = tree.GetCoefficients();
+        auto const p = coeff.size();
+        if (p == 0) { continue; }
+
+        auto const dag = BuildHessianDag(tree);
+        Interp const interp{&dtable, &ds, &tree};
+
+        for (std::size_t i = 0; i < p; ++i) {
+            for (std::size_t j = i; j < p; ++j) {
+                auto dagCol = EvalDagColumn(
+                    dag.Nodes, dag.HessianRoots[dag.UpperIdx(i, j)],
+                    coeff, ds, range, dtable);
+
+                // Finite difference: perturb coeff[j], measure change in J column i
+                auto coeffPlus = coeff;
+                auto coeffMinus = coeff;
+                coeffPlus[j] += fdEps;
+                coeffMinus[j] -= fdEps;
+
+                // Create temporary trees with perturbed coefficients
+                auto treePlus = tree;
+                auto treeMinus = tree;
+                treePlus.SetCoefficients({coeffPlus.data(), coeffPlus.size()});
+                treeMinus.SetCoefficients({coeffMinus.data(), coeffMinus.size()});
+
+                auto jacPlus = Interp{&dtable, &ds, &treePlus}.JacRev(coeffPlus, range);
+                auto jacMinus = Interp{&dtable, &ds, &treeMinus}.JacRev(coeffMinus, range);
+
+                auto fdCol = (jacPlus.col(static_cast<Eigen::Index>(i))
+                            - jacMinus.col(static_cast<Eigen::Index>(i)))
+                           / (2.0F * fdEps);
+
+                ++totalEntries;
+                for (int r = 0; r < static_cast<int>(range.Size()); ++r) {
+                    if (!std::isfinite(fdCol(r)) || !std::isfinite(dagCol(r))) { continue; }
+                    if (std::abs(dagCol(r) - fdCol(r)) > tol * (1.0F + std::abs(fdCol(r)))) {
+                        ++failedEntries;
+                        break; // one failure per (i,j) entry is enough
+                    }
+                }
+            }
+        }
+    }
+
+    auto rate = static_cast<double>(failedEntries) / static_cast<double>(std::max(totalEntries, std::size_t{1}));
+    fmt::print("FD Hessian (weighted): {} / {} entries failed ({:.2f}%)\n", failedEntries, totalEntries, rate * 100.0);
     CHECK(rate < maxFailRate);
 }
 

--- a/test/source/implementation/tree_diff.cpp
+++ b/test/source/implementation/tree_diff.cpp
@@ -239,11 +239,11 @@ TEST_CASE("BuildJacobianDag - Mul(c1,c2) product rule", "[tree_diff]")
 TEST_CASE("BuildJacobianDag - zero-weight Function node yields exact zero gradient", "[tree_diff]")
 {
     // d(0 * f(c))/dc must be exactly 0, not NaN. Exp/Sqrt/Cbrt/Tan/Tanh/Pow's
-    // symbolic rules shortcut through this node's own already-weighted dag
-    // value via Unweight() (dividing by the node's own weight to recover the
-    // unweighted local derivative) -- at weight == 0 that division is 0/0,
-    // which applyWeight's w == 0 short-circuit must catch before it can
-    // propagate as NaN (0 * NaN = NaN in IEEE-754, not 0).
+    // symbolic rules recompute their local derivative fresh from the child
+    // (e.g. Sqrt emits 1/(2*sqrt(j))), which can itself evaluate to Inf at
+    // c == 0 (sqrt(0) == 0). applyWeight's w == 0 short-circuit must catch
+    // this before Mul(Const(0), Inf) can propagate as NaN (IEEE-754: 0*Inf
+    // is NaN, not 0).
     for (auto op : {BuiltinOp::Exp, BuiltinOp::Sqrt, BuiltinOp::Cbrt, BuiltinOp::Tan, BuiltinOp::Tanh}) {
         Operon::Vector<Node> nodes;
         auto c = Node::Constant(2.0F); c.Optimize = true;
@@ -257,7 +257,7 @@ TEST_CASE("BuildJacobianDag - zero-weight Function node yields exact zero gradie
         CHECK(dag.Roots[0] == NoGrad); // exactly zero, not a NaN-producing expression
     }
 
-    // Pow(base, exponent) is a hardcoded binary case, also Unweight()-shortcut.
+    // Pow(base, exponent) is a hardcoded binary case with the same w == 0 risk.
     {
         Operon::Vector<Node> nodes;
         auto base = Node::Constant(2.0F); base.Optimize = true;


### PR DESCRIPTION
## Summary

`tree_diff.cpp`'s `Deriv()` (backs `BuildJacobianDag`/`BuildHessianDag`, consumed by `TreeCompiler::CompileJacobian` for JIT-path gradients) never applied a Function node's own weight to the derivative it returns — every branch (`Add`/`Mul`/`Sub`/`Div`/`Pow`, the unary registry, the binary/composed registry) computed as if the node's weight were 1. Latent for traditionally-built GP trees (Function-node weight is always 1 there), real for shipped composed functions, which can carry a non-unit outer weight.

Adds a single `applyWeight()` wrapper applied once at every `Deriv()` branch's return, mirroring the uniform per-node weight multiply the numeric path (`ReverseTraceGeneric`) already does. That surfaced a second bug: `Exp`/`Sqrt`/`Cbrt`/`Tan`/`Tanh` (registered rules) and the hardcoded `Pow` branch shortcut through the node's own already-weighted dag value instead of recomputing from children, so the new uniform weight-apply would double-count theirs. Adds an `Unweight()` helper to divide the baked-in weight back out before those rules reuse it.

Depends on #146 (the sibling numeric-path fix) for its own test suite's ground truth (`JacRev`) to be correct — based on `main` directly per repo convention; diff will show both changesets combined until #146 merges.

## Test plan

- [x] New `GenerateWeightedTrees` + property tests (Jacobian and Hessian) comparing the symbolic-diff DAG against `JacRev`/finite-difference ground truth across 1000/500 random weighted trees — 0% divergence after the fix (was ~8-11%).
- [x] Existing `tree_diff` test suite passes unchanged.
- [x] Verified against both static (Stl) and shared (Eve) builds.