### PR TITLE
Move interval/affine registries to exported .cpp singletons, add Has* predicates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ add_library(
     source/hash/hash.cpp
     source/hash/metrohash64.cpp
     source/hash/zobrist.cpp
+    source/interpreter/affine_evaluator.cpp
     source/interpreter/interpreter.cpp
+    source/interpreter/interval_evaluator.cpp
     source/operators/creator/creator.cpp
     source/operators/creator/balanced.cpp
     source/operators/creator/koza.cpp

--- a/include/operon/core/composed_function.hpp
+++ b/include/operon/core/composed_function.hpp
@@ -1001,8 +1001,8 @@ void RegisterComposedFunction(
     // this function was first written.
     if (dt.Contains(hash) || pset.Contains(hash)
         || HasUnarySymbolicDeriv(hash) || HasBinarySymbolicDeriv(hash)
-        || IntervalUnaryRules().Contains(hash) || IntervalBinaryRules().Contains(hash)
-        || AffineUnaryRules().Contains(hash) || AffineBinaryRules().Contains(hash)) {
+        || HasUnaryInterval(hash) || HasBinaryInterval(hash)
+        || HasUnaryAffine(hash) || HasBinaryAffine(hash)) {
         throw std::invalid_argument(fmt::format(
             "RegisterComposedFunction: '{}' is already registered", info.Name));
     }

--- a/include/operon/interpreter/affine_evaluator.hpp
+++ b/include/operon/interpreter/affine_evaluator.hpp
@@ -17,6 +17,7 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
+#include "operon/operon_export.hpp"
 
 // See interval_evaluator.hpp for the rationale behind these pragmas.
 #if defined(__clang__)
@@ -38,15 +39,16 @@
 namespace Operon {
 
 // Registered affine callbacks for unary/binary built-in or user-defined
-// functions, keyed by Node::HashValue. See interval_evaluator.hpp's matching
-// comment for the full rationale (global inline Meyer singletons, no
-// registry parameter threaded through the constructor/Evaluate(), plain
-// non-locking HashRegistry since all writes finish before Evaluate() is
-// first called from a GP worker thread). Only real difference from
-// IntervalUnaryFn/IntervalBinaryFn: every call here takes the shared
-// affine_context first — the context-threaded finalize overload of
-// PAPPUS_DEFINE_UNARY_OP is the only one either evaluator ever calls (the
-// bare affine_form<T>-only overload, without a context, is never used here).
+// functions, keyed by Node::HashValue. Exported `.cpp`-backed singletons
+// (see affine_evaluator.cpp) — see interval_evaluator.hpp's matching comment
+// for the full rationale (no registry parameter threaded through the
+// constructor/Evaluate(), plain non-locking HashRegistry since all writes
+// finish before Evaluate() is first called from a GP worker thread). Only
+// real difference from IntervalUnaryFn/IntervalBinaryFn: every call here
+// takes the shared affine_context first — the context-threaded finalize
+// overload of PAPPUS_DEFINE_UNARY_OP is the only one either evaluator ever
+// calls (the bare affine_form<T>-only overload, without a context, is never
+// used here).
 using AffineUnaryFn  = std::function<pappus::affine_form<Operon::Scalar>(
     pappus::ops::affine_context<Operon::Scalar> const&, pappus::affine_form<Operon::Scalar> const&)>;
 using AffineBinaryFn = std::function<pappus::affine_form<Operon::Scalar>(
@@ -59,75 +61,18 @@ using AffineBinaryRegistry = HashRegistry<AffineBinaryFn>;
 // Direct registry access — see interval_evaluator.hpp's matching comment.
 // Prefer RegisterUnaryAffine/RegisterBinaryAffine over calling .Register()
 // on the registry returned here directly.
-inline auto AffineUnaryRules() -> AffineUnaryRegistry&
-{
-    static AffineUnaryRegistry registry;
-    return registry;
-}
-
-inline auto AffineBinaryRules() -> AffineBinaryRegistry&
-{
-    static AffineBinaryRegistry registry;
-    return registry;
-}
+OPERON_EXPORT auto AffineUnaryRules() -> AffineUnaryRegistry&;
+OPERON_EXPORT auto AffineBinaryRules() -> AffineBinaryRegistry&;
 
 // Registers the built-in unary/binary affine rules exactly once, mirroring
-// interval_evaluator.hpp's RegisterIntervalBuiltins(). Every rule is lifted
-// verbatim out of AffineEvaluator's old switch statement, each calling
-// `pappus::ops::xxx` fully qualified (see interval_evaluator.hpp for the ADL
-// rationale). A free function (not an AffineEvaluator member) so both
-// AffineEvaluator::Evaluate() and the public Register{Unary,Binary}Affine()
-// entry points below can call it — the latter must trigger it before
-// writing, for the same reason RegisterIntervalBuiltins() does: a user hash
-// colliding with a built-in should throw immediately at the user's own call
-// site, not later inside Evaluate().
-inline void RegisterAffineBuiltins()
-{
-    using Scalar = Operon::Scalar;
-    using Affine = pappus::affine_form<Scalar>;
-    using Context = pappus::ops::affine_context<Scalar>;
-    static auto const registered = [] {
-        auto& unary  = AffineUnaryRules();
-        auto& binary = AffineBinaryRules();
-
-        unary.Register(Operon::Hash(BuiltinOp::Square), [](Context const& ctx, Affine const& v) { return pappus::ops::square<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sqrt), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrt<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Exp), [](Context const& ctx, Affine const& v) { return pappus::ops::exp<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Log), [](Context const& ctx, Affine const& v) { return pappus::ops::log<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sin), [](Context const& ctx, Affine const& v) { return pappus::ops::sin<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cos), [](Context const& ctx, Affine const& v) { return pappus::ops::cos<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Tan), [](Context const& ctx, Affine const& v) { return pappus::ops::tan<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Asin), [](Context const& ctx, Affine const& v) { return pappus::ops::asin<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Acos), [](Context const& ctx, Affine const& v) { return pappus::ops::acos<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Atan), [](Context const& ctx, Affine const& v) { return pappus::ops::atan<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sinh), [](Context const& ctx, Affine const& v) { return pappus::ops::sinh<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cosh), [](Context const& ctx, Affine const& v) { return pappus::ops::cosh<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Tanh), [](Context const& ctx, Affine const& v) { return pappus::ops::tanh<Scalar>(ctx, v); });
-        // May throw if the domain crosses zero (requires Chebyshev V-shape).
-        unary.Register(Operon::Hash(BuiltinOp::Abs), [](Context const& ctx, Affine const& v) { return pappus::ops::abs<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrtabs<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Logabs), [](Context const& ctx, Affine const& v) { return pappus::ops::logabs<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cbrt), [](Context const& ctx, Affine const& v) { return pappus::ops::cbrt<Scalar>(ctx, v); });
-        // May throw if the domain includes values <= -1.
-        unary.Register(Operon::Hash(BuiltinOp::Log1p), [](Context const& ctx, Affine const& v) { return pappus::ops::log1p<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Floor), [](Context const& ctx, Affine const& v) { return pappus::ops::floor<Scalar>(ctx, v); });
-        unary.Register(Operon::Hash(BuiltinOp::Ceil), [](Context const& ctx, Affine const& v) { return pappus::ops::ceil<Scalar>(ctx, v); });
-
-        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Context const& ctx, Affine const& a, Affine const& b) {
-            return pappus::ops::pow<Scalar>(ctx, a, b);
-        });
-        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Context const& ctx, Affine const& a, Affine const& b) {
-            return pappus::ops::aq<Scalar>(ctx, a, b);
-        });
-        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Context const& ctx, Affine const& a, Affine const& b) {
-            auto absBase = pappus::ops::abs<Scalar>(ctx, a);
-            return pappus::ops::pow<Scalar>(ctx, absBase, b);
-        });
-
-        return true;
-    }();
-    static_cast<void>(registered);
-}
+// interval_evaluator.hpp's RegisterIntervalBuiltins(). A free function (not
+// an AffineEvaluator member) so both AffineEvaluator::Evaluate() and the
+// public Register{Unary,Binary}Affine() entry points below can call it — the
+// latter must trigger it before writing, for the same reason
+// RegisterIntervalBuiltins() does: a user hash colliding with a built-in
+// should throw immediately at the user's own call site, not later inside
+// Evaluate().
+OPERON_EXPORT void RegisterAffineBuiltins();
 
 // Register an affine callback for a unary function (built-in or
 // user-defined), keyed by the same hash the function's Node::HashValue
