### PR TITLE
Add generation-based expiry for the Zobrist transposition cache

### DIFF
--- a/cli/source/jit_setup.cpp
+++ b/cli/source/jit_setup.cpp
@@ -21,7 +21,8 @@ auto MakeJitObjects(
     [[maybe_unused]] int                           jitMaxLength,
     [[maybe_unused]] std::size_t                   jitMinVisits,
     [[maybe_unused]] int                           maxLength,
-    [[maybe_unused]] std::size_t                   seed
+    [[maybe_unused]] std::size_t                   seed,
+    [[maybe_unused]] std::size_t                   cacheMaxAge
 ) -> JitObjects {
 #if !defined(HAVE_ASMJIT)
     fmt::print(stderr, "error: --jit requires a build with JIT support (HAVE_ASMJIT)\n");
@@ -30,7 +31,7 @@ auto MakeJitObjects(
     auto [metric, supportsLinearScale] = Operon::ParseErrorMetric(objective);
     auto j = Operon::JIT::MakeJitObjects(
         jitMode, problem, dtable, *metric, linearScaling && supportsLinearScale,
-        maxLength, jitMaxLength, jitMinVisits, seed);
+        maxLength, jitMaxLength, jitMinVisits, seed, cacheMaxAge);
     return JitObjects{
         .Evaluator      = std::move(j.Evaluator),
         .OptimizerJacEval = std::move(j.OptimizerJacEval),

--- a/cli/source/jit_setup.hpp
+++ b/cli/source/jit_setup.hpp
@@ -40,7 +40,8 @@ auto MakeJitObjects(
     int                         jitMaxLength,
     std::size_t                 jitMinVisits,
     int                         maxLength,
-    std::size_t                 seed
+    std::size_t                 seed,
+    std::size_t                 cacheMaxAge = 0
 ) -> JitObjects;
 
 } // namespace Operon::CLI

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -174,7 +174,7 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
         if (jitMode.empty()) {
             if (result["transposition-cache"].as<bool>()) {
                 Operon::RandomGenerator cacheRng(config.Seed);
-                zobrist = std::make_unique<Operon::Zobrist>(cacheRng, static_cast<int>(maxLength), problem.GetInputs());
+                zobrist = std::make_unique<Operon::Zobrist>(cacheRng, static_cast<int>(maxLength), problem.GetInputs(), result["cache-max-age"].as<size_t>());
                 config.Cache = zobrist.get();
             }
             evaluator = Operon::ParseEvaluator(result["objective"].as<std::string>(), problem, dtable, scale);

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -185,7 +185,8 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
                 result["objective"].as<std::string>(), scale,
                 result["jit-max-length"].as<int>(),
                 result["jit-min-visits"].as<std::size_t>(),
-                static_cast<int>(maxLength), config.Seed);
+                static_cast<int>(maxLength), config.Seed,
+                result["cache-max-age"].as<std::size_t>());
             if (jobj.Error) { return EXIT_FAILURE; }
             evaluator     = std::move(jobj.Evaluator);
             jacEvalStorage = std::move(jobj.OptimizerJacEval);

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -242,7 +242,8 @@ auto main(int argc, char** argv) -> int
                 result["objective"].as<std::string>(), scale,
                 result["jit-max-length"].as<int>(),
                 result["jit-min-visits"].as<std::size_t>(),
