### PR TITLE
fix(zobrist): remove dead FitnessEntry::Visits field

### DIFF
--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -160,7 +160,9 @@ public:
     // Returns true and fills `val` if the hash is found; thread-safe.
     [[nodiscard]] auto TryGet(Hash hash, Value& val) const -> bool;
 
-    // Inserts or increments the visit counter; thread-safe.
+    // Inserts a newly-computed value for `hash`; thread-safe. A concurrent
+    // race inserting the same hash first is not an error - the existing
+    // entry's value is kept (first writer wins).
     auto Insert(Hash hash, Value const& val) -> void;
 
     // Clears the transposition table and resets the hit counter.

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -30,7 +30,6 @@ struct CacheEntry : Data... {};
 // Fitness value produced by the evaluator after local search.
 struct FitnessData {
     Vector<Scalar>  Value;
-    std::size_t     Visits{1};
 };
 
 using FitnessEntry = CacheEntry<FitnessData>;

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -38,8 +38,12 @@ auto Zobrist::TryGet(Operon::Hash hash, Value& val) const -> bool
 
 auto Zobrist::Insert(Operon::Hash hash, Value const& val) -> void
 {
+    // Insert is only ever called after a TryGet miss on this same hash, so
+    // the "already exists" branch only fires on a genuine race (another
+    // thread inserted the same newly-seen hash first) - keep that entry's
+    // value (first writer wins), nothing else to do.
     tt_->Cache.LazyEmplace(hash,
-        [](FitnessEntry& e) -> void { ++e.Visits; },
+        [](FitnessEntry&) -> void { },
         [&](FitnessEntry& e) -> void { e.Value = val; }
     );
 }

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -188,7 +188,7 @@ TEST_CASE("Zobrist - Lookups counts every TryGet call regardless of outcome", "[
     REQUIRE(cache.Hits() >= 2);
 }
 
-TEST_CASE("Zobrist - duplicate inserts increment count, not entries", "[zobrist]")
+TEST_CASE("Zobrist - duplicate inserts collapse to one entry", "[zobrist]")
 {
     auto [ds, inputs, pset] = MakeSetup();
     Operon::RandomGenerator rng(Seed);


### PR DESCRIPTION
## Summary
`FitnessEntry::Visits` tracked the wrong thing: `Insert` only ever runs after a confirmed `TryGet` miss, so its "already exists" branch (the only place `Visits` was incremented) only fires on an insert-time race between threads computing the same newly-seen hash concurrently — never on ordinary cache reuse via `TryGet` hits, which never touched the field. Combined with zero consumers anywhere in the codebase and no test coverage, the field was dead weight.

Removes the field and its increment; `Insert`'s race-branch lambda is now a documented no-op (first writer wins, matching existing behavior minus the bookkeeping). Updates the header doc-comment and a test case name that referenced the removed visit counter.

## Test plan
- [x] `nix develop --command cmake --build build-ws`
- [x] `./build-ws/test/operon_test` — 22,173 assertions, 305 test cases, all pass
- [x] `./build-ws/test/operon_test "[zobrist]"` — 36 assertions, 13 test cases, all pass (post doc/test-name fixup)