### PR TITLE
algorithms: add fitness_stats generation probe

### DIFF
--- a/include/operon/algorithms/probes/fitness_stats.hpp
+++ b/include/operon/algorithms/probes/fitness_stats.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_ALGORITHMS_PROBES_FITNESS_STATS_HPP
+#define OPERON_ALGORITHMS_PROBES_FITNESS_STATS_HPP
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "operon/algorithms/probes/probe.hpp"
+#include "operon/core/comparison.hpp"
+
+namespace Operon {
+
+// Reports per-generation best/median/worst training fitness (objective 0)
+// and best/median/worst tree length across ctx.Parents(), so a
+// --probes-config run can produce a convergence curve (fitness and size
+// over generations) without decoding population_trace's binary frames.
+class FitnessStatsProbe final : public GenerationProbe {
+public:
+    auto operator()(ProbeContext& ctx) -> void override
+    {
+        auto parents = ctx.Parents();
+        if (parents.empty()) { return; }
+
+        fitness_.clear();
+        fitness_.reserve(parents.size());
+        length_.clear();
+        length_.reserve(parents.size());
+        for (auto const& ind : parents) {
+            fitness_.push_back(static_cast<double>(ind[0]));
+            length_.push_back(static_cast<std::int64_t>(ind.Genotype.Length()));
+        }
+
+        std::ranges::sort(fitness_, Operon::Less<true>{});
+        std::ranges::sort(length_);
+
+        auto const n = fitness_.size();
+        auto const fitnessMedian = (n % 2 == 0) ? (fitness_[n/2 - 1] + fitness_[n/2]) / 2 : fitness_[n/2];
+        auto const lengthMedian = (n % 2 == 0) ? (static_cast<double>(length_[n/2 - 1]) + static_cast<double>(length_[n/2])) / 2 : static_cast<double>(length_[n/2]);
+
+        ctx.Emit("fitness_best", fitness_.front());
+        ctx.Emit("fitness_median", fitnessMedian);
+        ctx.Emit("fitness_worst", fitness_.back());
+        ctx.Emit("length_min", length_.front());
+        ctx.Emit("length_median", lengthMedian);
+        ctx.Emit("length_max", length_.back());
+    }
+
+private:
+    std::vector<double> fitness_;
+    std::vector<std::int64_t> length_;
+};
+
+} // namespace Operon
+
+#endif

--- a/source/algorithms/probes/builtin.cpp
+++ b/source/algorithms/probes/builtin.cpp
@@ -9,6 +9,7 @@
 
 #include "operon/algorithms/probes/cache_hit_rate.hpp"
 #include "operon/algorithms/probes/diversity.hpp"
+#include "operon/algorithms/probes/fitness_stats.hpp"
 #include "operon/algorithms/probes/population_trace.hpp"
 #include "operon/core/constants.hpp"
 
@@ -28,6 +29,10 @@ auto RegisterBuiltinProbes(ProbeRegistry& registry) -> void
 
     registry.Register("cache_hit_rate", [](ProbeParams const& /*params*/) -> std::unique_ptr<GenerationProbe> {
         return std::make_unique<CacheHitRateProbe>();
+    });
+
+    registry.Register("fitness_stats", [](ProbeParams const& /*params*/) -> std::unique_ptr<GenerationProbe> {
+        return std::make_unique<FitnessStatsProbe>();
     });
 
     registry.Register("structural_diversity", [](ProbeParams const& params) -> std::unique_ptr<GenerationProbe> {

--- a/test/source/implementation/probes.cpp
+++ b/test/source/implementation/probes.cpp
@@ -454,7 +454,7 @@ TEST_CASE("ProbeRegistry factory receives its params", "[probes]")
     CHECK(probe != nullptr);
 }
 
-TEST_CASE("RegisterBuiltinProbes registers exactly the three concrete probes", "[probes]")
+TEST_CASE("RegisterBuiltinProbes registers exactly the four concrete probes", "[probes]")
 {
     Operon::ProbeRegistry registry;
     Operon::RegisterBuiltinProbes(registry);
@@ -462,6 +462,7 @@ TEST_CASE("RegisterBuiltinProbes registers exactly the three concrete probes", "
     CHECK(registry.Contains("population_trace"));
     CHECK(registry.Contains("cache_hit_rate"));
     CHECK(registry.Contains("structural_diversity"));
+    CHECK(registry.Contains("fitness_stats"));
     CHECK_FALSE(registry.Contains("not_a_real_probe"));
 }
 


### PR DESCRIPTION
Adds a `fitness_stats` generation probe reporting best/median/worst training fitness and min/median/max tree length across the population, once per generation.

Enable via `--probes-config`, e.g. `{"probes":[{"type":"fitness_stats","every":1}],"sink":{"type":"jsonl","path":"metrics.jsonl"}}`.

Complements the existing `cache_hit_rate`/`structural_diversity` probes for tracking convergence behavior, without needing to decode `population_trace`'s binary frames just to get basic fitness/size trends.