@@ -136,19 +81,17 @@ inline void RegisterAffineBuiltins()
 // today. Throws if `hash` is already registered (write-once) — including
 // when `hash` collides with a built-in, since RegisterAffineBuiltins() above
 // always runs first.
-inline void RegisterUnaryAffine(Operon::Hash hash, AffineUnaryFn fn)
-{
-    RegisterAffineBuiltins();
-    AffineUnaryRules().Register(hash, std::move(fn));
-}
+OPERON_EXPORT void RegisterUnaryAffine(Operon::Hash hash, AffineUnaryFn fn);
 
 // Register an affine callback for a binary function. See
 // RegisterUnaryAffine for the miss-behavior and built-in-collision notes.
-inline void RegisterBinaryAffine(Operon::Hash hash, AffineBinaryFn fn)
-{
-    RegisterAffineBuiltins();
-    AffineBinaryRules().Register(hash, std::move(fn));
-}
+OPERON_EXPORT void RegisterBinaryAffine(Operon::Hash hash, AffineBinaryFn fn);
+
+// Query whether an affine callback is registered for `hash` (built-in or
+// user-defined), forcing built-in registration first. See
+// HasUnaryInterval/HasBinaryInterval for the coverage-check use case.
+OPERON_EXPORT auto HasUnaryAffine(Operon::Hash hash) -> bool;
+OPERON_EXPORT auto HasBinaryAffine(Operon::Hash hash) -> bool;
 
 // Forward affine-arithmetic bounds for an Operon tree over a single input
 // domain. Mirrors `IntervalEvaluator` but every `affine_form` shares one