-                static_cast<int>(maxLength), config.Seed);
+                static_cast<int>(maxLength), config.Seed,
+                result["cache-max-age"].as<std::size_t>());
             if (jobj.Error) { return EXIT_FAILURE; }
             errorEvaluator = std::move(jobj.Evaluator);
             jacEvalStorage = std::move(jobj.OptimizerJacEval);

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -231,7 +231,7 @@ auto main(int argc, char** argv) -> int
         if (jitMode.empty()) {
             if (result["transposition-cache"].as<bool>()) {
                 Operon::RandomGenerator cacheRng(config.Seed);
-                zobrist = std::make_unique<Operon::Zobrist>(cacheRng, static_cast<int>(maxLength), problem.GetInputs());
+                zobrist = std::make_unique<Operon::Zobrist>(cacheRng, static_cast<int>(maxLength), problem.GetInputs(), result["cache-max-age"].as<size_t>());
                 config.Cache = zobrist.get();
             }
             errorEvaluator = Operon::ParseEvaluator(result["objective"].as<std::string>(), problem, dtable, scale);

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -189,6 +189,7 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("threads", "Number of threads to use for parallelism", cxxopts::value<size_t>()->default_value("0"))
         ("timelimit", "Time limit after which the algorithm will terminate", cxxopts::value<size_t>()->default_value(std::to_string(std::numeric_limits<size_t>::max())))
         ("transposition-cache", "Cache fitness values keyed by Zobrist hash of tree structure; most effective with coefficient optimization enabled", cxxopts::value<bool>()->default_value("false"))
+        ("cache-max-age", "Expire transposition cache entries older than this many generations (0 = never expire); only effective with --transposition-cache", cxxopts::value<size_t>()->default_value("0"))
         ("pareto-front", "Write rank-0 Pareto front to this JSON file after the run (only effective with Pareto-based algorithms, e.g. operon_nsgp)", cxxopts::value<std::string>())
         ("model-selection", "Pareto front model selection: obj0 (lowest first objective), mdl, bic, aic", cxxopts::value<std::string>()->default_value("obj0"))
         ("mdl-likelihood", "Likelihood for MDL/BIC/AIC model selection: gaussian or poisson", cxxopts::value<std::string>()->default_value("gaussian"))

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -222,6 +222,14 @@ auto ResumeFromCheckpoint(GeneticAlgorithmBase& algo, RandomGenerator& rng,
     }
     rng.set_state(cp->RngState);
     algo.Generation() = cp->Generation;
+    // The cache's own generation clock always starts at 0 for a freshly
+    // constructed Zobrist, regardless of the checkpoint's generation - align
+    // it here so the resumed population's re-evaluation (which runs before
+    // the GA loop's own SetGeneration(Generation() + 1) call) is stamped
+    // with the resumed generation instead of 0, which would otherwise make
+    // every entry read as ancient (and get evicted) the moment the loop
+    // advances the clock past the checkpoint's generation.
+    if (auto* cache = config.Cache) { cache->SetGeneration(cp->Generation); }
     auto parents = algo.Parents();
     for (std::size_t i = 0; i < cp->Population.size(); ++i) {
         parents[i] = std::move(cp->Population[i]);

--- a/include/operon/hash/zobrist.hpp
+++ b/include/operon/hash/zobrist.hpp
@@ -30,6 +30,7 @@ struct CacheEntry : Data... {};
 // Fitness value produced by the evaluator after local search.
 struct FitnessData {
     Vector<Scalar>  Value;
+    std::uint32_t   InsertGeneration{0};
 };
 
 using FitnessEntry = CacheEntry<FitnessData>;
@@ -59,6 +60,11 @@ public:
             [&](auto& kv)         { std::forward<OnExisting>(onExisting)(kv.second); },
             [&](auto const& ctor) { Entry e{}; std::forward<OnNew>(onNew)(e); ctor(h, std::move(e)); }
         );
+    }
+
+    template<typename Pred>
+    auto EraseIf(Hash h, Pred&& pred) -> std::size_t {
+        return map_.erase_if(h, [&](auto const& kv) { return pred(kv.second); });
     }
 
     [[nodiscard]] auto Size() const -> std::size_t { return map_.size(); }
