### PR TITLE
Defend Sinh/Tanh-derivative call sites against eve's cross-lane NaN bug

### DIFF
--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -324,7 +324,7 @@ namespace detail {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(eve::sinh(W{pj+s}), res+s);
+            eve::store(detail::SafeSinh<T>(W{pj+s}), res+s);
         }
     }
 
@@ -336,7 +336,13 @@ namespace detail {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(T{1} - eve::sqr(eve::tanh(W{pj+s})), res+s);
+            // FastTanh, not eve::tanh directly -- eve::tanh has a confirmed
+            // cross-lane NaN corruption bug (see functions.hpp's SafeSinh
+            // comment for the general shape of the issue); FastTanh is
+            // already NaN-safe (explicit is_nan guard) and structurally
+            // immune to cross-lane corruption (pure per-lane fma/clamp
+            // arithmetic, no operation touches more than one lane at once).
+            eve::store(T{1} - eve::sqr(detail::FastTanh<T>(W{pj+s})), res+s);
         }
     }
 

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -230,6 +230,24 @@ auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
     }
 }
 
+// eve::sinh has a confirmed cross-lane bug: a NaN in one SIMD lane corrupts
+// the computed result in a completely unrelated, non-NaN lane of the same
+// eve::wide register (not the single-lane NaN-swallowing pattern FastExp/
+// FastTanh above have -- this is a different, third-party defect in eve
+// itself, reported upstream). There is no in-house FastSinh polynomial to
+// fall back to, so defend the call site directly: scrub NaN lanes to a safe
+// placeholder before calling eve::sinh (so the SIMD op never sees a NaN in
+// any lane, which is what triggers the cross-lane corruption), then restore
+// NaN in the lanes that were actually NaN.
+template<std::floating_point T>
+auto SafeSinh(eve::wide<T> a) -> eve::wide<T> {
+    using W = eve::wide<T>;
+    auto isNan = eve::is_nan(a);
+    auto safe  = eve::if_else(isNan, W{T{0}}, a);
+    auto result = eve::sinh(safe);
+    return eve::if_else(isNan, eve::nan(eve::as<W>{}), result);
+}
+
 // FastPow: exp(y * log|x|) using FastExp+FastLog, ~2 ULP.
 // Sign rule: negate when x<0 and y is a finite odd integer.
 // Matches SLEEF xfastpowf_u3500 structure. Double falls back to eve::pow.
@@ -540,7 +558,7 @@ namespace Operon::Backend {
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {
-            eve::store(weight * eve::sinh(W{arg + i}), res+i);
+            eve::store(weight * detail::SafeSinh<T>(W{arg + i}), res+i);
         }
     }
 

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -65,7 +65,7 @@ namespace {
     auto VecLogabsf(__m256 v) noexcept -> __m256 { return Backend::detail::FastLog<float>(W8(eve::abs(W8(v)))); }
     auto VecLog1pf(__m256 v) noexcept -> __m256 { return eve::log1p(W8(v)); }
     auto VecSinf(__m256 v) noexcept -> __m256 { return Backend::detail::FastSinCos<true, float>(W8(v)); }
-    auto VecSinhf(__m256 v) noexcept -> __m256 { return eve::sinh(W8(v)); }
+    auto VecSinhf(__m256 v) noexcept -> __m256 { return Backend::detail::SafeSinh<float>(W8(v)); }
     auto VecTanf(__m256 v) noexcept -> __m256 { return eve::tan(W8(v)); }
     auto VecTanhf(__m256 v) noexcept -> __m256 { return Backend::detail::FastTanh<float>(W8(v)); }
     // Match interpreter's FastPow exactly.

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -257,6 +257,39 @@ TEST_CASE("Backend NaN propagation", "[backend]")
     CHECK(allNan2(Backend::Powabs<T,S>, 2.f, NaN));
 }
 
