### PR TITLE
Fold AggregateEvaluator into MultiEvaluator

### DIFF
--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -328,12 +328,12 @@ public:
     }
 
     auto SetAggregateType(std::optional<AggregateType> type) { aggregateType_ = type; }
+    auto ClearAggregateType() { aggregateType_ = std::nullopt; }
     auto GetAggregateType() const -> std::optional<AggregateType> { return aggregateType_; }
 
     auto ObjectiveCount() const -> std::size_t override
     {
-        if (aggregateType_) { return 1UL; }
-        return std::transform_reduce(evaluators_.begin(), evaluators_.end(), 0UL, std::plus {}, [](auto const eval) { return eval->ObjectiveCount(); });
+        return aggregateType_ ? 1UL : SubEvaluatorObjectiveCount();
     }
 
     auto
@@ -365,6 +365,11 @@ public:
     auto Evaluators() const { return evaluators_; }
 
 private:
+    auto SubEvaluatorObjectiveCount() const -> std::size_t
+    {
+        return std::transform_reduce(evaluators_.begin(), evaluators_.end(), 0UL, std::plus {}, [](auto const eval) { return eval->ObjectiveCount(); });
+    }
+
     std::vector<gsl::not_null<EvaluatorBase const*>> evaluators_;
     std::optional<AggregateType> aggregateType_;
 };

--- a/include/operon/operators/evaluator.hpp
+++ b/include/operon/operators/evaluator.hpp
@@ -299,6 +299,17 @@ private:
 
 class OPERON_EXPORT MultiEvaluator : public EvaluatorBase {
 public:
+    // When AggregateType is set (see SetAggregateType), the per-evaluator
+    // results are combined into a single scalar (e.g. so several objectives
+    // can be optimized as one aggregate) instead of being concatenated into
+    // a multi-objective vector.
+    enum class AggregateType : int { Min,
+        Max,
+        Median,
+        Mean,
+        HarmonicMean,
+        Sum };
+
     explicit MultiEvaluator(Problem const* problem)
         : EvaluatorBase(problem)
     {
@@ -316,34 +327,17 @@ public:
         }
     }
 
+    auto SetAggregateType(std::optional<AggregateType> type) { aggregateType_ = type; }
+    auto GetAggregateType() const -> std::optional<AggregateType> { return aggregateType_; }
+
     auto ObjectiveCount() const -> std::size_t override
     {
+        if (aggregateType_) { return 1UL; }
         return std::transform_reduce(evaluators_.begin(), evaluators_.end(), 0UL, std::plus {}, [](auto const eval) { return eval->ObjectiveCount(); });
     }
 
     auto
-    Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override
-    {
-        // CallCount tracks "this evaluator instance scored one individual" at
-        // every composition depth, not just the leaf Evaluator<DTable> - a
-        // caller (e.g. OffspringSelectionGenerator::SelectionPressure) reading
-        // CallCount to count real evaluation attempts must see the same
-        // increment-per-call semantics regardless of how many inner
-        // evaluators this composite wraps. Stats() below separately sums the
-        // inner evaluators' own counters too - that is a distinct "total
-        // sub-evaluator work done" profiling figure, not a substitute for this.
-        ++CallCount;
-
-        EvaluatorBase::ReturnType fit;
-        fit.reserve(ind.Size());
-
-        for (auto const& ev: evaluators_) {
-            auto f = (*ev)(rng, ind, buf);
-            std::copy(f.begin(), f.end(), std::back_inserter(fit));
-        }
-
-        return fit;
-    }
+    Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override;
 
     auto Stats() const -> std::tuple<std::size_t, std::size_t, std::size_t, std::size_t> final {
         auto resEval{0UL};
@@ -372,32 +366,7 @@ public:
 
 private:
     std::vector<gsl::not_null<EvaluatorBase const*>> evaluators_;
-};
-
-class OPERON_EXPORT AggregateEvaluator final : public EvaluatorBase {
-public:
-    enum class AggregateType : int { Min,
-        Max,
-        Median,
-        Mean,
-        HarmonicMean,
-        Sum };
-
-    explicit AggregateEvaluator(gsl::not_null<EvaluatorBase const*> evaluator)
-        : EvaluatorBase(evaluator->GetProblem())
-        , evaluator_(evaluator)
-    {
-    }
-
-    auto SetAggregateType(AggregateType type) { aggtype_ = type; }
-    auto GetAggregateType() const { return aggtype_; }
-
-    auto
-    Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType override;
-
-private:
-    gsl::not_null<EvaluatorBase const*> evaluator_;
-    AggregateType aggtype_ { AggregateType::Mean };
+    std::optional<AggregateType> aggregateType_;
 };
 
 // a couple of useful user-defined evaluators (mostly to avoid calling lambdas from python)
@@ -449,7 +418,6 @@ private:
 static_assert(Concepts::EvaluatorCallable<UserDefinedEvaluator>);
 static_assert(Concepts::EvaluatorCallable<Evaluator<ScalarDispatch>>);
 static_assert(Concepts::EvaluatorCallable<MultiEvaluator>);
