### PR TITLE
Expose a public DAG-builder facade for symbolic-diff rules

### DIFF
--- a/include/operon/core/tree_diff.hpp
+++ b/include/operon/core/tree_diff.hpp
@@ -97,6 +97,12 @@ OPERON_EXPORT auto GetBinarySymbolicDeriv(Operon::Hash hash) -> BinarySymbolicDe
 // subexpression-sharing logic — call them instead of appending nodes by
 // hand.
 //
+// Note: composed_function.hpp's detail::Diff{Mix,GetConst,MakeUnary,
+// MakeBinary} is a separate, intentionally-diverging port of this same
+// protocol (salted hashing, to avoid a Mix(0,0)==0 fixed point that this
+// unsalted version doesn't need to guard against for its own callers) —
+// not a redundant copy to migrate onto these functions.
+//
 // Get or create a constant node holding `val`. Two calls with the same
 // value return the same dag index.
 OPERON_EXPORT auto GetSymbolicDerivConst(Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
@@ -109,7 +115,9 @@ OPERON_EXPORT auto MakeSymbolicDerivUnary(Operon::Vector<Node>& dag, Operon::Map
 
 // Build `op(a, b)`, where `a` is the nearer child and `b` is the farther
 // child (same convention as Deriv()'s own hardcoded Pow case, and as the
-// `j`/`k` parameters BinarySymbolicDerivRule receives).
+// `j`/`k` parameters BinarySymbolicDerivRule receives). Note that Mul(a,b)
+// and Mul(b,a) get different hash keys (less deduplication but no
+// correctness issue) — relevant when writing a non-commutative binary rule.
 OPERON_EXPORT auto MakeSymbolicDerivBinary(Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
     Operon::Vector<Operon::Hash>& h, BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t;
 

--- a/include/operon/core/tree_diff.hpp
+++ b/include/operon/core/tree_diff.hpp
@@ -89,6 +89,30 @@ OPERON_EXPORT auto HasBinarySymbolicDeriv(Operon::Hash hash) -> bool;
 // GetUnarySymbolicDeriv for the external-caller use case.
 OPERON_EXPORT auto GetBinarySymbolicDeriv(Operon::Hash hash) -> BinarySymbolicDerivRule const*;
 
+// A UnarySymbolicDerivRule/BinarySymbolicDerivRule body needs to append new
+// nodes to the derivative dag under construction (`dag`/`memo`/`h`, the
+// same three arguments the rule itself receives), sharing identical
+// subexpressions across derivative columns the same way every built-in
+// rule does. These three functions are that same node-building,
+// subexpression-sharing logic — call them instead of appending nodes by
+// hand.
+//
+// Get or create a constant node holding `val`. Two calls with the same
+// value return the same dag index.
+OPERON_EXPORT auto GetSymbolicDerivConst(Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
+    Operon::Vector<Operon::Hash>& h, Scalar val) -> std::size_t;
+
+// Build `op(a)`, where `a` is an existing dag index. Two calls building the
+// same expression return the same dag index.
+OPERON_EXPORT auto MakeSymbolicDerivUnary(Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
+    Operon::Vector<Operon::Hash>& h, BuiltinOp op, std::size_t a) -> std::size_t;
+
+// Build `op(a, b)`, where `a` is the nearer child and `b` is the farther
+// child (same convention as Deriv()'s own hardcoded Pow case, and as the
+// `j`/`k` parameters BinarySymbolicDerivRule receives).
+OPERON_EXPORT auto MakeSymbolicDerivBinary(Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
+    Operon::Vector<Operon::Hash>& h, BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t;
+
 // A flat postfix array containing the original tree (indices 0..OriginalSize-1)
 // plus appended symbolic derivative subtrees. Shared subexpressions between
 // derivative columns are referenced via NodeType::Ref back-pointers.

--- a/source/core/tree_diff.cpp
+++ b/source/core/tree_diff.cpp
@@ -622,6 +622,21 @@ auto GetBinarySymbolicDeriv(Operon::Hash hash) -> BinarySymbolicDerivRule const*
     return BinaryDerivRules().TryGet(hash);
 }
 
+auto GetSymbolicDerivConst(Nodes& dag, Memo& memo, Hashes& h, Scalar val) -> std::size_t
+{
+    return GetConst(dag, memo, h, val);
+}
+
+auto MakeSymbolicDerivUnary(Nodes& dag, Memo& memo, Hashes& h, BuiltinOp op, std::size_t a) -> std::size_t
+{
+    return MakeUnary(dag, memo, h, op, a);
+}
+
+auto MakeSymbolicDerivBinary(Nodes& dag, Memo& memo, Hashes& h, BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t
+{
+    return MakeBinary(dag, memo, h, op, a, b);
+}
+
 auto BuildJacobianDag(Tree const& tree) -> JacobianDag {
     JacobianDag dag;
     Memo memo;

--- a/test/source/implementation/user_defined_registries.cpp
+++ b/test/source/implementation/user_defined_registries.cpp
@@ -28,57 +28,6 @@
 
 namespace Operon::Test {
 
-namespace {
-
-// Hash-consing convention private to tree_diff.cpp (MakeUnary/MakeBinary/
-// GetConst are anonymous-namespace, not exported) hand-rolled here using
-// only the public Node factories — this is exactly the amount of protocol
-// knowledge an external caller needs: children are appended as Ref nodes
-// (never inlined subtrees, so Node::Function(hash, arity)'s arity == the
-// node's Length with no further bookkeeping), a binary op's farther child
-// is appended before its nearer child, and any literal constant must have
-// Optimize forced to false (a leaf's default ctor sets Optimize=true,
-// which would make the derivative-DAG's own synthetic constant look like a
-// tunable coefficient to anything counting them). The parallel hash vector
-// `h` is read only by Deriv()'s own memo lookups within the same call
-// (verified: `grep h\[ source/core/tree_diff.cpp` shows exactly three
-// reads, all feeding Mix() for a memo key) — never compared against
-// anything outside this one Deriv() invocation — so any distinct
-// placeholder value here (dag.size() at push time) is safe; it costs
-// missed CSE opportunities, not correctness.
-struct HandRolledDagBuilder {
-    Operon::Vector<Node>& dag;
-    Operon::Vector<Operon::Hash>& h;
-
-    auto PushRef(std::size_t target) -> std::size_t {
-        dag.push_back(Node::Ref(static_cast<uint16_t>(target)));
-        h.push_back(static_cast<Operon::Hash>(dag.size()));
-        return dag.size() - 1;
-    }
-    auto PushConst(Scalar v) -> std::size_t {
-        auto n = Node::Constant(v);
-        n.Optimize = false;
-        dag.push_back(n);
-        h.push_back(static_cast<Operon::Hash>(dag.size()));
-        return dag.size() - 1;
-    }
-    auto PushUnary(BuiltinOp op, std::size_t a) -> std::size_t {
-        PushRef(a);
-        dag.push_back(Node::Function(static_cast<Operon::Hash>(op), 1));
-        h.push_back(static_cast<Operon::Hash>(dag.size()));
-        return dag.size() - 1;
-    }
-    auto PushBinary(BuiltinOp op, std::size_t a, std::size_t b) -> std::size_t {
-        PushRef(b); // farther child first — matches MakeBinary's documented layout
-        PushRef(a); // nearer child second
-        dag.push_back(Node::Function(static_cast<Operon::Hash>(op), 2));
-        h.push_back(static_cast<Operon::Hash>(dag.size()));
-        return dag.size() - 1;
-    }
-};
-
-} // namespace
-
 TEST_CASE("User-defined function via registries: recip(x) = 1/x", "[registry][user-defined]")
 {
     auto const hash = Operon::Hasher{}("recip");
@@ -103,16 +52,17 @@ TEST_CASE("User-defined function via registries: recip(x) = 1/x", "[registry][us
     auto result = interp.Evaluate(tree.GetCoefficients(), Range{ 0, 1 });
     CHECK(result[0] == Catch::Approx(0.5).epsilon(1e-5)); // 1/2
 
-    // 2. Symbolic differentiation — RegisterUnarySymbolicDeriv, the
-    // registry this PR adds. d(1/x)/dx = -1/x^2, built by hand per the
-    // HandRolledDagBuilder rationale above (no private helper needed).
+    // 2. Symbolic differentiation — RegisterUnarySymbolicDeriv. d(1/x)/dx =
+    // -1/x^2, built using the public DAG-builder facade (GetSymbolicDerivConst/
+    // MakeSymbolicDerivUnary/MakeSymbolicDerivBinary) so this rule gets the
+    // same node-sharing behavior every built-in rule gets, without needing
+    // to know tree_diff.cpp's internal node-append protocol.
     RegisterUnarySymbolicDeriv(hash,
-        [](Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& /*memo*/,
+        [](Operon::Vector<Node>& dag, Operon::Map<Operon::Hash, std::size_t>& memo,
            Operon::Vector<Operon::Hash>& h, std::size_t /*i*/, std::size_t j) -> std::size_t {
-            HandRolledDagBuilder b{ dag, h };
-            auto negOne = b.PushConst(Scalar{ -1 });
-            auto sq     = b.PushUnary(BuiltinOp::Square, j);
-            return b.PushBinary(BuiltinOp::Div, negOne, sq); // -1 / x^2, non-commutative — exercises binary child ordering
+            auto negOne = GetSymbolicDerivConst(dag, memo, h, Scalar{ -1 });
+            auto sq     = MakeSymbolicDerivUnary(dag, memo, h, BuiltinOp::Square, j);
+            return MakeSymbolicDerivBinary(dag, memo, h, BuiltinOp::Div, negOne, sq); // -1 / x^2, non-commutative — exercises binary child ordering
         });
     REQUIRE(HasUnarySymbolicDeriv(hash));
 


### PR DESCRIPTION
## Summary

Closes #142.

`RegisterUnarySymbolicDeriv`/`RegisterBinarySymbolicDeriv` are exported, but the hash-consing helpers a rule body actually needs to build its result (`MakeUnary`/`MakeBinary`/`GetConst` in `source/core/tree_diff.cpp`) are anonymous-namespace, not exported. Registering a real symbolic-derivative rule for a user-defined function required hand-rolling a ~30-line replica of the private node-append protocol (Ref-append ordering, `Optimize=false` on synthetic constants, the parallel hash-bookkeeping vector) — and that hand-rolled version has no hash-consing, so it can't share subexpressions across derivative columns the way every built-in rule does.

Adds three thin exported wrappers around the exact same implementation every built-in rule already uses:

- `GetSymbolicDerivConst(dag, memo, h, val)`
- `MakeSymbolicDerivUnary(dag, memo, h, op, a)`
- `MakeSymbolicDerivBinary(dag, memo, h, op, a, b)`

Updates `test/source/implementation/user_defined_registries.cpp`'s `recip(x) = 1/x` example to use the new facade instead of its previous hand-rolled, non-deduplicating equivalent.

## Test plan

- [x] `[registry]` suite green on both static (Stl) and shared (Eve) builds.
- [x] Full test suite green on both configs (2 pre-existing, unrelated skips from an earlier merged PR).