### PR TITLE
ci: bootstrap vcpkg after updating Windows checkout

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,14 +32,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:/vcpkg/downloads
-          key: operon-vcpkg-downloads-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'triplets/**') }}
+          key: operon-vcpkg-downloads-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'triplets/**', 'vcpkg-overlays/**') }}
           restore-keys: operon-vcpkg-downloads-windows-
 
       - name: Cache vcpkg installed packages
         uses: actions/cache@v4
         with:
           path: C:/vcpkg/installed
-          key: operon-vcpkg-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'triplets/**') }}
+          key: operon-vcpkg-windows-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'triplets/**', 'vcpkg-overlays/**') }}
           restore-keys: operon-vcpkg-windows-
 
       - name: Configure

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,8 +21,12 @@ jobs:
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Update vcpkg
-        run: git -C C:/vcpkg fetch origin && git -C C:/vcpkg reset --hard origin/master
+      - name: Update and bootstrap vcpkg
+        run: |
+          git -C C:/vcpkg fetch origin
+          git -C C:/vcpkg reset --hard origin/master
+          C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          C:/vcpkg/vcpkg.exe version
 
       - name: Cache vcpkg downloads
         uses: actions/cache@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,6 +76,7 @@
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded",
                 "VCPKG_TARGET_TRIPLET": "x64-windows-static-clang",
                 "VCPKG_INSTALLED_DIR": "$env{VCPKG_ROOT}/installed",
+                "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-overlays",
                 "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/triplets",
                 "CMAKE_CXX_FLAGS": "/W4 /permissive- /utf-8 /volatile:iso /EHsc /Zc:__cplusplus /Zc:throwingNew /arch:AVX2"
             }

--- a/vcpkg-overlays/vstat/portfile.cmake
+++ b/vcpkg-overlays/vstat/portfile.cmake
@@ -1,0 +1,25 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO heal-research/vstat
+    REF 495dca7736cef3db37cf6a8efced065c4befdab1
+    SHA512 897b45e3b9ae96eb1ec408fd38a23b225bd2ec7e0d01e4b1f1b954d08715b299a1f4da4ab8039ccf0f76aa7c280d3c9e7205752ad4a1c0b89f2d052d73f97d08
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_EXAMPLES=OFF
+)
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME vstat CONFIG_PATH lib/cmake/vstat DO_NOT_DELETE_PARENT_CONFIG_PATH)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+                    "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/lib")
+
+file(
+  INSTALL "${SOURCE_PATH}/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright)

--- a/vcpkg-overlays/vstat/portfile.cmake
+++ b/vcpkg-overlays/vstat/portfile.cmake
@@ -6,6 +6,8 @@ vcpkg_from_github(
     HEAD_REF main
 )
 
+set(VCPKG_BUILD_TYPE release)
+
 vcpkg_cmake_configure(
   SOURCE_PATH "${SOURCE_PATH}"
   OPTIONS

--- a/vcpkg-overlays/vstat/vcpkg.json
+++ b/vcpkg-overlays/vstat/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "vstat",
+  "version-string": "1.0.0-beta",
+  "description": "C++17 library of SIMD-enabled sample statistics (mean, variance, covariance, correlation).",
+  "dependencies": [
+    "eve",
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}


### PR DESCRIPTION
## Summary
- Rebuild the Windows runner's vcpkg executable after resetting C:/vcpkg to origin/master
- Print the vcpkg version so future CI logs show which binary handled manifest install

## Why
The hosted runner was using updated vcpkg scripts with a stale vcpkg.exe, causing configure to fail before compilation with `document schema version 2 is not supported by this version of vcpkg`.