-static_assert(Concepts::EvaluatorCallable<AggregateEvaluator>);
 static_assert(Concepts::EvaluatorCallable<DiversityEvaluator>);
 
 namespace detail {

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -244,7 +244,7 @@ namespace {
         ++CallCount;
 
         EvaluatorBase::ReturnType fit;
-        fit.reserve(ind.Size());
+        fit.reserve(SubEvaluatorObjectiveCount());
 
         for (auto const& ev: evaluators_) {
             auto f = (*ev)(rng, ind, buf);

--- a/source/operators/evaluator.cpp
+++ b/source/operators/evaluator.cpp
@@ -229,37 +229,56 @@ namespace {
     }
 
     auto
-    AggregateEvaluator::Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType
+    MultiEvaluator::Evaluate(Operon::RandomGenerator& rng, Individual const& ind, Operon::Span<Operon::Scalar> buf) const -> typename EvaluatorBase::ReturnType
     {
         using vstat::univariate::accumulate;
+
+        // CallCount tracks "this evaluator instance scored one individual" at
+        // every composition depth, not just the leaf Evaluator<DTable> - a
+        // caller (e.g. OffspringSelectionGenerator::SelectionPressure) reading
+        // CallCount to count real evaluation attempts must see the same
+        // increment-per-call semantics regardless of how many inner
+        // evaluators this composite wraps. Stats() below separately sums the
+        // inner evaluators' own counters too - that is a distinct "total
+        // sub-evaluator work done" profiling figure, not a substitute for this.
         ++CallCount;
-        auto f = (*evaluator_)(rng, ind, buf);
-        switch(aggtype_) {
+
+        EvaluatorBase::ReturnType fit;
+        fit.reserve(ind.Size());
+
+        for (auto const& ev: evaluators_) {
+            auto f = (*ev)(rng, ind, buf);
+            std::copy(f.begin(), f.end(), std::back_inserter(fit));
+        }
+
+        if (!aggregateType_) { return fit; }
+
+        switch(*aggregateType_) {
             case AggregateType::Min: {
-                return { *std::ranges::min_element(f) };
+                return { *std::ranges::min_element(fit) };
             }
             case AggregateType::Max: {
-                return { *std::ranges::max_element(f) };
+                return { *std::ranges::max_element(fit) };
             }
             case AggregateType::Median: {
-                auto const sz { std::ssize(f) };
-                auto const a = f.begin() + sz / 2;
-                std::nth_element(f.begin(), a, f.end());
+                auto const sz { std::ssize(fit) };
+                auto const a = fit.begin() + sz / 2;
+                std::nth_element(fit.begin(), a, fit.end());
                 if (sz % 2 == 0) {
-                    auto const b = std::max_element(f.begin(), a);
+                    auto const b = std::max_element(fit.begin(), a);
                     return { (*a + *b) / 2 };
                 }
                 return { *a };
             }
             case AggregateType::Mean: {
-                return { static_cast<Operon::Scalar>(accumulate<Operon::Scalar>(f.begin(), f.end()).mean) };
+                return { static_cast<Operon::Scalar>(accumulate<Operon::Scalar>(fit.begin(), fit.end()).mean) };
             }
             case AggregateType::HarmonicMean: {
-                auto stats = accumulate<Operon::Scalar>(f.begin(), f.end(), [](auto x) -> auto { return 1/x; });
+                auto stats = accumulate<Operon::Scalar>(fit.begin(), fit.end(), [](auto x) -> auto { return 1/x; });
                 return { static_cast<Operon::Scalar>(stats.count / stats.sum) };
             }
             case AggregateType::Sum: {
-                return { static_cast<Operon::Scalar>(vstat::univariate::accumulate<Operon::Scalar>(f.begin(), f.end()).sum) };
+                return { static_cast<Operon::Scalar>(vstat::univariate::accumulate<Operon::Scalar>(fit.begin(), fit.end()).sum) };
             }
             default: {
                 throw std::runtime_error("Unknown AggregateType");

--- a/test/source/implementation/evaluator.cpp
+++ b/test/source/implementation/evaluator.cpp
@@ -950,16 +950,18 @@ TEST_CASE("EvaluatorBase::Evaluate dispatch reaches the concrete derived overrid
         CHECK(combined[1] == expectedMse[0]);
     }
 
-    SECTION("AggregateEvaluator") {
+    SECTION("MultiEvaluator aggregate") {
         // Aggregating a single-objective evaluator is a no-op regardless of
         // AggregateType (min/max/median/mean of one element is that
         // element), so the 2-arg result must equal the wrapped evaluator's
         // own 2-arg result exactly.
         Operon::Evaluator<DTable> inner{&fix.problem, &fix.dtable, Operon::MSE{}};
-        Operon::AggregateEvaluator ae{&inner};
+        Operon::MultiEvaluator me{&fix.problem};
+        me.Add(&inner);
+        me.SetAggregateType(Operon::MultiEvaluator::AggregateType::Mean);
 
         auto ind = EvaluatorFixture::MakeIndividual(fix.tree);
-        auto const aggregated = ae(fix.rng, ind); // 2-arg
+        auto const aggregated = me(fix.rng, ind); // 2-arg
         auto const expected   = inner(fix.rng, ind);
 
         REQUIRE(aggregated.size() == 1);


### PR DESCRIPTION
## Summary
`AggregateEvaluator` wrapped an evaluator and reduced its multi-valued output to a scalar, but never overrode `Prepare()` — so a wrapped evaluator's per-generation state (e.g. a feasibility cache) was never refreshed past generation 0. `MultiEvaluator` now takes an optional `AggregateType` and performs the aggregation itself, inheriting its own `Prepare()` cascade to sub-evaluators for free. `AggregateEvaluator` is removed.

## Test plan
- [x] `cmake --build build -j16` (clean)
- [x] `./build/test/operon_test "[evaluator]"` — 148 assertions, 12 test cases pass