### PR TITLE
optimizer: make --iterations mean accepted steps consistently across backends

### DIFF
--- a/include/operon/ceres/tiny_solver.h
+++ b/include/operon/ceres/tiny_solver.h
@@ -1,5 +1,5 @@
 // Ceres Solver - A fast non-linear least squares minimizer
-// Copyright 2021 Google Inc. All rights reserved.
+// Copyright 2023 Google Inc. All rights reserved.
 // http://ceres-solver.org/
 //
 // Redistribution and use in source and binary forms, with or without
@@ -51,9 +51,11 @@
 #ifndef CERES_PUBLIC_TINY_SOLVER_H_
 #define CERES_PUBLIC_TINY_SOLVER_H_
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 
+#include "Eigen/Core"
 #include "Eigen/Dense"
 
 namespace ceres {
@@ -125,11 +127,15 @@ namespace ceres {
 //
 //   int NumParameters() const;
 //
-template <typename Function,
+template <typename Function, int kMaxResiduals = Function::NUM_RESIDUALS,
+          int kMaxParameters = Function::NUM_PARAMETERS,
           typename LinearSolver =
               Eigen::LDLT<Eigen::Matrix<typename Function::Scalar,  //
                                         Function::NUM_PARAMETERS,   //
-                                        Function::NUM_PARAMETERS>>>
+                                        Function::NUM_PARAMETERS,   //
+                                        0,                          //
+                                        kMaxParameters,             //
+                                        kMaxParameters>>>
 class TinySolver {
  public:
   // This class needs to have an Eigen aligned operator new as it contains
@@ -138,10 +144,27 @@ class TinySolver {
 
   enum {
     NUM_RESIDUALS = Function::NUM_RESIDUALS,
-    NUM_PARAMETERS = Function::NUM_PARAMETERS
+    NUM_PARAMETERS = Function::NUM_PARAMETERS,
+    MAX_NUM_RESIDUALS = kMaxResiduals,
+    MAX_NUM_PARAMETERS = kMaxParameters,
   };
   using Scalar = typename Function::Scalar;
-  using Parameters = typename Eigen::Matrix<Scalar, NUM_PARAMETERS, 1>;
+  using ParameterVector = typename Eigen::
+      Matrix<Scalar, NUM_PARAMETERS, 1, 0, MAX_NUM_PARAMETERS, 1>;
+  using ResidualVector =
+      typename Eigen::Matrix<Scalar, NUM_RESIDUALS, 1, 0, MAX_NUM_RESIDUALS, 1>;
+  using JacobianMatrix = typename Eigen::Matrix<Scalar,
+                                                NUM_RESIDUALS,
+                                                NUM_PARAMETERS,
+                                                0,
+                                                MAX_NUM_RESIDUALS,
+                                                MAX_NUM_PARAMETERS>;
+  using HessianMatrix = Eigen::Matrix<Scalar,
+                                      NUM_PARAMETERS,
+                                      NUM_PARAMETERS,
+                                      0,
+                                      MAX_NUM_PARAMETERS,
+                                      MAX_NUM_PARAMETERS>;
 
   enum Status {
     // max_norm |J'(x) * f(x)| < gradient_tolerance
@@ -160,6 +183,15 @@ class TinySolver {
 
   struct Options {
     int max_num_iterations = 50;
+
+    // Caps the number of *accepted* Levenberg-Marquardt steps (rho > 0),
+    // matching Eigen::LevenbergMarquardt's iterations() semantics, which
+    // only counts accepted steps - not this class's max_num_iterations,
+    // which (unmodified) bounds total attempts, accepted or rejected.
+    // Left at its default (no cap) for anyone using this class unchanged;
+    // Operon::LevenbergMarquardtOptimizer sets it explicitly so
+    // --iterations means the same thing across optimizer backends.
+    int max_num_accepted_steps = std::numeric_limits<int>::max();
 
     // max_norm |J'(x) * f(x)| < gradient_tolerance
     Scalar gradient_tolerance = 1e-10;
@@ -187,7 +219,7 @@ class TinySolver {
     Status status = HIT_MAX_ITERATIONS;
   };
 
-  bool Update(const Function& function, const Parameters& x) {
+  bool Update(const Function& function, const ParameterVector& x) {
     if (!function(x.data(), residuals_.data(), jacobian_.data())) {
       return false;
     }
@@ -217,10 +249,10 @@ class TinySolver {
     return true;
   }
 
-  const Summary& Solve(const Function& function, Parameters* x_and_min) {
+  const Summary& Solve(const Function& function, ParameterVector* x_and_min) {
     Initialize<NUM_RESIDUALS, NUM_PARAMETERS>(function);
     assert(x_and_min);
-    Parameters& x = *x_and_min;
+    ParameterVector& x = *x_and_min;
     summary = Summary();
     summary.iterations = 0;
 
@@ -242,16 +274,16 @@ class TinySolver {
     Scalar u = 1.0 / options.initial_trust_region_radius;
     Scalar v = 2;
 
-    for (summary.iterations = 1;
-         summary.iterations < options.max_num_iterations;
-         summary.iterations++) {
+    for (int attempts = 1;
+         attempts < options.max_num_iterations &&
+         summary.iterations < options.max_num_accepted_steps;
+         attempts++) {
       jtj_regularized_ = jtj_;
       const Scalar min_diagonal = 1e-6;
       const Scalar max_diagonal = 1e32;
-      for (int i = 0; i < lm_diagonal_.rows(); ++i) {
-        lm_diagonal_[i] = std::sqrt(
-            u * (std::min)((std::max)(jtj_(i, i), min_diagonal), max_diagonal));
-        jtj_regularized_(i, i) += lm_diagonal_[i] * lm_diagonal_[i];
+      for (int i = 0; i < dx_.rows(); ++i) {
+        jtj_regularized_(i, i) +=
+            u * std::clamp(jtj_(i, i), min_diagonal, max_diagonal);
       }
 
       // TODO(sameeragarwal): Check for failure and deal with it.
@@ -286,15 +318,15 @@ class TinySolver {
         // Accept the Levenberg-Marquardt step because the linear
         // model fits well.
         x = x_new_;
+        ++summary.iterations;
 
+        // TODO(sameeragarwal): Deal with failure.
+        Update(function, x);
         if (std::abs(cost_change) < options.function_tolerance) {
-          cost_ = f_x_new_.squaredNorm() / 2;
           summary.status = COST_CHANGE_TOO_SMALL;
           break;
         }
 
-        // TODO(sameeragarwal): Deal with failure.
-        Update(function, x);
         if (summary.gradient_max_norm < options.gradient_tolerance) {
           summary.status = GRADIENT_TOO_SMALL;
           break;
@@ -330,6 +362,17 @@ class TinySolver {
     return summary;
   }
 
+  ResidualVector Residuals()
+      const {
+    // Residual updates are stored with the opposite sign.
+    return -residuals_;
+  }
+
+  JacobianMatrix Jacobian() const {
+    // Undo the scaling applied to the jacobian matrix during Update().
+    return jacobian_ * jacobi_scaling_.cwiseInverse().asDiagonal();
+  }
+
   Options options;
   Summary summary;
 
@@ -338,54 +381,27 @@ class TinySolver {
   // linear system. This allows reusing the intermediate storage across solves.
   LinearSolver linear_solver_;
   Scalar cost_;
-  Parameters dx_, x_new_, g_, jacobi_scaling_, lm_diagonal_, lm_step_;
-  Eigen::Matrix<Scalar, NUM_RESIDUALS, 1> residuals_, f_x_new_;
-  Eigen::Matrix<Scalar, NUM_RESIDUALS, NUM_PARAMETERS> jacobian_;
-  Eigen::Matrix<Scalar, NUM_PARAMETERS, NUM_PARAMETERS> jtj_, jtj_regularized_;
+  ParameterVector dx_, x_new_, g_, jacobi_scaling_, lm_step_;
+  ResidualVector residuals_, f_x_new_;
+  JacobianMatrix jacobian_;
+  HessianMatrix jtj_, jtj_regularized_;
 
-  // The following definitions are needed for template metaprogramming.
-  template <bool Condition, typename T>
-  struct enable_if;
-
-  template <typename T>
-  struct enable_if<true, T> {
-    using type = T;
-  };
-
-  // The number of parameters and residuals are dynamically sized.
   template <int R, int P>
-  typename enable_if<(R == Eigen::Dynamic && P == Eigen::Dynamic), void>::type
-  Initialize(const Function& function) {
-    Initialize(function.NumResiduals(), function.NumParameters());
+  void Initialize(const Function& function) {
+    if constexpr (R == Eigen::Dynamic && P == Eigen::Dynamic) {
+      Initialize(function.NumResiduals(), function.NumParameters());
+    } else if constexpr (R == Eigen::Dynamic && P != Eigen::Dynamic) {
+      Initialize(function.NumResiduals(), P);
+    } else if constexpr (R != Eigen::Dynamic && P == Eigen::Dynamic) {
+      Initialize(R, function.NumParameters());
+    }
   }
-
-  // The number of parameters is dynamically sized and the number of
-  // residuals is statically sized.
-  template <int R, int P>
-  typename enable_if<(R == Eigen::Dynamic && P != Eigen::Dynamic), void>::type
-  Initialize(const Function& function) {
-    Initialize(function.NumResiduals(), P);
-  }
-
-  // The number of parameters is statically sized and the number of
-  // residuals is dynamically sized.
-  template <int R, int P>
-  typename enable_if<(R != Eigen::Dynamic && P == Eigen::Dynamic), void>::type
-  Initialize(const Function& function) {
-    Initialize(R, function.NumParameters());
-  }
-
-  // The number of parameters and residuals are statically sized.
-  template <int R, int P>
-  typename enable_if<(R != Eigen::Dynamic && P != Eigen::Dynamic), void>::type
-  Initialize(const Function& /* function */) {}
 
   void Initialize(int num_residuals, int num_parameters) {
     dx_.resize(num_parameters);
     x_new_.resize(num_parameters);
     g_.resize(num_parameters);
     jacobi_scaling_.resize(num_parameters);
-    lm_diagonal_.resize(num_parameters);
     lm_step_.resize(num_parameters);
     residuals_.resize(num_residuals);
     f_x_new_.resize(num_residuals);

--- a/include/operon/optimizer/optimizer.hpp
+++ b/include/operon/optimizer/optimizer.hpp
@@ -183,12 +183,23 @@ struct LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> final : public 
         Operon::Interpreter<Operon::Scalar, DTable> interpreter{dtable, dataset, &tree};
         Operon::LMCostFunction<Operon::Scalar> cf{&interpreter, target, range, weights};
         Eigen::LevenbergMarquardt<decltype(cf)> lm(cf);
-        lm.setMaxfev(static_cast<int>(iterations+2));
 
         auto x0 = tree.GetCoefficients();
         FitDiagnostics diag;
         diag.InitialParameters = x0;
         if (!x0.empty()) {
+            // `iterations` counts accepted LM steps (lm.iterations()), matching the
+            // Tiny/ceres variant's max_num_iterations - it is not itself a function-
+            // evaluation budget. maxfev is still needed as a bound on rejected
+            // trust-region retries within/across those steps (Eigen's own default,
+            // 400 regardless of iterations, is enough per individual to exhaust the
+            // CLI's overall --evaluations budget across a full GP run), scaled by
+            // parameter count using MINPACK's own convention (100*(n+1) for its
+            // "no fixed iteration count" default) so the ceiling grows with problem
+            // size instead of being a fixed constant.
+            auto const maxfev = static_cast<Eigen::Index>(iterations) * (static_cast<Eigen::Index>(x0.size()) + 1);
+            lm.setMaxfev(std::max<Eigen::Index>(maxfev, 1));
+
             Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1>> m0(x0.data(), std::ssize(x0));
             Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
 
@@ -198,7 +209,8 @@ struct LevenbergMarquardtOptimizer<DTable, OptimizerType::Eigen> final : public 
             if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
                 do {
                     status = lm.minimizeOneStep(m);
-                } while (status == Eigen::LevenbergMarquardtSpace::Running);
+                } while (status == Eigen::LevenbergMarquardtSpace::Running
+                          && lm.iterations() < static_cast<Eigen::Index>(iterations));
             }
             m0 = m;
         }
@@ -461,15 +473,17 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
                 gsl::not_null<Operon::InterpreterBase<Operon::Scalar> const*>{&interpreter},
                 target, range, weights};
             Eigen::LevenbergMarquardt<decltype(cf)> lm(cf);
-            lm.setMaxfev(static_cast<int>(iters + 2));
             if (!x0.empty()) {
+                lm.setMaxfev(std::max<Eigen::Index>(
+                    static_cast<Eigen::Index>(iters) * (static_cast<Eigen::Index>(x0.size()) + 1), 1));
                 Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1>> m0(x0.data(), std::ssize(x0));
                 Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
                 Eigen::LevenbergMarquardtSpace::Status status = lm.minimizeInit(m);
                 diag.InitialCost = diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
                 if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
                     do { status = lm.minimizeOneStep(m); }
-                    while (status == Eigen::LevenbergMarquardtSpace::Running);
+                    while (status == Eigen::LevenbergMarquardtSpace::Running
+                            && lm.iterations() < static_cast<Eigen::Index>(iters));
                 }
                 m0 = m;
             }
@@ -519,7 +533,8 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
             weights};
 
         Eigen::LevenbergMarquardt<decltype(cf)> lm(cf);
-        lm.setMaxfev(static_cast<int>(iters + 2));
+        lm.setMaxfev(std::max<Eigen::Index>(
+            static_cast<Eigen::Index>(iters) * (static_cast<Eigen::Index>(x0.size()) + 1), 1));
 
         Eigen::Map<Eigen::Matrix<Operon::Scalar, -1, 1>> m0(x0.data(), std::ssize(x0));
         Eigen::Matrix<Operon::Scalar, -1, 1> m = m0;
@@ -528,7 +543,8 @@ struct JitLevenbergMarquardtOptimizer : public OptimizerBase {
         diag.InitialCost = diag.FinalCost = lm.fnorm() * lm.fnorm() * 0.5;
         if (status != Eigen::LevenbergMarquardtSpace::ImproperInputParameters) {
             do { status = lm.minimizeOneStep(m); }
-            while (status == Eigen::LevenbergMarquardtSpace::Running);
+            while (status == Eigen::LevenbergMarquardtSpace::Running
+                    && lm.iterations() < static_cast<Eigen::Index>(iters));
         }
         m0 = m;
 

--- a/include/operon/optimizer/optimizer.hpp
+++ b/include/operon/optimizer/optimizer.hpp
@@ -127,14 +127,22 @@ struct LevenbergMarquardtOptimizer : public OptimizerBase {
         Operon::Interpreter<Operon::Scalar, DTable> interpreter{dtable, dataset, &tree};
         Operon::LMCostFunction cf{gsl::not_null<Operon::InterpreterBase<Operon::Scalar> const*>{&interpreter}, target, range, weights};
         ceres::TinySolver<decltype(cf)> solver;
-        solver.options.max_num_iterations = static_cast<int>(iterations+1);
 
         auto x0 = tree.GetCoefficients();
         FitDiagnostics diag;
         diag.InitialParameters = x0;
         auto m0 = Eigen::Map<Eigen::Matrix<Operon::Scalar, Eigen::Dynamic, 1>>(x0.data(), x0.size());
         if (!x0.empty()) {
-            typename decltype(solver)::Parameters p = m0.cast<typename decltype(cf)::Scalar>();
+            // max_num_accepted_steps counts accepted LM steps only, matching
+            // Eigen::LevenbergMarquardt's iterations() semantics (see the
+            // Eigen-backend LevenbergMarquardtOptimizer below) - unlike this
+            // class's own max_num_iterations, which (unmodified) bounds total
+            // attempts, accepted or rejected. max_num_iterations is still set,
+            // as a MINPACK-convention-scaled safety net on rejected-retry
+            // attempts, mirroring maxfev's role for the Eigen backend.
+            solver.options.max_num_accepted_steps = static_cast<int>(iterations);
+            solver.options.max_num_iterations = static_cast<int>(iterations) * (static_cast<int>(x0.size()) + 1);
+            typename decltype(solver)::ParameterVector p = m0.cast<typename decltype(cf)::Scalar>();
             solver.Solve(cf, &p);
             m0 = p.template cast<Operon::Scalar>();
         }

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -1196,7 +1196,7 @@ TEST_CASE("JitLMCostFunction TinySolver convergence", "[jit][lm]")
     ceres::TinySolver<JitLMCostFunction<>> solver;
     solver.options.max_num_iterations = 100;
 
-    typename decltype(solver)::Parameters p = m0.cast<Operon::Scalar>();
+    typename decltype(solver)::ParameterVector p = m0.cast<Operon::Scalar>();
     solver.Solve(cf, &p);
     m0 = p.template cast<Operon::Scalar>();
 


### PR DESCRIPTION
`maxfev` is Eigen's Levenberg-Marquardt cap on the total number of residual/Jacobian evaluations allowed in one optimization run, a safety limit stopping LM from iterating indefinitely when it fails to converge.

This is currently set to `iterations + 2`, a small fixed constant independent of parameter count. A single accepted LM step can require several rejected trial evaluations internally, so this budget can exhaust before LM makes real progress on models with more than a couple of parameters. `--iterations` also isn't used as an accepted-step count at all here, just folded directly into this fixed evaluation cap, so it doesn't do what its name implies.

Other LM implementations size this differently. Ceres bounds accepted steps directly via `max_num_iterations`, separate from any evaluation cap. MINPACK's `lmder` scales its own default evaluation cap by parameter count, `100 * (n + 1)`, instead of using a fixed constant.

This change adopts both conventions for the Eigen-backend optimizer: `--iterations` now bounds accepted steps directly (`lm.iterations() < iterations`, matching Ceres), and `maxfev` is set to `iterations * (n_params + 1)`, following MINPACK's parameter-count scaling in place of the old fixed constant. This also prevents a single individual's local search from consuming an outsized share of a run's shared `--evaluations` budget.

The default (Tiny-backend) optimizer had the same problem in a different form: `ceres::TinySolver`'s own `max_num_iterations` bounds total attempts (accepted or rejected), unlike `Eigen::LevenbergMarquardt::iterations()` (accepted steps only, confirmed directly in Eigen's MINPACK-derived source), so the same `--iterations` flag meant two different things depending on which backend was active. Fixed by updating the vendored `tiny_solver.h` to the latest upstream Ceres and adding a `max_num_accepted_steps` option (defaulting to unbounded, so behavior for any other user of the class is unchanged); `Operon::LevenbergMarquardtOptimizer` sets it directly from `--iterations` and repurposes `max_num_iterations` as a MINPACK-scaled safety net on rejected retries, the same role `maxfev` plays for the Eigen backend.