@@ -108,11 +114,22 @@ class OPERON_EXPORT Zobrist {
     mutable std::atomic<std::size_t> hits_{0};
     mutable std::atomic<std::size_t> lookups_{0};
 
+    // Generation clock ticked by the GA loop (see gp.cpp/nsga2.cpp) once per
+    // generation. Used only to lazily expire stale entries in TryGet - see
+    // maxAge_ below. Not related to hits_/lookups_.
+    mutable std::atomic<std::uint32_t> clock_{0};
+
+    // 0 disables age-based expiry (default, today's unbounded behavior).
+    // Otherwise, an entry older than maxAge_ generations is treated as a
+    // miss by TryGet and removed - see TryGet's implementation for why this
+    // is a pragmatic freshness/evolvability mitigation, not a memory bound.
+    std::size_t maxAge_{0};
+
 public:
     // variableHashes must include every variable hash that can appear in a tree.
     // Each variable gets its own row of independent random values so that
     // permuting variables at different positions always yields a different hash.
-    Zobrist(RandomGenerator& rng, int maxLength, Span<Hash const> variableHashes);
+    Zobrist(RandomGenerator& rng, int maxLength, Span<Hash const> variableHashes, std::size_t maxAge = 0);
     virtual ~Zobrist();
     Zobrist(Zobrist const&)            = delete;
     Zobrist(Zobrist&&)                 = delete;
@@ -169,6 +186,10 @@ public:
     // NOT safe to call concurrently with TryGet or Insert — call only after
     // the algorithm has fully stopped (e.g. after GeneticAlgorithm::Run returns).
     auto Clear() -> void;
+
+    // Advances the generation clock used by TryGet's age-based expiry.
+    // Thread-safe; called once per generation from the GA loop.
+    auto SetGeneration(std::size_t generation) -> void;
 
     [[nodiscard]] auto Hits() const -> std::size_t { return hits_.load(std::memory_order_relaxed); }
     // Total TryGet() calls regardless of outcome - the denominator Hits()

--- a/include/operon/interpreter/backend/jit/jit_evaluator.hpp
+++ b/include/operon/interpreter/backend/jit/jit_evaluator.hpp
@@ -38,7 +38,7 @@ class OPERON_EXPORT JitZobrist final : public Operon::Zobrist {
     mutable Operon::ZobristCache<JitEntry> cache_;     // destroyed first
 public:
     JitZobrist(Operon::RandomGenerator& rng, int maxLength,
-               Operon::Span<Operon::Hash const> variableHashes);
+               Operon::Span<Operon::Hash const> variableHashes, std::size_t maxAge = 0);
     ~JitZobrist() override = default;
 
     [[nodiscard]] auto JitCache() const -> Operon::ZobristCache<JitEntry>& { return cache_; }

--- a/include/operon/interpreter/backend/jit/jit_factory.hpp
+++ b/include/operon/interpreter/backend/jit/jit_factory.hpp
@@ -45,7 +45,8 @@ OPERON_EXPORT auto MakeJitObjects(
     int                       maxLength,
     int                       jitMaxLength,
     std::size_t               jitMinVisits,
-    std::size_t               seed
+    std::size_t               seed,
+    std::size_t               cacheMaxAge = 0
 ) -> JitObjects;
 
 } // namespace Operon::JIT

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -115,7 +115,15 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
             // (reinserter.hpp) - it protects the top EliteCount() parents
             // before reinsert() runs, so no offspring slot needs to be
             // reserved for a hand-picked elite here anymore.