--- a/include/operon/interpreter/interval_evaluator.hpp
+++ b/include/operon/interpreter/interval_evaluator.hpp
@@ -16,6 +16,7 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/types.hpp"
+#include "operon/operon_export.hpp"
 
 // pappus headers unconditionally redefine EXPECT/ENSURE (operon defines them
 // as ASSERT wrappers) and rely on a deprecated implicit copy ctor for
@@ -40,16 +41,16 @@
 namespace Operon {
 
 // Registered interval callbacks for unary/binary built-in or user-defined
-// functions, keyed by Node::HashValue. Global function-local-static
-// singletons (`inline` for one-definition-rule safety, since
-// IntervalEvaluator is a header-only class with no .cpp) mirroring the
-// pattern used by tree_diff.cpp's SymbolicDerivRegistry: no registry
-// parameter needs to thread through IntervalEvaluator's constructor or
-// Evaluate(). All writes (built-in registration below, plus any user calls
-// to RegisterUnaryInterval/RegisterBinaryInterval) happen before Evaluate()
-// is first called from a GP worker thread, so the plain (non-locking)
-// Operon::Map HashRegistry already uses is sufficient — no sharded-lock map
-// type needed, same read-only-after-setup contract DispatchTable relies on.
+// functions, keyed by Node::HashValue. Exported `.cpp`-backed singletons
+// (see interval_evaluator.cpp), matching the ownership model tree_diff.cpp's
+// SymbolicDerivRegistry and jit_compiler.cpp's JitCodegenRegistry already
+// use — no registry parameter needs to thread through IntervalEvaluator's
+// constructor or Evaluate(). All writes (built-in registration below, plus
+// any user calls to RegisterUnaryInterval/RegisterBinaryInterval) happen
+// before Evaluate() is first called from a GP worker thread, so the plain
+// (non-locking) Operon::Map HashRegistry already uses is sufficient — no
+// sharded-lock map type needed, same read-only-after-setup contract
+// DispatchTable relies on.
 //
 // Only two argument shapes are needed (not three, despite pappus's
 // PAPPUS_DEFINE_UNARY_OP macro generating three overloads per op): interval
@@ -61,82 +62,25 @@ using IntervalBinaryFn = std::function<pappus::interval<Operon::Scalar>(pappus::
 using IntervalUnaryRegistry  = HashRegistry<IntervalUnaryFn>;
 using IntervalBinaryRegistry = HashRegistry<IntervalBinaryFn>;
 
-// Direct registry access — needed by RegisterUnaryInterval/RegisterBinaryInterval
-// below (same TU) and by tests that assert on registration state. Prefer
-// RegisterUnaryInterval/RegisterBinaryInterval for registering a rule: calling
-// .Register() on the registry returned here directly skips the built-in
-// lazy-init those functions trigger first, reopening the ordering hazard they
-// exist to close (a user hash colliding with a built-in would be silently
-// accepted instead of throwing immediately).
-inline auto IntervalUnaryRules() -> IntervalUnaryRegistry&
-{
-    static IntervalUnaryRegistry registry;
-    return registry;
-}
-
-inline auto IntervalBinaryRules() -> IntervalBinaryRegistry&
-{
-    static IntervalBinaryRegistry registry;
-    return registry;
-}
+// Direct registry access — needed by tests that assert on registration
+// state. Prefer RegisterUnaryInterval/RegisterBinaryInterval for registering
+// a rule: calling .Register() on the registry returned here directly skips
+// the built-in lazy-init those functions trigger first, reopening the
+// ordering hazard they exist to close (a user hash colliding with a built-in
+// would be silently accepted instead of throwing immediately).
+OPERON_EXPORT auto IntervalUnaryRules() -> IntervalUnaryRegistry&;
+OPERON_EXPORT auto IntervalBinaryRules() -> IntervalBinaryRegistry&;
 
 // Registers the built-in unary/binary interval rules exactly once, mirroring
-// StandardLibrary::RegisterNames()'s lazy-static-lambda-once pattern. Every
-// rule is lifted verbatim out of IntervalEvaluator's old switch statement;
-// each lambda calls `pappus::ops::xxx` fully qualified rather than relying on
-// ADL, sidestepping the pappus::ops sibling-namespace ADL gap entirely (that
-// gap only bites a generic lambda expecting implicit lookup — these are
-// written inside operon's own code and can just spell out the qualified
-// name, same as the switch bodies already did). A free function (not an
-// IntervalEvaluator member) so both IntervalEvaluator::Evaluate() and the
-// public Register{Unary,Binary}Interval() entry points below can call it —
-// the latter must trigger it before writing, so that a user hash colliding
-// with a built-in throws immediately at the user's own call site instead of
-// being accepted now and only discovered (as a confusing, differently-hashed
-// throw) the first time Evaluate() runs.
-inline void RegisterIntervalBuiltins()
-{
-    using Scalar = Operon::Scalar;
-    using Interval = pappus::interval<Scalar>;
-    static auto const registered = [] {
-        auto& unary  = IntervalUnaryRules();
-        auto& binary = IntervalBinaryRules();
-
-        unary.Register(Operon::Hash(BuiltinOp::Square),  [](Interval const& v) { return pappus::ops::square<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sqrt),    [](Interval const& v) { return pappus::ops::sqrt<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Exp),     [](Interval const& v) { return pappus::ops::exp<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Log),     [](Interval const& v) { return pappus::ops::log<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sin),     [](Interval const& v) { return pappus::ops::sin<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cos),     [](Interval const& v) { return pappus::ops::cos<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Tan),     [](Interval const& v) { return pappus::ops::tan<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Asin),    [](Interval const& v) { return pappus::ops::asin<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Acos),    [](Interval const& v) { return pappus::ops::acos<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Atan),    [](Interval const& v) { return pappus::ops::atan<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sinh),    [](Interval const& v) { return pappus::ops::sinh<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cosh),    [](Interval const& v) { return pappus::ops::cosh<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Tanh),    [](Interval const& v) { return pappus::ops::tanh<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Abs),     [](Interval const& v) { return pappus::ops::abs<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Interval const& v) { return pappus::ops::sqrtabs<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Logabs),  [](Interval const& v) { return pappus::ops::logabs<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Cbrt),    [](Interval const& v) { return pappus::ops::cbrt<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Log1p),   [](Interval const& v) { return pappus::ops::log1p<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Floor),   [](Interval const& v) { return pappus::ops::floor<Scalar>(v); });
-        unary.Register(Operon::Hash(BuiltinOp::Ceil),    [](Interval const& v) { return pappus::ops::ceil<Scalar>(v); });
-
-        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Interval const& a, Interval const& b) {
-            return pappus::ops::pow<Scalar>(a, b);
-        });
-        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Interval const& a, Interval const& b) {
-            return pappus::ops::aq<Scalar>(a, b);
-        });
-        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Interval const& a, Interval const& b) {
-            return pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(a), b);
-        });
-
-        return true;
-    }();
-    static_cast<void>(registered);
-}
+// StandardLibrary::RegisterNames()'s lazy-static-lambda-once pattern. A free
+// function (not an IntervalEvaluator member) so both
+// IntervalEvaluator::Evaluate() and the public Register{Unary,Binary}Interval()
+// entry points below can call it — the latter must trigger it before
+// writing, so that a user hash colliding with a built-in throws immediately
+// at the user's own call site instead of being accepted now and only
+// discovered (as a confusing, differently-hashed throw) the first time
+// Evaluate() runs.
+OPERON_EXPORT void RegisterIntervalBuiltins();
 
 // Register an interval callback for a unary function (built-in or
 // user-defined), keyed by the same hash the function's Node::HashValue
