### PR TITLE
InfixFormatter, TreeFormatter, DotFormatter, PostfixFormatter: follow RefTo for Ref nodes

### DIFF
--- a/source/formatter/dot.cpp
+++ b/source/formatter/dot.cpp
@@ -35,14 +35,24 @@ auto DotFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::strin
         return s.Name();
     };
 
+    // A Ref is a pointer, not an independent DAG node -- chase it to the
+    // node it actually points at so edges connect to the shared node
+    // itself rather than to a dangling/duplicated placeholder.
+    auto resolve = [&](auto idx) {
+        while (tree[idx].IsRef()) { idx = tree[idx].RefTo; }
+        return idx;
+    };
+
     for (auto i = 0UL; i < tree.Length(); ++i) {
+        if (tree[i].IsRef()) { continue; }
+
         auto label = format(tree[i]);
         fmt::format_to(std::back_inserter(result), "\t{} [label=\"{}\"]\n", i, label);
 
         if (tree[i].IsLeaf()) { continue; }
 
         for (auto j : tree.Indices(i)) {
-            fmt::format_to(std::back_inserter(result), "\t{} -> {}\n", j, i);
+            fmt::format_to(std::back_inserter(result), "\t{} -> {}\n", resolve(j), i);
         }
     }
 

--- a/source/formatter/infix.cpp
+++ b/source/formatter/infix.cpp
@@ -22,6 +22,13 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
         } else {
             throw std::runtime_error(fmt::format("A key with hash value {} could not be found in the variable map.\n", s.HashValue));
         }
+    } else if (s.IsRef()) {
+        // Ref is a leaf (Arity == 0) that points backward to a shared
+        // subtree via RefTo, not the physically preceding node -- without
+        // this case the generic operator fallback below would recurse into
+        // `i-1`, silently formatting the wrong subtree for any tree with
+        // structural sharing (e.g. a symbolic-derivative DAG).
+        FormatNode(tree, variableNames, s.RefTo, current, decimalPrecision);
     } else {
         if (s.Value != 1) {
             fmt::format_to(std::back_inserter(current), "(");

--- a/source/formatter/postfix.cpp
+++ b/source/formatter/postfix.cpp
@@ -28,6 +28,26 @@ auto PostfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, st
             }
             break;
         }
+        case NodeType::Ref: {
+            // Ref has no tokens of its own -- replay the referenced
+            // subtree's token range (it occupies the contiguous flat
+            // range [RefTo-Length, RefTo], same as any other subtree)
+            // instead of emitting a bare, non-evaluable "ref" token.
+            auto const& t = tree[s.RefTo];
+            for (auto j = s.RefTo - t.Length; j <= s.RefTo; ++j) {
+                if (static_cast<int>(j) == tree[j].Parent - tree[tree[j].Parent].Length) {
+                    fmt::format_to(std::back_inserter(current), "(");
+                }
+                FormatNode(tree, variableNames, j, current, decimalPrecision);
+                if (!tree[j].IsLeaf()) {
+                    fmt::format_to(std::back_inserter(current), ")");
+                }
+                if (j != s.RefTo) {
+                    fmt::format_to(std::back_inserter(current), " ");
+                }
+            }
+            break;
+        }
         default: {
             fmt::format_to(std::back_inserter(current), fmt::runtime(s.Name()));
         }

--- a/source/formatter/tree.cpp
+++ b/source/formatter/tree.cpp
@@ -46,12 +46,19 @@ auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::
     }
     fmt::format_to(std::back_inserter(current), " D:{} L:{} N:{}\n", s.Depth, s.Level, s.Length + 1);
 
-    if (s.IsLeaf()) {
+    if (s.IsLeaf() && !s.IsRef()) {
         return;
     }
 
     if (i != tree.Length() - 1) {
         indent += isLast ? "    " : "│   ";
+    }
+
+    if (s.IsRef()) {
+        // Ref has no children of its own -- nest the shared subtree's
+        // diagram directly under it so it's visible rather than eliding it.
+        FormatNode(tree, variableNames, s.RefTo, current, indent, /*isLast=*/true, /*initialMarker=*/true, decimalPrecision);
+        return;
     }
 
     size_t count = 0;

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -144,6 +144,45 @@ TEST_CASE("Formatter output", "[parser]")
             CHECK(validateString(s));
         }
     }
