### PR TITLE
algorithms: apply local search to the initial population, not just offspring

### DIFF
--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -7,7 +7,9 @@
 
 #include <atomic>
 #include <functional>
+#include <optional>
 #include <utility>
+#include <vector>
 
 #include "operon/collections/projection.hpp"
 #include "operon/core/concepts.hpp"
@@ -193,15 +195,15 @@ private:
 };
 
 // Optionally applies local search (coefficient optimization) to `ind`'s
-// genotype with probability `pLocal`. If local search ran, the optimized
-// coefficients are kept only with probability `pLamarck` (a Lamarckian
-// trial) and reverted to their pre-optimization values otherwise. Does not
+// genotype with probability `pLocal`. If local search ran and the update is
+// non-Lamarckian, returns the original coefficients so the caller can evaluate
+// the optimized genotype first, then restore inherited coefficients. Does not
 // evaluate `ind`'s fitness - split out from ScoreIndividual so a caller that
 // needs to run local search over a whole population before any of it is
 // scored (e.g. so Prepare() on an evaluator that snapshots the population,
 // such as DiversityEvaluator, sees post-optimization genotypes) can do so
 // without duplicating this logic.
-OPERON_EXPORT auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> void;
+OPERON_EXPORT auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> std::optional<std::vector<Operon::Scalar>>;
 
 // Optionally applies local search (coefficient optimization) to `ind`'s
 // genotype with probability `pLocal`, then scores it via `evaluator`. Non-

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -26,6 +26,8 @@
 
 namespace Operon {
 
+class CoefficientOptimizer; // operators/local_search.hpp
+
 enum class ErrorType : int { SSE, MSE, NMSE, RMSE, MAE, R2, C2 };
 
 struct OPERON_EXPORT ErrorMetric {
@@ -189,6 +191,27 @@ private:
     gsl::not_null<Problem const*> problem_;
     size_t budget_ = DefaultEvaluationBudget;
 };
+
+// Optionally applies local search (coefficient optimization) to `ind`'s
+// genotype with probability `pLocal`. If local search ran, the optimized
+// coefficients are kept only with probability `pLamarck` (a Lamarckian
+// trial) and reverted to their pre-optimization values otherwise. Does not
+// evaluate `ind`'s fitness - split out from ScoreIndividual so a caller that
+// needs to run local search over a whole population before any of it is
+// scored (e.g. so Prepare() on an evaluator that snapshots the population,
+// such as DiversityEvaluator, sees post-optimization genotypes) can do so
+// without duplicating this logic.
+OPERON_EXPORT auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> void;
+
+// Optionally applies local search (coefficient optimization) to `ind`'s
+// genotype with probability `pLocal`, then scores it via `evaluator`. Non-
+// finite fitness values are clamped to EvaluatorBase::ErrMax either way.
+//
+// Shared by offspring generation (OffspringGeneratorBase::Generate) and
+// initial-population scoring (GeneticProgrammingAlgorithm::Run,
+// NSGA2::Run) so both receive identical local-search treatment - passing
+// pLocal=0 (or a null coeffOptimizer) degenerates to a plain evaluate.
+OPERON_EXPORT auto ScoreIndividual(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) -> void;
 
 class OPERON_EXPORT UserDefinedEvaluator : public EvaluatorBase {
 public:

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -5,7 +5,6 @@
 #ifndef OPERON_GENERATOR_HPP
 #define OPERON_GENERATOR_HPP
 
-#include <chrono>
 #include "operon/core/operator.hpp"
 #include "operon/hash/zobrist.hpp"
 #include "operon/operators/crossover.hpp"
@@ -13,7 +12,6 @@
 #include "operon/operators/mutation.hpp"
 #include "operon/operators/selector.hpp"
 #include "operon/operators/local_search.hpp"
-#include "operon/optimizer/optimizer.hpp"
 
 namespace Operon {
 
@@ -73,28 +71,7 @@ public:
         }
 
         auto evaluate = [&]() {
-            if (coeffOptimizer_ != nullptr && BernoulliTrial{pLocal}(random)) {
-                auto c = res.Child->Genotype.GetCoefficients(); // save original coefficients
-                auto t0 = std::chrono::steady_clock::now();
-                auto [optimizedTree, outcome] = (*Optimizer())(random, std::move(res.Child->Genotype));
-                auto t1 = std::chrono::steady_clock::now();
-                auto const& diag = Diagnostics(outcome);
-                Evaluator()->ResidualEvaluations += diag.FunctionEvaluations;
-                Evaluator()->JacobianEvaluations += diag.JacobianEvaluations;
-                Evaluator()->CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-                res.Child->Genotype = std::move(optimizedTree);
-                res.Child->Fitness = (*Evaluator())(random, *res.Child, buf);
-
-                if(!BernoulliTrial{pLamarck}(random)) {
-                    res.Child->Genotype.SetCoefficients(c); // restore original coefficients
-                }
-            } else {
-                res.Child->Fitness = (*Evaluator())(random, *res.Child, buf);
-            }
-
-            for (auto& v : res.Child->Fitness) {
-                if (!std::isfinite(v)) { v = std::numeric_limits<Operon::Scalar>::max(); }
-            }
+            ScoreIndividual(random, *res.Child, *Evaluator(), coeffOptimizer_, pLocal, pLamarck, buf);
         };
 
         if (cache_ != nullptr) {

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -6,6 +6,7 @@
 #include <chrono> // for steady_clock
 #include <cstddef> // for size_t
 #include <functional> // for std::function
+#include <optional> // for std::optional
 #include <thread> // for std::thread
 #include <utility> // for std::move
 #include <vector> // for std::vector
@@ -70,6 +71,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     auto parents = Parents();
     auto offspring = Offspring();
     std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
+    std::vector<std::optional<std::vector<Operon::Scalar>>> originalCoeffs(parents.size());
 
     // Declared here (Run()'s own scope), not inside the "init" task's
     // callable below: a subflow's tasks run after that callable returns, so
@@ -99,8 +101,6 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                    ScoreIndividual(rngs[i], parents[i], *evaluator, generator->Optimizer(), /*pLocal=*/0.0, config.LamarckianProbability, Operon::Span<Operon::Scalar>(slots[id]));
                                })
                             .name("evaluate population");
-            eval.precede(reportProgress);
-
             if (warmResume) {
                 // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
                 // the worker RNG states so that subsequent generations remain deterministic.
@@ -121,12 +121,18 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                 // Prepare() (e.g. DiversityEvaluator) sees post-optimization
                 // genotypes rather than the raw initial ones.
                 auto localSearch = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                       LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
-                                   })
+                                       originalCoeffs[i] = LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
+                                    })
                                 .name("local search on initial population");
