### PR TITLE
generator: fix SelectionPressure to count evaluation calls, not LM internals

### DIFF
--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -269,6 +269,16 @@ public:
     auto
     Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override
     {
+        // CallCount tracks "this evaluator instance scored one individual" at
+        // every composition depth, not just the leaf Evaluator<DTable> - a
+        // caller (e.g. OffspringSelectionGenerator::SelectionPressure) reading
+        // CallCount to count real evaluation attempts must see the same
+        // increment-per-call semantics regardless of how many inner
+        // evaluators this composite wraps. Stats() below separately sums the
+        // inner evaluators' own counters too - that is a distinct "total
+        // sub-evaluator work done" profiling figure, not a substitute for this.
+        ++CallCount;
+
         EvaluatorBase::ReturnType fit;
         fit.reserve(ind.Size());
 
@@ -283,20 +293,18 @@ public:
     auto Stats() const -> std::tuple<std::size_t, std::size_t, std::size_t, std::size_t> final {
         auto resEval{0UL};
         auto jacEval{0UL};
-        auto callCnt{0UL};
         auto cfTime{0UL};
 
         for (auto const& ev: evaluators_) {
             auto [re, je, cc, ct] = ev->Stats();
             resEval += re;
             jacEval += je;
-            callCnt += cc;
             cfTime  += ct;
         }
 
         return std::tuple{resEval + ResidualEvaluations.load(),
             jacEval + JacobianEvaluations.load(),
-            callCnt + CallCount.load(),
+            CallCount.load(),
             cfTime + CostFunctionTime.load()};
     }
 

--- a/include/operon/operators/generator.hpp
+++ b/include/operon/operators/generator.hpp
@@ -193,16 +193,23 @@ public:
     void Prepare(const Operon::Span<const Individual> pop) const override
     {
         OffspringGeneratorBase::Prepare(pop);
-        lastEvaluations_ = this->Evaluator()->TotalEvaluations();
+        lastEvaluations_ = this->Evaluator()->CallCount;
     }
 
+    // Counts real offspring-candidate attempts (one CallCount increment per
+    // individual scored, regardless of local search), not local search's own
+    // internal residual/Jacobian evaluations - TotalEvaluations() (used here
+    // previously) counts the latter, wildly overstating selection pressure
+    // whenever local search runs (each attempt can cost dozens of internal
+    // LM evaluations, all counted as if they were separate failed
+    // candidates).
     auto SelectionPressure() const -> double
     {
         auto n = this->FemaleSelector()->Population().size();
         if (n == 0U) {
             return 0;
         }
-        auto e = this->Evaluator()->TotalEvaluations() - lastEvaluations_;
+        auto e = this->Evaluator()->CallCount - lastEvaluations_;
         return static_cast<double>(e) / static_cast<double>(n);
     }
 

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -125,6 +125,7 @@ namespace {
     AggregateEvaluator::Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType
     {
         using vstat::univariate::accumulate;
+        ++CallCount;
         auto f = (*evaluator_)(rng, ind, buf);
         switch(aggtype_) {
             case AggregateType::Min: {


### PR DESCRIPTION
`OffspringSelectionGenerator` implements offspring selection: it retries recombination on a parent pair until the child beats a parent, up to a configurable ceiling (`MaxSelectionPressure`, default 100). Selection pressure is meant to count how many candidates were tried per accepted offspring, and the whole run terminates once this exceeds the ceiling.

`SelectionPressure()` computed this as `TotalEvaluations() / populationSize`, where `TotalEvaluations()` is local search's internal residual/Jacobian evaluation count, not the number of offspring candidates tried. Since local search runs on every candidate, a single attempt can already cost dozens of these internal evaluations. This inflates selection pressure far past its intended meaning and can terminate the whole run after only a handful of real attempts whenever local search is enabled.

`SelectionPressure()` now uses `CallCount` (incremented once per individual actually scored) instead, matching its intended semantics regardless of whether local search runs. `MultiEvaluator` and `AggregateEvaluator` (which wrap other evaluators) now also increment their own `CallCount` once per call, so this holds at every composition depth, not just for the base `Evaluator`.
