### PR TITLE
creator: enforce maxDepth in ProbabilisticTreeCreator

### DIFF
--- a/source/operators/creator/ptc2.cpp
+++ b/source/operators/creator/ptc2.cpp
@@ -110,6 +110,7 @@ namespace Operon {
 auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_t targetLen, size_t /*minDepth*/, size_t maxDepth) const -> Tree
 {
     EXPECT(targetLen > 0);
+    EXPECT(maxDepth > 0);
     auto const& variables = GetVariables();
     auto const& pset = GetPrimitiveSet();
     auto [minFunctionArity, maxFunctionArity] = pset->FunctionArityLimits();
@@ -156,7 +157,8 @@ auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_
     BuildPostfix(nodes, childIndices, postfix, idx, 0);
 
     auto tree = Tree(postfix).UpdateNodes();
-    ENSURE(tree.Nodes().size() <= requestedLen);
+    ENSURE(tree.Length() <= requestedLen);
+    ENSURE(tree.Depth() <= maxDepth);
     return tree;
 }
 } // namespace Operon

--- a/source/operators/creator/ptc2.cpp
+++ b/source/operators/creator/ptc2.cpp
@@ -74,11 +74,16 @@ auto ProcessNextNode(
     size_t maxFunctionArity,
     Operon::PrimitiveSet const* pset,
     Operon::Span<Operon::Hash const> variables,
-    std::bernoulli_distribution& sampleIrregular
+    std::bernoulli_distribution& sampleIrregular,
+    size_t maxDepth
 ) -> void {
     auto childDepth = RandomDequeue(random, q);
 
-    auto maxArity = q.size() > 1 && sampleIrregular(random)
+    // A node at childDepth == maxDepth is the deepest one this budget allows
+    // (root sits at depth 1), so it must be a leaf.
+    bool const depthExhausted = childDepth >= maxDepth;
+
+    auto maxArity = (q.size() > 1 && sampleIrregular(random)) || depthExhausted
         ? size_t{0}
         : std::min(maxFunctionArity, targetLen - q.size() - nodes.size() - 1);
 
@@ -102,7 +107,7 @@ auto ProcessNextNode(
 } // anonymous namespace
 
 namespace Operon {
-auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_t targetLen, size_t /*args*/, size_t /*args*/) const -> Tree
+auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_t targetLen, size_t /*minDepth*/, size_t maxDepth) const -> Tree
 {
     EXPECT(targetLen > 0);
     auto const& variables = GetVariables();
@@ -115,7 +120,9 @@ auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_
     Operon::Vector<Node> nodes;
     nodes.reserve(targetLen);
 
-    auto maxArity = std::min(maxFunctionArity, targetLen - 1);
+    // the root lives at depth 1; if maxDepth can't fit even one level of
+    // children, force a terminal (same check ProcessNextNode applies).
+    auto maxArity = maxDepth <= 1 ? size_t{0} : std::min(maxFunctionArity, targetLen - 1);
     auto minArity = std::min(minFunctionArity, maxArity);
 
     auto root = pset->SampleRandomSymbol(random, minArity, maxArity);
@@ -138,7 +145,7 @@ auto ProbabilisticTreeCreator::operator()(Operon::RandomGenerator& random, size_
     std::bernoulli_distribution sampleIrregular(irregularityBias_);
 
     while (!q.empty()) {
-        ProcessNextNode(random, q, nodes, targetLen, minFunctionArity, maxFunctionArity, pset, variables, sampleIrregular);
+        ProcessNextNode(random, q, nodes, targetLen, minFunctionArity, maxFunctionArity, pset, variables, sampleIrregular, maxDepth);
     }
 
     std::sort(nodes.begin(), nodes.end(), [](const auto& lhs, const auto& rhs) -> auto { return lhs.Depth < rhs.Depth; });

--- a/test/source/implementation/initialization.cpp
+++ b/test/source/implementation/initialization.cpp
@@ -200,6 +200,42 @@ TEST_CASE("PTC2 creator", "[operators]")
     }
 }
 