@@ -146,19 +90,19 @@ inline void RegisterIntervalBuiltins()
 // today. Throws if `hash` is already registered (write-once) — including
 // when `hash` collides with a built-in, since RegisterIntervalBuiltins()
 // above always runs first.
-inline void RegisterUnaryInterval(Operon::Hash hash, IntervalUnaryFn fn)
-{
-    RegisterIntervalBuiltins();
-    IntervalUnaryRules().Register(hash, std::move(fn));
-}
+OPERON_EXPORT void RegisterUnaryInterval(Operon::Hash hash, IntervalUnaryFn fn);
 
 // Register an interval callback for a binary function. See
 // RegisterUnaryInterval for the miss-behavior and built-in-collision notes.
-inline void RegisterBinaryInterval(Operon::Hash hash, IntervalBinaryFn fn)
-{
-    RegisterIntervalBuiltins();
-    IntervalBinaryRules().Register(hash, std::move(fn));
-}
+OPERON_EXPORT void RegisterBinaryInterval(Operon::Hash hash, IntervalBinaryFn fn);
+
+// Query whether an interval callback is registered for `hash` (built-in or
+// user-defined), forcing built-in registration first. Mainly useful for
+// coverage checks (e.g. asserting every BuiltinOp is either registered here
+// or deliberately excluded as a structural n-ary case handled directly in
+// IntervalEvaluator::Evaluate()). Mirrors HasUnaryJitCodegen/HasBinaryJitCodegen.
+OPERON_EXPORT auto HasUnaryInterval(Operon::Hash hash) -> bool;
+OPERON_EXPORT auto HasBinaryInterval(Operon::Hash hash) -> bool;
 
 // Forward rigorous bounds for an Operon tree over a single input domain.
 //