+
+    SECTION("Ref nodes follow RefTo, not the preceding array slot") {
+        // x + ref(x) -- a minimal tree with structural sharing, the shape
+        // symbolic differentiation produces. Node 1 (Ref) has no bearing on
+        // node 0 by array adjacency alone (they'd coincide here by
+        // accident), so also cover a case where RefTo is NOT i-1: x*y +
+        // ref(x) should format to reference x again, not y.
+        using DTable = DispatchTable<Operon::Scalar>;
+        Operon::Dataset const ds2({"x", "y"}, {{2.0F}, {3.0F}});
+        auto const hx = ds2.GetVariable("x").value().Hash;
+        auto const hy = ds2.GetVariable("y").value().Hash;
+        Operon::Map<Operon::Hash, std::string> const names { {hx, "x"}, {hy, "y"} };
+
+        Operon::Node nx(NodeType::Variable);
+        nx.HashValue = hx;
+        nx.Value = 1;
+        Operon::Node ny(NodeType::Variable);
+        ny.HashValue = hy;
+        ny.Value = 1;
+        auto mul = Operon::Node::Function(Operon::Hash(BuiltinOp::Mul), 2);
+        auto refX = Operon::Node::Ref(0); // points at nx, not at mul (the preceding node)
+        auto add = Operon::Node::Function(Operon::Hash(BuiltinOp::Add), 2);
+
+        Operon::Tree tree({nx, ny, mul, refX, add});
+        tree.UpdateNodes();
+
+        auto const s = InfixFormatter::Format(tree, names, 3);
+        CHECK(s.find('y') != std::string::npos); // from x*y
+        // Formatted string must reference x twice (once from x*y, once from
+        // ref(x)) -- a formatter that follows i-1 instead of RefTo would
+        // wrap the mul node again and never mention y a second time nor
+        // produce a string that round-trips to the tree's actual value.
+        auto const reparsed = InfixParser::Parse(s, ds2);
+        Operon::Range const rg(0, 1);
+        auto const original = Interpreter<Operon::Scalar, DTable>::Evaluate(tree, ds2, rg);
+        auto const roundtrip = Interpreter<Operon::Scalar, DTable>::Evaluate(reparsed, ds2, rg);
+        CHECK(original[0] == Catch::Approx(8.0F)); // x*y + x = 2*3 + 2
+        CHECK(roundtrip[0] == Catch::Approx(original[0]));
+    }
 }
 
 TEST_CASE("ParseFunctionBody", "[parser]")

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -183,6 +183,58 @@ TEST_CASE("Formatter output", "[parser]")
         CHECK(original[0] == Catch::Approx(8.0F)); // x*y + x = 2*3 + 2
         CHECK(roundtrip[0] == Catch::Approx(original[0]));
     }
