### PR TITLE
algorithms: propagate task exceptions instead of silently dropping them

### DIFF
--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -190,9 +190,18 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
-    Timings() = timer->Timings();
-    executor.remove_observer(std::move(timer));
+    auto cleanupTimer = [&]() -> void {
+        Timings() = timer->Timings();
+        executor.remove_observer(std::move(timer));
+    };
+
+    try {
+        executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
+    } catch (...) {
+        cleanupTimer();
+        throw;
+    }
+    cleanupTimer();
 }
 
 auto GeneticProgrammingAlgorithm::Run(Operon::RandomGenerator& random, Operon::ReportCallback report, size_t threads, bool warmStart) -> void

--- a/source/algorithms/gp.cpp
+++ b/source/algorithms/gp.cpp
@@ -190,7 +190,7 @@ auto GeneticProgrammingAlgorithm::Run(tf::Executor& executor, Operon::RandomGene
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow).wait();
+    executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
     Timings() = timer->Timings();
     executor.remove_observer(std::move(timer));
 }

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -303,9 +303,18 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
-    Timings() = timer->Timings();
-    executor.remove_observer(std::move(timer));
+    auto cleanupTimer = [&]() -> void {
+        Timings() = timer->Timings();
+        executor.remove_observer(std::move(timer));
+    };
+
+    try {
+        executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
+    } catch (...) {
+        cleanupTimer();
+        throw;
+    }
+    cleanupTimer();
 }
 
 auto NSGA2::Run(Operon::RandomGenerator& random, Operon::ReportCallback report, size_t threads, bool warmStart) -> void

--- a/source/algorithms/nsga2.cpp
+++ b/source/algorithms/nsga2.cpp
@@ -303,7 +303,7 @@ auto NSGA2::Run(tf::Executor& executor, Operon::RandomGenerator& random, Operon:
     body.precede(back);
     back.precede(cond);
 
-    executor.run(taskflow).wait();
+    executor.run(taskflow).get(); // .wait() would silently drop an exception thrown by any task
     Timings() = timer->Timings();
     executor.remove_observer(std::move(timer));
 }

--- a/source/interpreter/interpreter.cpp
+++ b/source/interpreter/interpreter.cpp
@@ -19,8 +19,7 @@ namespace Operon {
             Operon::Span<Operon::Scalar> const s{result[i].data(), result[i].size()};
             INT{&dtable, dataset, &trees[i]}.Evaluate({}, range, s);
         });
-        executor.run(taskflow);
-        executor.wait_for_all();
+        executor.run(taskflow).get(); // .wait_for_all() would silently drop an exception thrown by any task
         return result;
     }
 
@@ -35,7 +34,6 @@ namespace Operon {
             auto res = result.subspan(i * range.Size(), range.Size());
             INT{&dtable, dataset, &trees[i]}.Evaluate({}, range, res);
         });
-        executor.run(taskflow);
-        executor.wait_for_all();
+        executor.run(taskflow).get(); // .wait_for_all() would silently drop an exception thrown by any task
     }
 } // namespace Operon

--- a/test/source/implementation/evaluation.cpp
+++ b/test/source/implementation/evaluation.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <stdexcept>
+
 #include "../operon_test.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/types.hpp"
@@ -102,6 +104,24 @@ TEST_CASE("Batch evaluation", "[interpreter]")
     // Should not throw
     REQUIRE_NOTHROW(Operon::EvaluateTrees(trees, &ds, range, {result.data(), result.size()}));
     REQUIRE_NOTHROW(Operon::EvaluateTrees(trees, &ds, range));
+}
+
+TEST_CASE("Batch evaluation propagates task exceptions", "[interpreter]")
+{
+    auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto range = Range{0, ds.Rows<std::size_t>()};
+
+    constexpr auto missingPrimitive = Operon::Hash{0xBADF00D};
+    auto tree = Operon::Tree({
+        Operon::Node::Constant(1),
+        Operon::Node::Constant(2),
+        Operon::Node::Function(missingPrimitive, 2),
+    });
+    Operon::Vector<Operon::Tree> trees{tree};
+    Operon::Vector<Operon::Scalar> result(range.Size());
+
+    REQUIRE_THROWS_AS(Operon::EvaluateTrees(trees, &ds, range, {result.data(), result.size()}), std::runtime_error);
+    REQUIRE_THROWS_AS(Operon::EvaluateTrees(trees, &ds, range), std::runtime_error);
 }
 
 } // namespace Operon::Test


### PR DESCRIPTION
\`GeneticProgrammingAlgorithm::Run()\`/\`NSGA2::Run()\` ended with \`executor.run(taskflow).wait()\`. \`tf::Future\` extends \`std::future\`, and \`.wait()\` blocks without retrieving the result — any exception thrown by any task in the graph (including deep inside a subflow's \`for_each_index\`) was silently dropped. A run that hit such an exception would exit 0 having quietly completed only part of the work, indistinguishable from an early-stop or convergence condition.

Switched both to \`.get()\`, which retrieves and rethrows through the existing CLI-level \`catch (std::exception&)\` — a failing run now fails loudly with a clear error message and non-zero exit instead of silently truncating.