### PR TITLE
Fix FastExp/FastTanh silently laundering NaN into a finite wrong value

### DIFF
--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -39,7 +39,17 @@ auto FastExp(eve::wide<T> a) -> eve::wide<T> {
         // just deep in the clamped-out region but even near the boundary,
         // e.g. a=-88.7 subnormal-adjacent), e.g. FastExp(-128) returned
         // -128 instead of ~0.
-        return eve::max(eve::ldexp(y, eve::convert(m, eve::as<std::int32_t>{})), W{T(0)});
+        auto result = eve::max(eve::ldexp(y, eve::convert(m, eve::as<std::int32_t>{})), W{T(0)});
+        // eve::clamp/min/max on this platform return the non-NaN operand
+        // instead of propagating NaN (x86 minps/maxps semantics, not IEEE
+        // NaN rules) -- the initial clamp above silently turns a NaN input
+        // into a finite boundary value, and the max(...,0) floor does the
+        // same again if that corrupted computation itself produces NaN. Both
+        // combined made FastExp(NaN) return 0 instead of NaN, e.g. from a
+        // NaN that arose from an earlier sqrt(negative) elsewhere in the
+        // tree -- silently laundering it into a plausible-looking fitness
+        // value instead of correctly propagating "undefined" outward.
+        return eve::if_else(eve::is_nan(a), eve::nan(eve::as<W>{}), result);
     } else {
         return eve::exp(a);
     }
@@ -185,7 +195,12 @@ auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
         auto q = eve::fma(x2, W{T(1.19825839466702e-06f)}, W{T(1.18534705686654e-04f)});
         q = eve::fma(x2, q, W{T(2.26843463243900e-03f)});
         q = eve::fma(x2, q, W{T(4.89352518554385e-03f)});
-        return eve::if_else(tiny, x, p / q);
+        auto result = eve::if_else(tiny, x, p / q);
+        // Same eve::clamp NaN-swallowing issue as FastExp above: a NaN input
+        // (e.g. from sqrt(negative) elsewhere in the tree) silently becomes
+        // the clamp boundary instead of propagating, so FastTanh(NaN) would
+        // otherwise return -1 or 1 instead of NaN.
+        return eve::if_else(eve::is_nan(a), eve::nan(eve::as<W>{}), result);
     } else {
         // 19/18-degree rational minimax, ~2 ULP on [-18.7,18.7].
         // Ported from Eigen's ptanh_double (rminimax-optimised coefficients).
@@ -210,7 +225,8 @@ auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
         q = eve::fma(x2, q, W{T(3.437448108450402717e-02)});
         q = eve::fma(x2, q, W{T(4.851805297361760360e-01)});
         q = eve::fma(x2, q, W{T(1.0)});
-        return eve::if_else(tiny, x, p / q);
+        auto result = eve::if_else(tiny, x, p / q);
+        return eve::if_else(eve::is_nan(a), eve::nan(eve::as<W>{}), result);
     }
 }
 

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -83,6 +83,7 @@ namespace {
     }
 
     constexpr T   Inf = std::numeric_limits<T>::infinity();
+    constexpr T   NaN = std::numeric_limits<T>::quiet_NaN();
     constexpr int N   = 10000;
 } // namespace
 
@@ -194,6 +195,66 @@ TEST_CASE("Backend transcendental ULP accuracy", "[backend]")
              << ") at x=" << worst << " got=" << got << " expected=" << expected);
         CHECK(max_ulp <= ulp_limit);
     }