+
+    SECTION("PostfixFormatter, TreeFormatter and DotFormatter follow RefTo") {
+        // same x*y + ref(x) tree as the InfixFormatter section above
+        Operon::Dataset const ds2({"x", "y"}, {{2.0F}, {3.0F}});
+        auto const hx = ds2.GetVariable("x").value().Hash;
+        auto const hy = ds2.GetVariable("y").value().Hash;
+        Operon::Map<Operon::Hash, std::string> const names { {hx, "x"}, {hy, "y"} };
+
+        Operon::Node nx(NodeType::Variable);
+        nx.HashValue = hx;
+        nx.Value = 1;
+        Operon::Node ny(NodeType::Variable);
+        ny.HashValue = hy;
+        ny.Value = 1;
+        auto mul = Operon::Node::Function(Operon::Hash(BuiltinOp::Mul), 2);
+        auto refX = Operon::Node::Ref(0); // points at nx (index 0)
+        auto add = Operon::Node::Function(Operon::Hash(BuiltinOp::Add), 2);
+
+        Operon::Tree tree({nx, ny, mul, refX, add});
+        tree.UpdateNodes();
+
+        auto countOccurrences = [](std::string const& s, std::string const& sub) -> size_t {
+            size_t count{0};
+            for (size_t pos = s.find(sub); pos != std::string::npos; pos = s.find(sub, pos + sub.size())) {
+                ++count;
+            }
+            return count;
+        };
+
+        SECTION("PostfixFormatter replays the referenced subtree's tokens") {
+            auto const s = PostfixFormatter::Format(tree, names, 2);
+            // x*y contributes one "x", ref(x) must replay x's token again --
+            // a formatter following i-1 instead of RefTo would instead
+            // duplicate the "y" (or mul) token and never emit a second x.
+            CHECK(countOccurrences(s, "x") == 2);
+            CHECK(s.find("ref") == std::string::npos);
+        }
+
+        SECTION("TreeFormatter nests the referenced subtree under the Ref leaf") {
+            auto const s = TreeFormatter::Format(tree, names, 2);
+            CHECK(countOccurrences(s, "x D:") == 2);
+        }
+
+        SECTION("DotFormatter points edges at the shared node, not a duplicate/dangling Ref box") {
+            auto const s = DotFormatter::Format(tree, names, 2);
+            CHECK_NOTHROW(DotFormatter::Format(tree, names, 2));
+            CHECK(s.find("3 [label=") == std::string::npos); // no box for the Ref node itself
+            CHECK(s.find("0 -> 4") != std::string::npos); // nx -> add, resolved through the Ref
+            CHECK(s.find("3 ->") == std::string::npos);
+            CHECK(s.find("-> 3") == std::string::npos);
+        }
+    }
 }
 
 TEST_CASE("ParseFunctionBody", "[parser]")


### PR DESCRIPTION
## Summary

None of `InfixFormatter`, `TreeFormatter`, `DotFormatter`, or `PostfixFormatter` had a case for `NodeType::Ref` (a backward-pointer leaf used by symbolic differentiation's shared-subexpression DAG output). Each fell through to generic leaf/operator handling instead:

- `InfixFormatter` recursed into `i-1` — the physically preceding node in the flat array — instead of `RefTo`, silently producing a plausible-looking but wrong formula for any tree with structural sharing.
- `DotFormatter` threw (`Ref` is a leaf but not a constant/variable).
- `PostfixFormatter` emitted a bare, non-evaluable `ref` token.
- `TreeFormatter` printed a `ref` leaf line with no visible target.

Found while debugging an unrelated investigation: a derivative tree's printed formula showed no dependency on the variable being differentiated, which turned out to be this formatting bug rather than an actual differentiation issue.

## Fix

- `InfixFormatter`: explicit `s.IsRef()` case that recurses into `s.RefTo`.
- `TreeFormatter`: nests the referenced subtree's diagram directly under the `Ref` leaf instead of eliding it.
- `DotFormatter`: resolves `Ref` nodes transitively to the node they point at, drawing edges directly to the shared node and skipping a redundant box for the `Ref` node itself — a natural fit since DOT is a graph format that already supports shared nodes.
- `PostfixFormatter`: replays the referenced subtree's token range (which occupies a contiguous span in the flat array, like any subtree) instead of emitting a bare `ref` token.

## Test plan

- [x] New regression tests for all four formatters using a hand-built `x*y + ref(x)` tree where `RefTo != i-1`: `InfixFormatter` checked via round-trip parse + evaluate; `TreeFormatter`/`PostfixFormatter` checked for correct occurrence counts of the referenced variable; `DotFormatter` checked for edges resolving to the shared node and no dangling/duplicate `Ref` box.
- [x] Full `[parser]` and `[interpreter]` (excluding `[performance]`) suites pass with zero regressions.