--- a/source/interpreter/affine_evaluator.cpp
+++ b/source/interpreter/affine_evaluator.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/interpreter/affine_evaluator.hpp"
+
+namespace Operon {
+
+auto AffineUnaryRules() -> AffineUnaryRegistry&
+{
+    static AffineUnaryRegistry registry;
+    return registry;
+}
+
+auto AffineBinaryRules() -> AffineBinaryRegistry&
+{
+    static AffineBinaryRegistry registry;
+    return registry;
+}
+
+void RegisterAffineBuiltins()
+{
+    using Scalar = Operon::Scalar;
+    using Affine = pappus::affine_form<Scalar>;
+    using Context = pappus::ops::affine_context<Scalar>;
+    static auto const registered = [] {
+        auto& unary  = AffineUnaryRules();
+        auto& binary = AffineBinaryRules();
+
+        unary.Register(Operon::Hash(BuiltinOp::Square), [](Context const& ctx, Affine const& v) { return pappus::ops::square<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrt), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrt<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Exp), [](Context const& ctx, Affine const& v) { return pappus::ops::exp<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log), [](Context const& ctx, Affine const& v) { return pappus::ops::log<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sin), [](Context const& ctx, Affine const& v) { return pappus::ops::sin<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cos), [](Context const& ctx, Affine const& v) { return pappus::ops::cos<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tan), [](Context const& ctx, Affine const& v) { return pappus::ops::tan<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Asin), [](Context const& ctx, Affine const& v) { return pappus::ops::asin<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Acos), [](Context const& ctx, Affine const& v) { return pappus::ops::acos<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Atan), [](Context const& ctx, Affine const& v) { return pappus::ops::atan<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sinh), [](Context const& ctx, Affine const& v) { return pappus::ops::sinh<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cosh), [](Context const& ctx, Affine const& v) { return pappus::ops::cosh<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tanh), [](Context const& ctx, Affine const& v) { return pappus::ops::tanh<Scalar>(ctx, v); });
+        // May throw if the domain crosses zero (requires Chebyshev V-shape).
+        unary.Register(Operon::Hash(BuiltinOp::Abs), [](Context const& ctx, Affine const& v) { return pappus::ops::abs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Context const& ctx, Affine const& v) { return pappus::ops::sqrtabs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Logabs), [](Context const& ctx, Affine const& v) { return pappus::ops::logabs<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cbrt), [](Context const& ctx, Affine const& v) { return pappus::ops::cbrt<Scalar>(ctx, v); });
+        // May throw if the domain includes values <= -1.
+        unary.Register(Operon::Hash(BuiltinOp::Log1p), [](Context const& ctx, Affine const& v) { return pappus::ops::log1p<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Floor), [](Context const& ctx, Affine const& v) { return pappus::ops::floor<Scalar>(ctx, v); });
+        unary.Register(Operon::Hash(BuiltinOp::Ceil), [](Context const& ctx, Affine const& v) { return pappus::ops::ceil<Scalar>(ctx, v); });
+
+        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Context const& ctx, Affine const& a, Affine const& b) {
+            return pappus::ops::pow<Scalar>(ctx, a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Context const& ctx, Affine const& a, Affine const& b) {
+            return pappus::ops::aq<Scalar>(ctx, a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Context const& ctx, Affine const& a, Affine const& b) {
+            auto absBase = pappus::ops::abs<Scalar>(ctx, a);
+            return pappus::ops::pow<Scalar>(ctx, absBase, b);
+        });
+
+        return true;
+    }();
+    static_cast<void>(registered);
+}
+
+void RegisterUnaryAffine(Operon::Hash hash, AffineUnaryFn fn)
+{
+    RegisterAffineBuiltins();
+    AffineUnaryRules().Register(hash, std::move(fn));
+}
+
+void RegisterBinaryAffine(Operon::Hash hash, AffineBinaryFn fn)
+{
+    RegisterAffineBuiltins();
+    AffineBinaryRules().Register(hash, std::move(fn));
+}
+
+auto HasUnaryAffine(Operon::Hash hash) -> bool
+{
+    RegisterAffineBuiltins();
+    return AffineUnaryRules().Contains(hash);
+}
+
+auto HasBinaryAffine(Operon::Hash hash) -> bool
+{
+    RegisterAffineBuiltins();
+    return AffineBinaryRules().Contains(hash);
+}
+
+} // namespace Operon