+TEST_CASE("PTC2 creator respects maxDepth", "[operators]")
+{
+    auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto inputs = ds.VariableHashes();
+    std::erase(inputs, ds.GetVariable("Y").value().Hash);
+
+    PrimitiveSet grammar;
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
+
+    constexpr size_t maxLength = 100;
+    ProbabilisticTreeCreator const ptc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    Operon::RandomGenerator random(1234);
+    auto sizeDistribution = std::uniform_int_distribution<size_t>(1, maxLength);
+
+    SECTION("produced trees never exceed the requested depth budget") {
+        for (size_t const maxDepth : { size_t{1}, size_t{2}, size_t{3}, size_t{5} }) {
+            for (int i = 0; i < 2000; ++i) {
+                auto const targetLen = sizeDistribution(random);
+                auto const tree = ptc(random, targetLen, 1, maxDepth);
+                CHECK(tree.Length() <= targetLen);
+                CHECK(tree.Depth() <= maxDepth);
+            }
+        }
+    }
+
+    SECTION("a depth budget of 1 yields a single-terminal tree") {
+        // the root sits at depth 1, so maxDepth == 1 must force a terminal at the root.
+        for (int i = 0; i < 1000; ++i) {
+            auto const tree = ptc(random, sizeDistribution(random), 1, 1);
+            REQUIRE(tree.Length() == 1);
+            CHECK(tree.Depth() == 1);
+            CHECK(tree.Nodes().front().IsLeaf());
+        }
+    }
+}
+
 TEST_CASE("AchievableLength snap-down table", "[operators]") // NOLINT(readability-function-cognitive-complexity)
 {
     // A thin subclass that exposes the protected AchievableLength method.

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -133,6 +133,37 @@ TEST_CASE("Mutation tree stays within bounds", "[operators]")
     }
 }
 
+TEST_CASE("ReplaceSubtreeMutation via PTC2 respects maxDepth", "[operators]")
+{
+    auto ds = Dataset("./data/Poly-10.csv", true);
+    auto inputs = ds.VariableHashes();
+    std::erase(inputs, ds.GetVariable("Y").value().Hash);
+    constexpr size_t maxLength = 50;
+    constexpr size_t maxDepth = 5;
+
+    PrimitiveSet grammar;
+    grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
+
+    // PTC2 is the creator whose depth enforcement is being exercised here: the
+    // mutation hands it a per-call depth budget and relies on the creator to
+    // honor it when growing the replacement subtree.
+    ProbabilisticTreeCreator const ptc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    UniformCoefficientInitializer cfi;
+    ReplaceSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&ptc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxDepth, maxLength);
+
+    Operon::RandomGenerator random(42);
+
+    // start from a tree that already satisfies the budget (PTC2 enforces it),
+    // then keep mutating; every replacement subtree must stay within its budget
+    // so no tree in the chain can exceed maxDepth.
+    auto tree = ptc(random, maxLength, 1, maxDepth);
+    REQUIRE(tree.Depth() <= maxDepth);
+    for (int i = 0; i < 5000; ++i) {
+        tree = mut(random, std::move(tree));
+        CHECK(tree.Depth() <= maxDepth);
+    }
+}
+
 TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators unchanged", "[operators]")
 {
     auto ds = Dataset("./data/Poly-10.csv", true);


### PR DESCRIPTION
## Summary

`ProbabilisticTreeCreator::operator()` accepted a `maxDepth` parameter but silently discarded it (the parameter was literally named `/*args*/`). Callers that depend on it — `ReplaceSubtreeMutation` and `InsertSubtreeMutation` — compute a real, non-trivial per-call depth budget specifically to pass into this creator, and that computation was dead code as far as actual tree growth was concerned.

`SubtreeCrossover` already enforces a depth bound on the branches it produces. PTC2 growth now does the same: once a node's depth reaches the budget, it's forced to be a leaf, both at the root and throughout the internal growth queue.

`TreeInitializer`'s use of this creator for initial population creation (`DefaultMaxDepth = 1000`, intentionally a large sentinel — see that constant's own comment) is unaffected in practice, since 1000 never binds for any real tree.

## Test plan

- [x] Added `"PTC2 creator respects maxDepth"`: 2000 trees per depth budget (1/2/3/5) never exceed it; a depth-1 budget always yields a single terminal.
- [x] Added `"ReplaceSubtreeMutation via PTC2 respects maxDepth"`: 5000 successive mutations on a chain of trees, confirming depth stays bounded throughout repeated regrowth, not just on first creation.
- [x] Full test suite passes clean (46318 assertions, 297 test cases), no regressions.