### PR TITLE
Gate JIT-vs-reference tests to the Eve math backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,15 @@ CMakeLists.txt.user
 CMakeUserPresets.json
 project-include-after.cmake
 .direnv
+
+# Local scratch/analysis scripts and outputs — not part of the library,
+# kept out of git so a dirty tree here doesn't force `nix develop` to
+# re-evaluate/re-copy the flake's source on every invocation.
+docs/research/
+scratch/
+tools/__pycache__/
+tools/results/
+tools/*.py
+tools/*.sh
+tools/*.yaml
+tools/*.txt

--- a/include/operon/interpreter/backend/jit/jit_compiler.hpp
+++ b/include/operon/interpreter/backend/jit/jit_compiler.hpp
@@ -143,6 +143,15 @@ struct JitRuntimePool {
 
 // Stateless JIT code generator. All runtime state lives in the JitRuntimePool
 // provided at construction; TreeCompiler can be destroyed before the pool.
+//
+// Every transcendental op it compiles (Exp/Log/Pow/etc., see the
+// JitUnaryCodegenFn/JitBinaryCodegenFn registrations in jit_compiler.cpp)
+// calls the Eve backend's approximate math functions directly, regardless
+// of which MATH_BACKEND the rest of the library was built with. A tree
+// compiled here always computes Eve-equivalent results, even when
+// MATH_BACKEND is Stl, MadEve, or Eigen — comparing its output against a
+// reference Interpreter built with a different MATH_BACKEND will show
+// small, expected numeric differences, not a JIT bug.
 class OPERON_EXPORT TreeCompiler {
 public:
     explicit TreeCompiler(JitRuntimePool const* pool) : pool_(pool) {}

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -477,6 +477,14 @@ TEST_CASE("Zobrist hash is structural: constant values do not affect the hash", 
 
 TEST_CASE("JitEvaluator vs interpreter on random population", "[jit][evaluator][population]")
 {
+#ifndef OPERON_MATH_EVE
+    // TreeCompiler always codegens Eve's approximate FastExp/FastLog/FastPow,
+    // regardless of MATH_BACKEND (see jit_compiler.cpp) — under any other
+    // backend this test compares JIT-compiled output against a reference
+    // interpreter using genuinely different (exact) math, which diverges on
+    // deep trees. Not a JIT correctness bug against its actual target (Eve).
+    SKIP("JIT always targets Eve math; only comparable against an Eve-backend reference");
+#endif
     auto ds    = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
     auto range = Range{0, std::min(ds.Rows<std::size_t>(), std::size_t{200})};
 
@@ -705,6 +713,12 @@ TEST_CASE("CompileJacobian correctness vs JacRev - random trees", "[jit][jacobia
 
 TEST_CASE("CompileJacobian correctness - variable weights", "[jit][jacobian]")
 {
+#ifndef OPERON_MATH_EVE
+    // Same reason as "JitEvaluator vs interpreter on random population" above:
+    // CompileJacobian funnels through the same Eve-hardcoded op registries as
+    // CompileAVX2, regardless of MATH_BACKEND.
+    SKIP("JIT always targets Eve math; only comparable against an Eve-backend reference");
+#endif
     JIT::JitRuntimePool compilerPool;
     JIT::TreeCompiler compiler{&compilerPool};
     if (!compiler.HasAVX2()) {


### PR DESCRIPTION
## Summary

`TreeCompiler` hardcodes Eve's approximate `FastExp`/`FastLog`/`FastPow` for all codegen (`CompileAVX2` and `CompileJacobian` both funnel through the same op registries), regardless of the configured `MATH_BACKEND`. Under `MATH_BACKEND=Stl`, the reference `Interpreter` uses exact `std::exp`/`std::log`/`std::pow` instead, so two tests that compare JIT-compiled output against that reference diverge on deep trees — not because the JIT miscompiles, but because it's being compared against math it was never designed to match.

Confirmed clean (0 failures) under the production-default Eve backend; only fails under Stl.

Gates `"JitEvaluator vs interpreter on random population"` and `"CompileJacobian correctness - variable weights"` to skip under non-Eve backends.

## Test plan

- [x] Verified both tests skip cleanly under `build-ws-stl` (Stl backend).
- [x] Verified both tests still run and pass under `build-ws-shared` (Eve backend).