--- a/source/interpreter/interval_evaluator.cpp
+++ b/source/interpreter/interval_evaluator.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include "operon/interpreter/interval_evaluator.hpp"
+
+namespace Operon {
+
+auto IntervalUnaryRules() -> IntervalUnaryRegistry&
+{
+    static IntervalUnaryRegistry registry;
+    return registry;
+}
+
+auto IntervalBinaryRules() -> IntervalBinaryRegistry&
+{
+    static IntervalBinaryRegistry registry;
+    return registry;
+}
+
+void RegisterIntervalBuiltins()
+{
+    using Scalar = Operon::Scalar;
+    using Interval = pappus::interval<Scalar>;
+    static auto const registered = [] {
+        auto& unary  = IntervalUnaryRules();
+        auto& binary = IntervalBinaryRules();
+
+        unary.Register(Operon::Hash(BuiltinOp::Square),  [](Interval const& v) { return pappus::ops::square<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrt),    [](Interval const& v) { return pappus::ops::sqrt<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Exp),     [](Interval const& v) { return pappus::ops::exp<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log),     [](Interval const& v) { return pappus::ops::log<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sin),     [](Interval const& v) { return pappus::ops::sin<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cos),     [](Interval const& v) { return pappus::ops::cos<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tan),     [](Interval const& v) { return pappus::ops::tan<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Asin),    [](Interval const& v) { return pappus::ops::asin<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Acos),    [](Interval const& v) { return pappus::ops::acos<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Atan),    [](Interval const& v) { return pappus::ops::atan<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sinh),    [](Interval const& v) { return pappus::ops::sinh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cosh),    [](Interval const& v) { return pappus::ops::cosh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Tanh),    [](Interval const& v) { return pappus::ops::tanh<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Abs),     [](Interval const& v) { return pappus::ops::abs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Sqrtabs), [](Interval const& v) { return pappus::ops::sqrtabs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Logabs),  [](Interval const& v) { return pappus::ops::logabs<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Cbrt),    [](Interval const& v) { return pappus::ops::cbrt<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Log1p),   [](Interval const& v) { return pappus::ops::log1p<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Floor),   [](Interval const& v) { return pappus::ops::floor<Scalar>(v); });
+        unary.Register(Operon::Hash(BuiltinOp::Ceil),    [](Interval const& v) { return pappus::ops::ceil<Scalar>(v); });
+
+        binary.Register(Operon::Hash(BuiltinOp::Pow), [](Interval const& a, Interval const& b) {
+            return pappus::ops::pow<Scalar>(a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Aq), [](Interval const& a, Interval const& b) {
+            return pappus::ops::aq<Scalar>(a, b);
+        });
+        binary.Register(Operon::Hash(BuiltinOp::Powabs), [](Interval const& a, Interval const& b) {
+            return pappus::ops::pow<Scalar>(pappus::ops::abs<Scalar>(a), b);
+        });
+
+        return true;
+    }();
+    static_cast<void>(registered);
+}
+
+void RegisterUnaryInterval(Operon::Hash hash, IntervalUnaryFn fn)
+{
+    RegisterIntervalBuiltins();
+    IntervalUnaryRules().Register(hash, std::move(fn));
+}
+
+void RegisterBinaryInterval(Operon::Hash hash, IntervalBinaryFn fn)
+{
+    RegisterIntervalBuiltins();
+    IntervalBinaryRules().Register(hash, std::move(fn));
+}
+
+auto HasUnaryInterval(Operon::Hash hash) -> bool
+{
+    RegisterIntervalBuiltins();
+    return IntervalUnaryRules().Contains(hash);
+}
+
+auto HasBinaryInterval(Operon::Hash hash) -> bool
+{
+    RegisterIntervalBuiltins();
+    return IntervalBinaryRules().Contains(hash);
+}
+
+} // namespace Operon

--- a/test/source/implementation/registry_coverage.cpp
+++ b/test/source/implementation/registry_coverage.cpp
@@ -80,16 +80,6 @@ TEST_CASE("Cross-registry coverage: symbolic-diff registry", "[registry][coverag
 
 TEST_CASE("Cross-registry coverage: interval/affine registries", "[registry][coverage]")
 {
-    // Force built-in registration (each evaluator populates its registries
-    // lazily on first Evaluate() call). Optimize=false so Evaluate({}) needs
-    // no coefficient span (Node::Constant() defaults Optimize=true as a leaf).
-    auto constNode = Node::Constant(1.0F);
-    constNode.Optimize = false;
-    Operon::Tree dummy{{constNode}};
-    Operon::IntervalEvaluator::DomainMap noDomains;
-    static_cast<void>(IntervalEvaluator{&dummy, noDomains}.Evaluate({}));
-    static_cast<void>(AffineEvaluator{&dummy, noDomains}.Evaluate({}));
-
     auto const& deliberatelyAbsent = NaryFolds();
 
     for (std::size_t i = 0; i < Operon::BuiltinOpCount; ++i) {

--- a/test/source/implementation/registry_coverage.cpp
+++ b/test/source/implementation/registry_coverage.cpp
@@ -97,10 +97,10 @@ TEST_CASE("Cross-registry coverage: interval/affine registries", "[registry][cov
         auto const hash = static_cast<Operon::Hash>(op);
         bool const expectAbsent = std::ranges::find(deliberatelyAbsent, op) != deliberatelyAbsent.end();
 
-        bool const inInterval = Operon::IntervalUnaryRules().Contains(hash)
-            || Operon::IntervalBinaryRules().Contains(hash);
-        bool const inAffine = Operon::AffineUnaryRules().Contains(hash)
-            || Operon::AffineBinaryRules().Contains(hash);
+        bool const inInterval = Operon::HasUnaryInterval(hash)
+            || Operon::HasBinaryInterval(hash);
+        bool const inAffine = Operon::HasUnaryAffine(hash)
+            || Operon::HasBinaryAffine(hash);
 
         INFO("op: " << OpName(op));
         CHECK(inInterval == !expectAbsent);


### PR DESCRIPTION
The four registry-based systems (symbolic-diff, interval, affine, JIT
codegen) split into two ownership models: symbolic-diff and JIT use
exported `.cpp`-backed singletons, while interval and affine used
header-inline function-local statics with no `.cpp` counterpart. Only
symbolic-diff and JIT exposed `Has*` predicates for coverage checks.

This PR moves `IntervalUnaryRules`/`IntervalBinaryRules`/
`RegisterIntervalBuiltins`/`RegisterUnaryInterval`/`RegisterBinaryInterval`
(and the affine equivalents) out of the two headers into new
`source/interpreter/interval_evaluator.cpp` and
`source/interpreter/affine_evaluator.cpp`, declared `OPERON_EXPORT` in the
headers exactly like `tree_diff.hpp`/`tree_diff.cpp` and
`jit_compiler.hpp`/`jit_compiler.cpp` already do. Adds
`HasUnaryInterval`/`HasBinaryInterval`/`HasUnaryAffine`/`HasBinaryAffine`
for parity, and switches `registry_coverage.cpp`'s interval/affine
coverage test and `composed_function.hpp`'s duplicate-registration
preflight check to use them instead of calling `.Contains()` on the raw
registry accessors directly.

No behavioral change — same registration/lookup semantics, same built-in
rule set, just relocated and given the missing predicate API.

Closes #143