+                auto restoreCoeffs = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                        if (originalCoeffs[i]) { parents[i].Genotype.SetCoefficients(*originalCoeffs[i]); }
+                                    })
+                                .name("restore non-lamarckian coefficients");
                 init.precede(localSearch);
                 localSearch.precede(prepareEval);
                 prepareEval.precede(eval);
+                eval.precede(restoreCoeffs);
+                restoreCoeffs.precede(reportProgress);
             }
         }, // init
         stop, // loop condition

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -19,6 +19,7 @@
 #include "operon/algorithms/phase_timer.hpp"
 #include "operon/core/contracts.hpp" // for ENSURE
 #include "operon/core/types.hpp"
+#include "operon/operators/evaluator.hpp"
 #include "operon/operators/initializer.hpp"
 #include "operon/operators/reinserter.hpp"
 
@@ -70,6 +71,12 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     auto offspring = Offspring();
     std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
 
+    // Declared here (Run()'s own scope), not inside the "init" task's
+    // callable below: a subflow's tasks run after that callable returns, so
+    // a variable local to it and captured by reference would be dangling by
+    // the time a worker thread actually reads it.
+    bool const warmResume = IsFitted() && warmStart;
+
     auto timer = executor.make_observer<PhaseTimer>();
 
     // while loop control flow
@@ -82,15 +89,19 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                              if (report && std::invoke(report)) { RequestStop(); }
                                          }).name("report progress");
 