+// eve::sinh has a confirmed third-party bug: a NaN in one SIMD lane
+// corrupts the computed result in an unrelated, non-NaN lane of the same
+// eve::wide register -- a different, cross-lane defect from the single-
+// lane NaN-swallowing pattern the "Backend NaN propagation" test above
+// checks. Backend::Sinh defends against it via SafeSinh (scrub-compute-
+// restore around eve::sinh). Verify a NaN anywhere in the batch changes
+// no *other* lane's result versus an otherwise-identical all-clean batch.
+TEST_CASE("Backend Sinh is immune to eve::sinh's cross-lane NaN corruption", "[backend]")
+{
+    Buf clean{};
+    for (std::size_t i = 0; i < S; ++i) {
+        clean.v[i] = static_cast<T>(-2.0 + 0.1 * static_cast<double>(i));
+    }
+
+    Buf dstClean{};
+    Backend::Sinh<T,S>(dstClean.v.data(), T{1}, clean.v.data());
+
+    for (std::size_t nanPos = 0; nanPos < S; ++nanPos) {
+        Buf dirty = clean;
+        dirty.v[nanPos] = NaN;
+        Buf dstDirty{};
+        Backend::Sinh<T,S>(dstDirty.v.data(), T{1}, dirty.v.data());
+        for (std::size_t i = 0; i < S; ++i) {
+            INFO("nanPos=" << nanPos << " lane=" << i);
+            if (i == nanPos) {
+                CHECK(std::isnan(dstDirty.v[i]));
+            } else {
+                CHECK(dstDirty.v[i] == dstClean.v[i]);
+            }
+        }
+    }
+}
+
 TEST_CASE("Backend Pow/Powabs ULP accuracy", "[backend]")
 {
     auto MaxUlpError2 = [](auto fn, auto ref, std::vector<T> const& xs, std::vector<T> const& ys) {

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -284,7 +284,8 @@ TEST_CASE("Backend Sinh is immune to eve::sinh's cross-lane NaN corruption", "[b
             if (i == nanPos) {
                 CHECK(std::isnan(dstDirty.v[i]));
             } else {
-                CHECK(dstDirty.v[i] == dstClean.v[i]);
+                using U = std::conditional_t<sizeof(T) == 4, uint32_t, uint64_t>;
+                CHECK(std::bit_cast<U>(dstDirty.v[i]) == std::bit_cast<U>(dstClean.v[i]));
             }
         }
     }


### PR DESCRIPTION
## Summary

`eve::sinh` and `eve::tanh` (third-party, `jfalcou/eve`, pinned `eve-unstable-2026-06-29`) have a confirmed bug: a `NaN` in one SIMD lane corrupts the computed result in a completely unrelated, non-`NaN` lane of the same `eve::wide` register — a different, more serious defect than the single-lane NaN-swallowing pattern fixed in #171 (that one only corrupted the NaN-producing lane itself; this corrupts *other* lanes). Found via a 62-function sweep of `eve`'s math module (6 functions affected: `sinh`, `tanh`, `expm1`, `coth`, `csch`, `gd` — only `sinh`/`tanh` are actually used anywhere in operon). Reported upstream; a fix in `eve` itself isn't expected soon, so this defends operon's own call sites in the meantime.

Exposure map in operon's own code (excluding the already-known-broken, non-default MadEve backend):

- **Primal `Sinh`** (standard interpreter, `functions.hpp`) — called `eve::sinh` directly.
- **JIT `Sinh`** (`jit_compiler.cpp`) — called `eve::sinh` directly.
- **`Cosh`'s derivative rule** (`derivatives.hpp`, computes `sinh(x)`) — called `eve::sinh` directly.
- **`Tanh`'s derivative rule** (`derivatives.hpp`, computes `1 - tanh(x)²`) — called `eve::tanh` directly, instead of the already NaN-safe, cross-lane-immune `FastTanh` polynomial operon already uses for `Tanh`'s own primal evaluation. No principled reason found for the inconsistency — `derivatives.hpp` already includes `functions.hpp` and `FastTanh` was fully reachable.

`Cosh` itself (primal, JIT, and `Sinh`'s own derivative rule, all `eve::cosh`) is confirmed clean by the sweep — untouched.

## Fix

- Added `SafeSinh` (`Operon::Backend::detail`): scrubs `NaN` lanes to a safe placeholder before calling `eve::sinh` (so the underlying SIMD op never sees a `NaN` in any lane, which is what the sweep found triggers the corruption), then restores `NaN` in the lanes that actually were `NaN`. Used at all three `eve::sinh` call sites.
- Switched `Tanh`'s derivative rule to `FastTanh` (already NaN-safe per #171, and structurally immune to cross-lane corruption — pure per-lane `fma`/`clamp` arithmetic, no operation touches more than one lane at once).

## Test plan

- [x] New `"Backend Sinh is immune to eve::sinh's cross-lane NaN corruption"` test: for every possible `NaN` lane position across a full batch, verifies every *other* lane's result is bit-identical to an all-clean baseline, and the `NaN` lane itself is `NaN`.
- [x] Full suite (`~[performance]`) passes: 62748/62748 assertions, 299/299 test cases.
- [x] Verified the `SafeSinh` approach directly against the original cross-lane repro before wiring it in (raw `eve::sinh` corrupted; `SafeSinh` matched the clean baseline exactly).