-            auto prepareGenerator = subflow.emplace([&]() -> void { generator->Prepare(parents); }).name("prepare generator");
+            auto prepareGenerator = subflow.emplace([&]() -> void {
+                                        generator->Prepare(parents);
+                                        // Stamp the cache clock with the generation offspring will
+                                        // belong to *before* they're evaluated - Generation() itself
+                                        // isn't incremented until after reinsert() below, so without
+                                        // this the cache would stamp entries with the prior
+                                        // generation's number (see incrementGeneration).
+                                        if (auto* cache = config.Cache) { cache->SetGeneration(Generation() + 1); }
+                                    }).name("prepare generator");
             auto generateOffspring = subflow.for_each_index(size_t { 0 }, offspring.size(), size_t { 1 }, [&](size_t i) -> void {
                                                 slots[executor.this_worker_id()].resize(trainSize);
                                                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -215,7 +215,15 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
         }, // init
         stop, // loop condition
         [&, timer](tf::Subflow& subflow) -> void {
-            auto prepareGenerator = subflow.emplace([&]() -> void { generator->Prepare(parents); }).name("prepare generator");
+            auto prepareGenerator = subflow.emplace([&]() -> void {
+                                        generator->Prepare(parents);
+                                        // Stamp the cache clock with the generation offspring will
+                                        // belong to *before* they're evaluated - Generation() itself
+                                        // isn't incremented until after reinsert() below, so without
+                                        // this the cache would stamp entries with the prior
+                                        // generation's number (see incrementGeneration).
+                                        if (auto* cache = config.Cache) { cache->SetGeneration(Generation() + 1); }
+                                    }).name("prepare generator");
             auto generateOffspring = subflow.for_each_index(size_t { 0 }, offspring.size(), size_t { 1 }, [&](size_t i) -> void {
                                                 slots[executor.this_worker_id()].resize(trainSize);
                                                 auto buf = Operon::Span<Operon::Scalar>(slots[executor.this_worker_id()]);

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -5,6 +5,7 @@
 #include "operon/hash/zobrist.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 
 namespace Operon {
@@ -88,6 +89,10 @@ auto Zobrist::Clear() -> void
 
 auto Zobrist::SetGeneration(std::size_t generation) -> void
 {
+    // A run with more than 2^32-1 generations is not realistic, but a
+    // silent truncation here would otherwise be a very hard-to-diagnose
+    // wraparound bug in the age-based expiry.
+    ENSURE(generation <= std::numeric_limits<std::uint32_t>::max());
     clock_.store(static_cast<std::uint32_t>(generation), std::memory_order_relaxed);
 }
 

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -13,9 +13,10 @@ struct Zobrist::TranspositionTable {
     ZobristCache<FitnessEntry> Cache;
 };
 
-Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes)
+Zobrist::Zobrist(Operon::RandomGenerator& rng, int maxLength, Operon::Span<Operon::Hash const> variableHashes, std::size_t maxAge)
     : table_(static_cast<int>(variableHashes.size()) + 1, maxLength)
     , tt_(std::make_unique<TranspositionTable>())
+    , maxAge_(maxAge)
 {
     std::generate(table_.container().begin(), table_.container().end(), std::ref(rng));
     for (int i = 0; std::cmp_less(i, variableHashes.size()); ++i) {
@@ -31,7 +32,32 @@ auto Zobrist::TryGet(Operon::Hash hash, Value& val) const -> bool
     // on anything else, and TryGet is in the per-individual evaluation hot
     // path - the default seq_cst RMW would tax every lookup for no benefit.
     lookups_.fetch_add(1, std::memory_order_relaxed);
-    bool const found = tt_->Cache.IfContains(hash, [&](FitnessEntry const& e) -> void { val = e.Value; });
+
+    bool found = false;
+    bool stale = false;
+    std::uint32_t observedGen = 0;
+    tt_->Cache.IfContains(hash, [&](FitnessEntry const& e) {
+        observedGen = e.InsertGeneration;
+        auto const now = clock_.load(std::memory_order_relaxed);
+        stale = maxAge_ > 0 && static_cast<std::size_t>(now - e.InsertGeneration) > maxAge_;
+        if (!stale) { val = e.Value; found = true; }
+    });
+
+    if (stale) {
+        // Conditional erase: only remove if it's STILL the same stale
+        // generation we observed. This is not about a concurrent Insert()
+        // on the entry we just saw - Insert()'s onExisting branch is a
+        // no-op, so it can't refresh InsertGeneration in place. The race
+        // this guards against is: another thread's TryGet erases this same
+        // stale entry first, then a concurrent Insert() recreates it fresh
+        // (onNew, new InsertGeneration) before we reach EraseIf here -
+        // without the generation recheck we'd delete that fresh entry
+        // instead of the stale one we actually observed.
+        tt_->Cache.EraseIf(hash, [&](FitnessEntry const& e) {
+            return e.InsertGeneration == observedGen;
+        });
+        return false; // treat as a miss - caller re-evaluates
+    }
     if (found) { hits_.fetch_add(1, std::memory_order_relaxed); }
     return found;
 }
@@ -42,9 +68,10 @@ auto Zobrist::Insert(Operon::Hash hash, Value const& val) -> void
     // the "already exists" branch only fires on a genuine race (another
     // thread inserted the same newly-seen hash first) - keep that entry's
     // value (first writer wins), nothing else to do.
+    auto const gen = clock_.load(std::memory_order_relaxed);
     tt_->Cache.LazyEmplace(hash,
         [](FitnessEntry&) -> void { },
-        [&](FitnessEntry& e) -> void { e.Value = val; }
+        [&](FitnessEntry& e) -> void { e.Value = val; e.InsertGeneration = gen; }
     );
 }
 
@@ -53,6 +80,11 @@ auto Zobrist::Clear() -> void
     tt_->Cache.Clear();
     hits_.store(0, std::memory_order_relaxed);
     lookups_.store(0, std::memory_order_relaxed);
+}
+
+auto Zobrist::SetGeneration(std::size_t generation) -> void
+{
+    clock_.store(static_cast<std::uint32_t>(generation), std::memory_order_relaxed);
 }
 
 auto Zobrist::Size() const -> std::size_t

--- a/source/hash/zobrist.cpp
+++ b/source/hash/zobrist.cpp
@@ -80,6 +80,10 @@ auto Zobrist::Clear() -> void
     tt_->Cache.Clear();
     hits_.store(0, std::memory_order_relaxed);
     lookups_.store(0, std::memory_order_relaxed);
+    // Otherwise a subsequent run's entries get stamped against a clock left
+    // over from before this Clear(), immediately reading as stale (or, on
+    // wraparound if the new run's generation is smaller, falsely fresh).
+    clock_.store(0, std::memory_order_relaxed);
 }
 
 auto Zobrist::SetGeneration(std::size_t generation) -> void

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -18,8 +18,8 @@
 namespace Operon::JIT {
 
 JitZobrist::JitZobrist(Operon::RandomGenerator& rng, int maxLength,
-                       Operon::Span<Operon::Hash const> variableHashes)
-    : Zobrist(rng, maxLength, variableHashes)
+                       Operon::Span<Operon::Hash const> variableHashes, std::size_t maxAge)
+    : Zobrist(rng, maxLength, variableHashes, maxAge)
 {}
 
 

--- a/source/interpreter/backend/jit/jit_factory.cpp
+++ b/source/interpreter/backend/jit/jit_factory.cpp
@@ -19,12 +19,13 @@ auto MakeJitObjects(
     int                           maxLength,
     int                           jitMaxLength,
     std::size_t                   jitMinVisits,
-    std::size_t                   seed
+    std::size_t                   seed,
+    std::size_t                   cacheMaxAge
 ) -> JitObjects {
     JitObjects out;
 
     Operon::RandomGenerator cacheRng(seed);
-    auto jz   = std::make_unique<JitZobrist>(cacheRng, maxLength, problem.GetInputs());
+    auto jz   = std::make_unique<JitZobrist>(cacheRng, maxLength, problem.GetInputs(), cacheMaxAge);
     auto* jzp = jz.get();
     out.Zobrist = std::move(jz);
 

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
+#include <atomic>
 #include <thread>
 
 #include <catch2/catch_test_macros.hpp>

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -342,13 +342,21 @@ TEST_CASE("Zobrist - a stale-triggered miss actually removes the entry", "[zobri
 
 TEST_CASE("Zobrist - an entry inserted after the clock is set to a high starting value (warm resume) is not immediately stale", "[zobrist]")
 {
-    // Regression test: on --resume, GeneticAlgorithmBase::Generation() is
+    // This verifies the Zobrist-level contract that CLI warm-resume relies
+    // on (SetGeneration() before re-caching avoids the immediate-eviction
+    // bug described below) - it does NOT regression-test the CLI wiring
+    // itself. That fix lives in cli/source/util.cpp's ResumeFromCheckpoint
+    // (calls cache->SetGeneration(cp->Generation) right after restoring
+    // algo.Generation(), before the resumed population is re-evaluated);
+    // cli/source/util.cpp isn't linked into this test binary (see
+    // test/CMakeLists.txt), so that call site has no automated regression
+    // coverage - only this narrower API-level guarantee does.
+    //
+    // Background: on --resume, GeneticAlgorithmBase::Generation() is
     // restored from the checkpoint, but a freshly constructed Zobrist always
-    // starts at clock_ == 0. CLI resume code must call SetGeneration() with
-    // the checkpoint's generation *before* re-evaluating/re-caching the
-    // resumed population, or those entries get stamped generation 0 and read
-    // as ancient the moment the GA loop advances the clock past the
-    // checkpoint's generation.
+    // starts at clock_ == 0. Without the fix above, resumed entries get
+    // stamped generation 0 and read as ancient the moment the GA loop
+    // advances the clock past the checkpoint's generation.
     auto [ds, inputs, pset] = MakeSetup();
     Operon::RandomGenerator rng(Seed);
     constexpr std::size_t maxAge = 5;
@@ -393,8 +401,11 @@ TEST_CASE("Zobrist - Clear resets the generation clock", "[zobrist]")
     cache.Clear();
     REQUIRE(cache.Size() == 0);
 
-    // A new "run" starts its own generation count from 0.
-    cache.SetGeneration(0);
+    // A new "run" starts its own generation count from 0. Deliberately do
+    // NOT call SetGeneration(0) here - the whole point is to check that
+    // Clear() itself already reset the clock; if it didn't, this Insert
+    // would be stamped 0 while clock_ is still 500, and TryGet below would
+    // immediately (falsely) evict it as 500 generations stale.
     cache.Insert(hash, val);
 
     Operon::Vector<Operon::Scalar> retrieved;

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
+#include <thread>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "../operon_test.hpp"
@@ -265,6 +267,177 @@ TEST_CASE("Zobrist - different Optimize flags yield different hashes", "[zobrist
     Tree const tree2 = Tree({ c2, Util::MakeOp<BuiltinOp::Sin>() }).UpdateNodes();
 
     REQUIRE(cache.ComputeHash(tree1) != cache.ComputeHash(tree2));
+}
+
+TEST_CASE("Zobrist - maxAge disabled (default) never expires entries", "[zobrist]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    Zobrist cache(rng, MaxLength, inputs); // maxAge defaults to 0 = disabled
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash, val);
+
+    // advance the clock far beyond any plausible age and confirm the entry
+    // is still considered fresh, since maxAge == 0 disables expiry entirely.
+    cache.SetGeneration(1'000'000);
+
+    Operon::Vector<Operon::Scalar> retrieved;
+    REQUIRE(cache.TryGet(hash, retrieved));
+    REQUIRE(cache.Size() == 1);
+}
+
+TEST_CASE("Zobrist - entry older than maxAge is treated as a miss", "[zobrist]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    constexpr std::size_t maxAge = 5;
+    Zobrist cache(rng, MaxLength, inputs, maxAge);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    cache.SetGeneration(0);
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash, val); // stamped with generation 0
+
+    cache.SetGeneration(maxAge + 1); // strictly older than maxAge
+
+    Operon::Vector<Operon::Scalar> retrieved;
+    REQUIRE_FALSE(cache.TryGet(hash, retrieved));
+}
+
+TEST_CASE("Zobrist - a stale-triggered miss actually removes the entry", "[zobrist]")
+{
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    constexpr std::size_t maxAge = 5;
+    Zobrist cache(rng, MaxLength, inputs, maxAge);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    cache.SetGeneration(0);
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash, val);
+    REQUIRE(cache.Size() == 1);
+
+    cache.SetGeneration(maxAge + 1);
+
+    Operon::Vector<Operon::Scalar> retrieved;
+    REQUIRE_FALSE(cache.TryGet(hash, retrieved)); // triggers the expiry-erase
+    REQUIRE(cache.Size() == 0);
+
+    // A subsequent lookup is a plain miss against an empty cache, not a
+    // repeated expiry - Lookups() should reflect two calls, no more erasing.
+    REQUIRE_FALSE(cache.TryGet(hash, retrieved));
+    REQUIRE(cache.Size() == 0);
+}
+
+TEST_CASE("Zobrist - EraseIf generation guard preserves a value refreshed between observation and erase", "[zobrist]")
+{
+    // Deterministic, single-threaded repro of the exact race TryGet's
+    // conditional EraseIf guards against: thread A observes a stale entry
+    // and records its InsertGeneration, but before A's erase runs, another
+    // thread erases that same entry and a third thread recreates it fresh
+    // (new InsertGeneration). A's erase, guarded by the generation it
+    // originally observed, must not remove the fresh entry that replaced it.
+    ZobristCache<FitnessEntry> cache;
+    Operon::Hash const hash = Operon::Hasher{}("erase-guard-repro");
+
+    cache.LazyEmplace(hash,
+        [](FitnessEntry&) {},
+        [](FitnessEntry& e) { e.Value = { Operon::Scalar{0.1} }; e.InsertGeneration = 5; });
+
+    // Thread A "observes" the entry while it's still stale at generation 5.
+    constexpr std::uint32_t observedGen = 5;
+
+    // Before A's erase runs: another thread erases the entry, then a third
+    // thread inserts a fresh one for the same hash at a later generation.
+    cache.EraseIf(hash, [](FitnessEntry const&) { return true; });
+    cache.LazyEmplace(hash,
+        [](FitnessEntry&) {},
+        [](FitnessEntry& e) { e.Value = { Operon::Scalar{0.9} }; e.InsertGeneration = 6; });
+
+    // A's delayed erase, guarded by the generation it originally observed -
+    // this must be a no-op now that the entry has moved on to generation 6.
+    cache.EraseIf(hash, [&](FitnessEntry const& e) { return e.InsertGeneration == observedGen; });
+
+    REQUIRE(cache.Size() == 1);
+    bool found = false;
+    cache.IfContains(hash, [&](FitnessEntry const& e) {
+        found = true;
+        REQUIRE(e.InsertGeneration == 6);
+        REQUIRE(e.Value[0] == Operon::Scalar{0.9});
+    });
+    REQUIRE(found);
+}
+
+TEST_CASE("Zobrist - concurrent readers racing an expiry-erase-then-reinsert never lose a fresh value", "[zobrist]")
+{
+    // Two reader threads (not one) are needed to exercise the guard's actual
+    // race under real scheduling: with a single reader, that reader is the
+    // only thread that can ever erase an entry, so "another thread erased it
+    // first, then it got recreated fresh before my erase ran" can never
+    // happen - see the deterministic "EraseIf generation guard..." test
+    // above for a targeted, guaranteed repro of that exact interleaving.
+    // This test additionally stresses it under real thread scheduling.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    constexpr std::size_t maxAge = 1;
+    Zobrist cache(rng, MaxLength, inputs, maxAge);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    cache.SetGeneration(0);
+    Operon::Vector<Operon::Scalar> const initial = { Operon::Scalar{0.1} };
+    cache.Insert(hash, initial);
+
+    std::atomic<bool> stop{false};
+    Operon::Vector<Operon::Scalar> const fresh = { Operon::Scalar{0.9} };
+
+    // Advance generations and keep re-inserting a fresh value for the same
+    // hash, racing against two reader threads that will observe stale
+    // entries and attempt to erase them - with two readers, one can erase
+    // an entry the other already observed as stale, before the other's own
+    // erase runs.
+    std::thread writer([&]() {
+        for (std::size_t g = 1; g < 2000; ++g) {
+            cache.SetGeneration(g);
+            cache.Insert(hash, fresh); // no-op if entry already fresh (LazyEmplace keeps existing)
+            if (stop.load(std::memory_order_relaxed)) { break; }
+        }
+    });
+
+    auto readerLoop = [&]() {
+        Operon::Vector<Operon::Scalar> tmp;
+        for (int i = 0; i < 2000; ++i) {
+            std::ignore = cache.TryGet(hash, tmp); // may observe stale + erase; must not crash
+        }
+    };
+    std::thread reader1(readerLoop);
+    std::thread reader2([&]() {
+        readerLoop();
+        stop.store(true, std::memory_order_relaxed);
+    });
+
+    writer.join();
+    reader1.join();
+    reader2.join();
+
+    // The hash must still resolve to *some* value afterward - a fresh
+    // Insert() right after an expiry-erase must never be permanently lost.
+    cache.Insert(hash, fresh);
+    Operon::Vector<Operon::Scalar> final;
+    REQUIRE(cache.TryGet(hash, final));
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/zobrist.cpp
+++ b/test/source/implementation/zobrist.cpp
@@ -340,6 +340,67 @@ TEST_CASE("Zobrist - a stale-triggered miss actually removes the entry", "[zobri
     REQUIRE(cache.Size() == 0);
 }
 
+TEST_CASE("Zobrist - an entry inserted after the clock is set to a high starting value (warm resume) is not immediately stale", "[zobrist]")
+{
+    // Regression test: on --resume, GeneticAlgorithmBase::Generation() is
+    // restored from the checkpoint, but a freshly constructed Zobrist always
+    // starts at clock_ == 0. CLI resume code must call SetGeneration() with
+    // the checkpoint's generation *before* re-evaluating/re-caching the
+    // resumed population, or those entries get stamped generation 0 and read
+    // as ancient the moment the GA loop advances the clock past the
+    // checkpoint's generation.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    constexpr std::size_t maxAge = 5;
+    Zobrist cache(rng, MaxLength, inputs, maxAge);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    constexpr std::size_t resumedGeneration = 500;
+    cache.SetGeneration(resumedGeneration); // as the fixed resume path does, before re-evaluation
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash, val);
+
+    // The GA loop's own SetGeneration(Generation() + 1) call follows next.
+    cache.SetGeneration(resumedGeneration + 1);
+
+    Operon::Vector<Operon::Scalar> retrieved;
+    REQUIRE(cache.TryGet(hash, retrieved));
+}
+
+TEST_CASE("Zobrist - Clear resets the generation clock", "[zobrist]")
+{
+    // Regression test: without resetting clock_, a Clear() between separate
+    // runs (e.g. sequential invocations sharing one Zobrist instance) leaves
+    // a stale-relative-to-nothing clock value; the next run's entries get
+    // stamped against generation 0 while the clock remains at the old run's
+    // high value, immediately reading as ancient.
+    auto [ds, inputs, pset] = MakeSetup();
+    Operon::RandomGenerator rng(Seed);
+    constexpr std::size_t maxAge = 5;
+    Zobrist cache(rng, MaxLength, inputs, maxAge);
+
+    BalancedTreeCreator const creator{&pset, inputs, /* bias= */ 0.0, MaxLength};
+    auto tree = creator(rng, 10, 1, MaxLength);
+    auto hash = cache.ComputeHash(tree);
+
+    cache.SetGeneration(500);
+    Operon::Vector<Operon::Scalar> const val = { Operon::Scalar{0.1} };
+    cache.Insert(hash, val);
+
+    cache.Clear();
+    REQUIRE(cache.Size() == 0);
+
+    // A new "run" starts its own generation count from 0.
+    cache.SetGeneration(0);
+    cache.Insert(hash, val);
+
+    Operon::Vector<Operon::Scalar> retrieved;
+    REQUIRE(cache.TryGet(hash, retrieved));
+}
+
 TEST_CASE("Zobrist - EraseIf generation guard preserves a value refreshed between observation and erase", "[zobrist]")
 {
     // Deterministic, single-threaded repro of the exact race TryGet's
@@ -433,8 +494,16 @@ TEST_CASE("Zobrist - concurrent readers racing an expiry-erase-then-reinsert nev
     reader1.join();
     reader2.join();
 
-    // The hash must still resolve to *some* value afterward - a fresh
-    // Insert() right after an expiry-erase must never be permanently lost.
+    // Whatever entry survived the race (if any) may legitimately be stale
+    // relative to wherever the clock landed - Insert() only stamps a fresh
+    // InsertGeneration when the entry didn't already exist (see the
+    // "first writer wins" comment on Insert()), so a leftover stale survivor
+    // would make a plain Insert()-then-TryGet flaky here, not indicative of
+    // a real bug. Clear() first (deterministically resets both the map and
+    // the clock) so the final check only asserts what it's meant to: a
+    // fresh Insert() after the race is never lost.
+    cache.Clear();
+    cache.SetGeneration(0);
     cache.Insert(hash, fresh);
     Operon::Vector<Operon::Scalar> final;
     REQUIRE(cache.TryGet(hash, final));


### PR DESCRIPTION
## Summary

Adds an optional generation-based (age) expiry to `Zobrist`, the fitness-value
transposition cache keyed by structural hash of a GP tree. Unbounded caching
can hurt evolvability late in a run by keeping stale fitness values around
indefinitely; entries older than `--cache-max-age` generations are now
treated as a cache miss and lazily evicted on lookup. Default is `0`
(disabled), preserving today's unbounded behavior.

- `FitnessData::InsertGeneration` + `Zobrist::clock_`/`SetGeneration()`,
  advanced once per generation from the GA loop (`gp.cpp`/`nsga2.cpp`)
  before offspring evaluation.
- `TryGet` treats an entry older than `maxAge` generations as a miss and
  removes it via a generation-guarded conditional erase (race-safe against
  a concurrent erase-and-reinsert of the same hash).
- New CLI flag `--cache-max-age`, wired through both the interpreter and
  JIT-backed (`--jit`) transposition-cache paths.
- `--resume` correctly aligns the cache clock with the checkpoint's
  generation before the resumed population is re-evaluated, and `Clear()`
  resets the clock, so neither path stamps entries against a stale clock.

## Test plan

- [x] Full static build (`cmake --build .`)
- [x] `operon_test '[zobrist]'` — 20 cases, 52 assertions, all passing
- [x] `operon_test '[jit]'` — 24 cases, all passing (confirms
      `--cache-max-age` reaches the JIT-backed cache too)