+            // Local search (if any) always runs before prepareEval below, either
+            // here (cold start) or not at all (warm resume, pLocal=0), so this
+            // loop itself never applies local search - passing pLocal=0 makes it
+            // a plain evaluate.
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                    auto id = executor.this_worker_id();
                                    if (slots[id].size() < trainSize) { slots[id].resize(trainSize); }
-                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                                   ScoreIndividual(rngs[i], parents[i], *evaluator, generator->Optimizer(), /*pLocal=*/0.0, config.LamarckianProbability, Operon::Span<Operon::Scalar>(slots[id]));
                                })
                             .name("evaluate population");
             eval.precede(reportProgress);
 
-            if (IsFitted() && warmStart) {
+            if (warmResume) {
                 // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
                 // the worker RNG states so that subsequent generations remain deterministic.
                 auto saveRngs    = subflow.emplace([&]() { savedRngs = rngs; }).name("save rng states");
@@ -105,7 +116,16 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
                                    })
                                 .name("initialize population");
-                init.precede(prepareEval);
+                // Local search runs before prepareEval (not after, alongside
+                // eval) so that an evaluator snapshotting the population in
+                // Prepare() (e.g. DiversityEvaluator) sees post-optimization
+                // genotypes rather than the raw initial ones.
+                auto localSearch = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                       LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
+                                   })
+                                .name("local search on initial population");
+                init.precede(localSearch);
+                localSearch.precede(prepareEval);
                 prepareEval.precede(eval);
             }
         }, // init

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -18,6 +18,7 @@
 #include "operon/core/problem.hpp" // for Problem
 #include "operon/core/range.hpp" // for Range
 #include "operon/core/tree.hpp" // for Tree
+#include "operon/operators/evaluator.hpp" // for ScoreIndividual
 #include "operon/operators/initializer.hpp" // for CoefficientInitializerBase
 #include "operon/operators/non_dominated_sorter.hpp" // for RankSorter
 #include "operon/operators/reinserter.hpp" // for ReinserterBase
@@ -170,6 +171,12 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
     auto offspring = Offspring();
     std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
 
+    // Declared here (Run()'s own scope), not inside the "init" task's
+    // callable below: a subflow's tasks run after that callable returns, so
+    // a variable local to it and captured by reference would be dangling by
+    // the time a worker thread actually reads it.
+    bool const warmResume = IsFitted() && warmStart;
+
     // while loop control flow
     auto timer = executor.make_observer<PhaseTimer>();
 
@@ -186,15 +193,19 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
             nonDominatedSort.precede(reportProgress);
 
             // nonDominatedSort runs after eval in both paths to rebuild fronts_ from current fitness.
+            // Local search (if any) always runs before prepareEval below, either
+            // in the cold-start localSearch task or not at all (warm resume,
+            // pLocal=0), so this loop itself never applies local search -
+            // passing pLocal=0 makes it a plain evaluate.
             auto eval = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
                                    auto const id = executor.this_worker_id();
                                    slots[id].resize(trainSize);
-                                   parents[i].Fitness = (*evaluator)(rngs[i], parents[i], slots[id]);
+                                   ScoreIndividual(rngs[i], parents[i], *evaluator, generator->Optimizer(), /*pLocal=*/0.0, config.LamarckianProbability, Operon::Span<Operon::Scalar>(slots[id]));
                                })
                             .name("evaluate population");
             eval.precede(nonDominatedSort);
 
-            if (IsFitted() && warmStart) {
+            if (warmResume) {
                 // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
                 // the worker RNG states so that subsequent generations remain deterministic.
                 auto saveRngs    = subflow.emplace([&]() { savedRngs = rngs; }).name("save rng states");
@@ -209,7 +220,16 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
                                        (*coeffInit)(rngs[i], parents[i].Genotype);
                                    })
                                 .name("initialize population");