+}
+
+// Regression net for a previously-unknown bug: eve::clamp/min/max on this
+// platform return the non-NaN operand instead of propagating NaN (x86
+// minps/maxps semantics, not IEEE-754 NaN rules), so any Fast* approximation
+// that range-limits its input via those primitives can silently turn a NaN
+// (e.g. from sqrt(negative) elsewhere in a tree) into a finite,
+// plausible-looking wrong value instead of correctly propagating
+// "undefined" outward. Found in FastExp and FastTanh (both fixed with an
+// explicit is_nan guard, matching FastLog's pre-existing one).
+//
+// Each lane in every batch here is either NaN or the inert padding value
+// 0.5 -- deliberately NOT mixed with other "interesting" edge-case values.
+// A NaN placed alongside an unrelated real value in the same batch was
+// found, separately, to trigger a genuine third-party bug in eve::sinh
+// (a NaN in one SIMD lane corrupting an unrelated lane's result) -- see
+// project_eve_sinh_crosslane_nan_bug in memory. That's a different bug in
+// eve itself, not something this test is trying to catch, and mixing
+// values here would make this test's pass/fail depend on unrelated
+// batch-layout coincidences.
+TEST_CASE("Backend NaN propagation", "[backend]")
+{
+    auto allNan = [](auto fn) -> bool {
+        Buf src{};
+        src.v.fill(T{0.5});
+        src.v[0] = NaN;
+        Buf dst{};
+        fn(dst.v.data(), T{1}, src.v.data());
+        return std::isnan(dst.v[0]);
+    };
+
+    CHECK(allNan(Backend::Exp<T,S>));
+    CHECK(allNan(Backend::Log<T,S>));
+    CHECK(allNan(Backend::Log1p<T,S>));
+    CHECK(allNan(Backend::Logabs<T,S>));
+    CHECK(allNan(Backend::Sin<T,S>));
+    CHECK(allNan(Backend::Cos<T,S>));
+    CHECK(allNan(Backend::Tan<T,S>));
+    CHECK(allNan(Backend::Asin<T,S>));
+    CHECK(allNan(Backend::Acos<T,S>));
+    CHECK(allNan(Backend::Atan<T,S>));
+    CHECK(allNan(Backend::Sinh<T,S>));
+    CHECK(allNan(Backend::Cosh<T,S>));
+    CHECK(allNan(Backend::Tanh<T,S>));
+    CHECK(allNan(Backend::Sqrt<T,S>));
+    CHECK(allNan(Backend::Sqrtabs<T,S>));
+    CHECK(allNan(Backend::Cbrt<T,S>));
+
+    auto allNan2 = [](auto fn, T x, T y) -> bool {
+        Buf sa{}; sa.v.fill(T{0.5}); sa.v[0] = x;
+        Buf sb{}; sb.v.fill(T{0.5}); sb.v[0] = y;
+        Buf dst{};
+        fn(dst.v.data(), T{1}, sa.v.data(), sb.v.data());
+        return std::isnan(dst.v[0]);
+    };
+
+    CHECK(allNan2(Backend::Pow<T,S>, NaN, 2.f));
+    CHECK(allNan2(Backend::Pow<T,S>, 2.f, NaN));
+    CHECK(allNan2(Backend::Powabs<T,S>, NaN, 2.f));
+    CHECK(allNan2(Backend::Powabs<T,S>, 2.f, NaN));
 }
 
 TEST_CASE("Backend Pow/Powabs ULP accuracy", "[backend]")


### PR DESCRIPTION
## Summary

`FastExp` and `FastTanh` (`Operon::Backend::detail`, single-precision `exp()`/`tanh()` approximations used for all single-precision tree evaluation) silently turned a `NaN` input into a finite, plausible-looking wrong output instead of propagating `NaN`.

Root cause: `eve::clamp`/`eve::min`/`eve::max` on this platform return the non-`NaN` operand instead of propagating `NaN` (x86 `minps`/`maxps` semantics, not IEEE-754 NaN rules). `FastExp`'s initial range-reduction clamp and `FastTanh`'s clamp (both float and double precision) hit this. E.g. `FastTanh(NaN)` returned exactly `-1`; `FastExp(NaN)` returned `0` — even after #169's fix, since that fix only changed the final floor, not this earlier clamp.

Found while independently re-verifying a shape-constraints soundness-sweep finding: a `tanh(sqrt(...) + sqrt(...))`-shaped derivative tree's "ground truth" sample landed at exactly `-1`, tracing back to a `sqrt(negative)` domain error producing `NaN` that got silently laundered into `-1` by `FastTanh` instead of propagating.

Audited every `Fast*` function in `functions.hpp` for the same pattern (grepped for `eve::clamp`/`eve::min(`/`eve::max(`):

| Function | Uses clamp/min/max? | NaN-safe before this fix? |
|---|---|---|
| `FastExp` | yes (2 places) | No — fixed |
| `FastLog` | yes (1 place) | Yes — already had an explicit `is_nan` guard |
| `FastSinCos` (Sin/Cos) | no | Yes — confirmed unaffected |
| `FastTanh` (both precisions) | yes | No — fixed |
| `FastPow`/`FastPowabs` | composes `FastExp(y*FastLog(...))` | Fixed transitively |

## Fix

Added the same explicit `is_nan` guard `FastLog` already used to `FastExp` and both `FastTanh` branches.

## Test plan

- [x] New `"Backend NaN propagation"` test case: every `Backend::*` unary/binary function checked directly against a `NaN` input, each in its own isolated batch (deliberately not mixed with other edge-case values in the same SIMD batch — doing that during development accidentally surfaced an unrelated third-party bug in `eve::sinh`, reported separately upstream, not part of this PR).
- [x] Full suite (`~[performance]`) passes: 46364/46364 assertions, 298/298 test cases.
- [x] Measured performance cost in isolation (microbenchmark, `-O3 -march=x86-64-v3`, repeated for stability): `FastExp` +9-12%, `FastTanh` +9-13%. Since these are two of many primitives evaluated per tree, the effect on whole-tree throughput is expected to be diluted well below that, proportional to how often these two ops appear in a given primitive set.