-                init.precede(prepareEval);
+                // Local search runs before prepareEval (not after, alongside
+                // eval) so that an evaluator snapshotting the population in
+                // Prepare() (e.g. DiversityEvaluator) sees post-optimization
+                // genotypes rather than the raw initial ones.
+                auto localSearch = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                       LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
+                                   })
+                                .name("local search on initial population");
+                init.precede(localSearch);
+                localSearch.precede(prepareEval);
                 prepareEval.precede(eval);
             }
         }, // init

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -170,6 +170,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
     auto parents = Parents();
     auto offspring = Offspring();
     std::vector<Operon::RandomGenerator> savedRngs; // used only on warm resume
+    std::vector<std::optional<std::vector<Operon::Scalar>>> originalCoeffs(parents.size());
 
     // Declared here (Run()'s own scope), not inside the "init" task's
     // callable below: a subflow's tasks run after that callable returns, so
@@ -203,8 +204,6 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
                                    ScoreIndividual(rngs[i], parents[i], *evaluator, generator->Optimizer(), /*pLocal=*/0.0, config.LamarckianProbability, Operon::Span<Operon::Scalar>(slots[id]));
                                })
                             .name("evaluate population");
-            eval.precede(nonDominatedSort);
-
             if (warmResume) {
                 // Re-evaluate to catch evaluator/objective config mismatches, but snapshot and restore
                 // the worker RNG states so that subsequent generations remain deterministic.
@@ -225,12 +224,18 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
                 // Prepare() (e.g. DiversityEvaluator) sees post-optimization
                 // genotypes rather than the raw initial ones.
                 auto localSearch = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
-                                       LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
-                                   })
+                                       originalCoeffs[i] = LocalSearch(rngs[i], parents[i], *evaluator, generator->Optimizer(), config.LocalSearchProbability, config.LamarckianProbability);
+                                    })
                                 .name("local search on initial population");
+                auto restoreCoeffs = subflow.for_each_index(size_t { 0 }, parents.size(), size_t { 1 }, [&](size_t i) -> void {
+                                        if (originalCoeffs[i]) { parents[i].Genotype.SetCoefficients(*originalCoeffs[i]); }
+                                    })
+                                .name("restore non-lamarckian coefficients");
                 init.precede(localSearch);
                 localSearch.precede(prepareEval);
                 prepareEval.precede(eval);
+                eval.precede(restoreCoeffs);
+                restoreCoeffs.precede(nonDominatedSort);
             }
         }, // init
         stop, // loop condition

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -183,11 +183,11 @@ namespace {
         return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(aik) };
     }
 
-    auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> void
+    auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> std::optional<std::vector<Operon::Scalar>>
     {
         using BernoulliTrial = std::bernoulli_distribution;
 
-        if (coeffOptimizer == nullptr || pLocal <= 0 || !BernoulliTrial{pLocal}(random)) { return; }
+        if (coeffOptimizer == nullptr || pLocal <= 0 || !BernoulliTrial{pLocal}(random)) { return std::nullopt; }
 
         auto c = ind.Genotype.GetCoefficients(); // save original coefficients
         auto t0 = std::chrono::steady_clock::now();
@@ -199,15 +199,14 @@ namespace {
         evaluator.CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
         ind.Genotype = std::move(optimizedTree);
 
-        if (!BernoulliTrial{pLamarck}(random)) {
-            ind.Genotype.SetCoefficients(c); // restore original coefficients
-        }
+        return BernoulliTrial{pLamarck}(random) ? std::nullopt : std::make_optional(std::move(c));
     }
 
     auto ScoreIndividual(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) -> void
     {
-        LocalSearch(random, ind, evaluator, coeffOptimizer, pLocal, pLamarck);
+        auto originalCoeffs = LocalSearch(random, ind, evaluator, coeffOptimizer, pLocal, pLamarck);
         ind.Fitness = evaluator(random, ind, buf);
+        if (originalCoeffs) { ind.Genotype.SetCoefficients(*originalCoeffs); }
 
         for (auto& v : ind.Fitness) {
             if (!std::isfinite(v)) { v = EvaluatorBase::ErrMax; }

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -5,10 +5,14 @@
 #include "operon/core/distance.hpp"
 #include "operon/core/dispatch.hpp"
 #include "operon/operators/evaluator.hpp"
+#include "operon/operators/local_search.hpp"
+#include "operon/optimizer/optimizer.hpp"
 #include "operon/random/random.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <operon/operon_export.hpp>
+#include <random>
 #include <type_traits>
 
 namespace Operon {
@@ -177,5 +181,36 @@ namespace {
         auto aik = n/2 * (std::log(Operon::Math::Tau) + std::log(mse) + 1);
         if (!std::isfinite(aik)) { aik = EvaluatorBase::ErrMax; }
         return typename EvaluatorBase::ReturnType { static_cast<Operon::Scalar>(aik) };
+    }
+
+    auto LocalSearch(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck) -> void
+    {
+        using BernoulliTrial = std::bernoulli_distribution;
+
+        if (coeffOptimizer == nullptr || pLocal <= 0 || !BernoulliTrial{pLocal}(random)) { return; }
+
+        auto c = ind.Genotype.GetCoefficients(); // save original coefficients
+        auto t0 = std::chrono::steady_clock::now();
+        auto [optimizedTree, outcome] = (*coeffOptimizer)(random, std::move(ind.Genotype));
+        auto t1 = std::chrono::steady_clock::now();
+        auto const& diag = Diagnostics(outcome);
+        evaluator.ResidualEvaluations += diag.FunctionEvaluations;
+        evaluator.JacobianEvaluations += diag.JacobianEvaluations;
+        evaluator.CostFunctionTime += std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+        ind.Genotype = std::move(optimizedTree);
+
+        if (!BernoulliTrial{pLamarck}(random)) {
+            ind.Genotype.SetCoefficients(c); // restore original coefficients
+        }
+    }
+
+    auto ScoreIndividual(Operon::RandomGenerator& random, Operon::Individual& ind, Operon::EvaluatorBase const& evaluator, Operon::CoefficientOptimizer const* coeffOptimizer, double pLocal, double pLamarck, Operon::Span<Operon::Scalar> buf) -> void
+    {
+        LocalSearch(random, ind, evaluator, coeffOptimizer, pLocal, pLamarck);
+        ind.Fitness = evaluator(random, ind, buf);
+
+        for (auto& v : ind.Fitness) {
+            if (!std::isfinite(v)) { v = EvaluatorBase::ErrMax; }
+        }
     }
 } // namespace Operon

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -11,8 +11,10 @@
 #include "operon/core/individual.hpp"
 #include "operon/core/types.hpp"
 #include "operon/operators/evaluator.hpp"
+#include "operon/operators/local_search.hpp"
 #include "operon/optimizer/likelihood/gaussian_likelihood.hpp"
 #include "operon/optimizer/likelihood/poisson_likelihood.hpp"
+#include "operon/optimizer/optimizer.hpp"
 #include "operon/parser/infix.hpp"
 #include "operon/random/random.hpp"
 
@@ -72,6 +74,68 @@ struct EvaluatorFixture {
         return ind;
     }
 };
+
+class FixedCoefficientOptimizer final : public OptimizerBase {
+public:
+    explicit FixedCoefficientOptimizer(gsl::not_null<Problem const*> problem)
+        : OptimizerBase(problem)
+    {
+    }
+
+    [[nodiscard]] auto Optimize(Operon::RandomGenerator& /*rng*/, Tree const& tree) const -> FitOutcome override
+    {
+        FitResult result;
+        result.InitialParameters = tree.GetCoefficients();
+        result.FinalParameters.assign(result.InitialParameters.size(), static_cast<Operon::Scalar>(1));
+        result.InitialCost = static_cast<Operon::Scalar>(1);
+        result.FinalCost = static_cast<Operon::Scalar>(0);
+        result.FunctionEvaluations = 1;
+        return result;
+    }
+
+    [[nodiscard]] auto ComputeLikelihood(Operon::Span<Operon::Scalar const> /*x*/, Operon::Span<Operon::Scalar const> /*y*/, Operon::Span<Operon::Scalar const> /*w*/) const -> Operon::Scalar override
+    {
+        return Operon::Scalar{};
+    }
+
+    [[nodiscard]] auto ComputeFisherMatrix(Operon::Span<Operon::Scalar const> /*pred*/, Operon::Span<Operon::Scalar const> /*jac*/, Operon::Span<Operon::Scalar const> /*sigma*/) const -> Eigen::Matrix<Operon::Scalar, -1, -1> override
+    {
+        return {};
+    }
+};
+
+TEST_CASE("ScoreIndividual evaluates optimized coefficients before non-Lamarckian restore", "[evaluator]")
+{
+    EvaluatorFixture fix;
+    Evaluator<EvaluatorFixture::DTable> evaluator{&fix.problem, &fix.dtable, MSE{}, /*linearScaling=*/false};
+    FixedCoefficientOptimizer optimizer{&fix.problem};
+    CoefficientOptimizer coeffOptimizer{&optimizer};
+    Operon::Vector<Operon::Scalar> buf(fix.problem.TrainingRange().Size());
+
+    SECTION("non-Lamarckian local search restores genotype but keeps optimized fitness") {
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        Operon::RandomGenerator rng{1};
+
+        ScoreIndividual(rng, ind, evaluator, &coeffOptimizer, /*pLocal=*/1.0, /*pLamarck=*/0.0, Operon::Span<Operon::Scalar>{buf});
+
+        CHECK_THAT(static_cast<double>(ind.Fitness.front()), Catch::Matchers::WithinAbs(0.0, 1e-6));
+        for (auto c : ind.Genotype.GetCoefficients()) {
+            CHECK_THAT(static_cast<double>(c), Catch::Matchers::WithinRel(0.1, 1e-5));
+        }
+    }
+
+    SECTION("Lamarckian local search keeps optimized genotype") {
+        auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
+        Operon::RandomGenerator rng{1};
+
+        ScoreIndividual(rng, ind, evaluator, &coeffOptimizer, /*pLocal=*/1.0, /*pLamarck=*/1.0, Operon::Span<Operon::Scalar>{buf});
+
+        CHECK_THAT(static_cast<double>(ind.Fitness.front()), Catch::Matchers::WithinAbs(0.0, 1e-6));
+        for (auto c : ind.Genotype.GetCoefficients()) {
+            CHECK_THAT(static_cast<double>(c), Catch::Matchers::WithinRel(1.0, 1e-5));
+        }
+    }
+}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Poisson likelihood static methods

--- a/test/source/performance/evaluation.cpp
+++ b/test/source/performance/evaluation.cpp
@@ -28,6 +28,7 @@
 #include "operon/operators/non_dominated_sorter.hpp"
 #include "operon/operators/reinserter.hpp"
 #include "operon/operators/selector.hpp"
+#include "operon/optimizer/optimizer.hpp"
 #ifdef HAVE_ASMJIT
 #include "operon/hash/zobrist.hpp"
 #include "operon/interpreter/backend/jit/jit_evaluator.hpp"


### PR DESCRIPTION
The initial population in `GeneticProgrammingAlgorithm`/`NSGA2` is currently scored with whatever coefficients the coefficient initializer produced, via a plain evaluate. Local search (Levenberg-Marquardt coefficient optimization, governed by `--local-search-probability`/`--lamarckian-probability`) only ever runs on individuals produced by crossover/mutation from generation 1 onward.

This makes generation 0 systematically weaker than it needs to be, and the effect compounds: with `replace-worst` reinsertion, generation 1's offspring have to first outperform an under-optimized starting population before local search's benefit becomes visible at all.

Extracts the local-search-then-evaluate step already used for offspring (previously inline in `OffspringGeneratorBase::Generate`) into a shared function, `ScoreIndividual`, and applies it to the initial population too, with the same probabilities the offspring generator uses. A warm-started resume's re-evaluation step (which exists to catch evaluator/objective config mismatches across a checkpoint) does not run local search, matching its existing purpose of re-scoring already-optimized individuals rather than refining them further.

For a cold start, local search on the initial population runs as its own pass before the evaluator's `Prepare(parents)` call, not interleaved with evaluation: an evaluator that snapshots the population in `Prepare` (e.g. `DiversityEvaluator`) then sees post-optimization genotypes rather than the raw initial ones. `ScoreIndividual`'s local-search step is exposed separately as `LocalSearch` for this purpose.
