### PR TITLE
Remove SafeSinh cross-lane defense now that eve fixed it upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783345914,
-        "narHash": "sha256-Th1NPQdVFhvxAV66Reu2XhCCXGEMJpsi58+GWgbNh68=",
+        "lastModified": 1786347833,
+        "narHash": "sha256-h/PYrwkBxICorJOVsk0lwGG/W0Fk2MLBFV9F9xzoiN4=",
         "owner": "foolnotion",
         "repo": "nur-pkg",
-        "rev": "47c762f58ae57a606708b66211ce65527600d274",
+        "rev": "049b418d5bd88485c15e2f5cbac9c4dc63184b00",
         "type": "github"
       },
       "original": {

--- a/include/operon/interpreter/backend/eve/derivatives.hpp
+++ b/include/operon/interpreter/backend/eve/derivatives.hpp
@@ -324,7 +324,7 @@ namespace detail {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            eve::store(detail::SafeSinh<T>(W{pj+s}), res+s);
+            eve::store(eve::sinh(W{pj+s}), res+s);
         }
     }
 
@@ -336,12 +336,11 @@ namespace detail {
         auto* res = Ptr(trace, j);
         auto const* pj = Ptr(primal, j);
         for (auto s = 0UL; s < S; s += L) {
-            // FastTanh, not eve::tanh directly -- eve::tanh has a confirmed
-            // cross-lane NaN corruption bug (see functions.hpp's SafeSinh
-            // comment for the general shape of the issue); FastTanh is
-            // already NaN-safe (explicit is_nan guard) and structurally
-            // immune to cross-lane corruption (pure per-lane fma/clamp
-            // arithmetic, no operation touches more than one lane at once).
+            // FastTanh, not eve::tanh directly -- matches primal Tanh's own
+            // evaluation, which already uses FastTanh (no principled reason
+            // to diverge). Also NaN-safe and immune to eve::tanh's now-fixed
+            // (see eve#2366) cross-lane corruption bug, though that's no
+            // longer the reason to prefer it here.
             eve::store(T{1} - eve::sqr(detail::FastTanh<T>(W{pj+s})), res+s);
         }
     }

--- a/include/operon/interpreter/backend/eve/functions.hpp
+++ b/include/operon/interpreter/backend/eve/functions.hpp
@@ -230,24 +230,6 @@ auto FastTanh(eve::wide<T> a) -> eve::wide<T> {
     }
 }
 
-// eve::sinh has a confirmed cross-lane bug: a NaN in one SIMD lane corrupts
-// the computed result in a completely unrelated, non-NaN lane of the same
-// eve::wide register (not the single-lane NaN-swallowing pattern FastExp/
-// FastTanh above have -- this is a different, third-party defect in eve
-// itself, reported upstream). There is no in-house FastSinh polynomial to
-// fall back to, so defend the call site directly: scrub NaN lanes to a safe
-// placeholder before calling eve::sinh (so the SIMD op never sees a NaN in
-// any lane, which is what triggers the cross-lane corruption), then restore
-// NaN in the lanes that were actually NaN.
-template<std::floating_point T>
-auto SafeSinh(eve::wide<T> a) -> eve::wide<T> {
-    using W = eve::wide<T>;
-    auto isNan = eve::is_nan(a);
-    auto safe  = eve::if_else(isNan, W{T{0}}, a);
-    auto result = eve::sinh(safe);
-    return eve::if_else(isNan, eve::nan(eve::as<W>{}), result);
-}
-
 // FastPow: exp(y * log|x|) using FastExp+FastLog, ~2 ULP.
 // Sign rule: negate when x<0 and y is a finite odd integer.
 // Matches SLEEF xfastpowf_u3500 structure. Double falls back to eve::pow.
@@ -558,7 +540,7 @@ namespace Operon::Backend {
         using W = eve::wide<T>;
         constexpr auto L = W::size();
         for (auto i = 0UL; i < S; i += L) {
-            eve::store(weight * detail::SafeSinh<T>(W{arg + i}), res+i);
+            eve::store(weight * eve::sinh(W{arg + i}), res+i);
         }
     }
 

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -65,7 +65,7 @@ namespace {
     auto VecLogabsf(__m256 v) noexcept -> __m256 { return Backend::detail::FastLog<float>(W8(eve::abs(W8(v)))); }
     auto VecLog1pf(__m256 v) noexcept -> __m256 { return eve::log1p(W8(v)); }
     auto VecSinf(__m256 v) noexcept -> __m256 { return Backend::detail::FastSinCos<true, float>(W8(v)); }
-    auto VecSinhf(__m256 v) noexcept -> __m256 { return Backend::detail::SafeSinh<float>(W8(v)); }
+    auto VecSinhf(__m256 v) noexcept -> __m256 { return eve::sinh(W8(v)); }
     auto VecTanf(__m256 v) noexcept -> __m256 { return eve::tan(W8(v)); }
     auto VecTanhf(__m256 v) noexcept -> __m256 { return Backend::detail::FastTanh<float>(W8(v)); }
     // Match interpreter's FastPow exactly.

--- a/test/source/implementation/backend.cpp
+++ b/test/source/implementation/backend.cpp
@@ -257,13 +257,13 @@ TEST_CASE("Backend NaN propagation", "[backend]")
     CHECK(allNan2(Backend::Powabs<T,S>, 2.f, NaN));
 }
 
-// eve::sinh has a confirmed third-party bug: a NaN in one SIMD lane
-// corrupts the computed result in an unrelated, non-NaN lane of the same
-// eve::wide register -- a different, cross-lane defect from the single-
-// lane NaN-swallowing pattern the "Backend NaN propagation" test above
-// checks. Backend::Sinh defends against it via SafeSinh (scrub-compute-
-// restore around eve::sinh). Verify a NaN anywhere in the batch changes
-// no *other* lane's result versus an otherwise-identical all-clean batch.
+// eve::sinh had a third-party cross-lane bug (a NaN in one SIMD lane
+// corrupted the computed result in an unrelated, non-NaN lane of the same
+// eve::wide register), fixed upstream in eve#2366. Kept as a permanent
+// regression guard now that Backend::Sinh calls eve::sinh directly again
+// (no more scrub-compute-restore wrapper). Verify a NaN anywhere in the
+// batch changes no *other* lane's result versus an otherwise-identical
+// all-clean batch.
 TEST_CASE("Backend Sinh is immune to eve::sinh's cross-lane NaN corruption", "[backend]")
 {
     Buf clean{};

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
         {
             "kind": "git",
             "repository": "https://github.com/foolnotion/vcpkg-registry",
-            "baseline": "ef66d57bf16d0f407c7e1cc0f86332f704d82426",
+            "baseline": "82663846db2204d2c78a2dd567a87e71123ab3fa",
             "packages": [
                 "aria-csv",
                 "asmjit",


### PR DESCRIPTION
## Summary

#172 defended `eve::sinh`/`eve::tanh` call sites against a confirmed
third-party bug: a `NaN` in one SIMD lane of an `eve::wide` register
corrupted the computed result in a completely unrelated, non-`NaN` lane
of the same register (affecting `sinh`, `tanh`, `expm1`, `coth`, `csch`,
`gd` in `eve`'s math module).

[jfalcou/eve#2366](https://github.com/jfalcou/eve/pull/2366) fixes the
shared root cause: `expm1`'s own non-finite-lane handling was calling
the fast/approximate `[raw]` path for the *entire* register whenever any
lane was non-finite, degrading accuracy in every other lane too. Since
`sinh`, `tanh`, and `coth` call `expm1` directly, and `csch`/`gd` call
`sinh`/`tanh` respectively, this one-line upstream fix covers all 6
affected functions.

## Changes

- Bumped the `foolnotion/nur-pkg` (`eve` package) pin to
  `unstable-2026-08-07` (past eve#2366's merge).
- Removed `SafeSinh` (`functions.hpp`) and reverted its 3 call sites
  (primal `Sinh`, JIT `Sinh`, `Cosh`'s derivative rule) to call
  `eve::sinh` directly.
- Left `Tanh`'s derivative rule on `FastTanh` — #172 framed that switch
  as also fixing an unrelated inconsistency with primal `Tanh` (which
  already used `FastTanh`), not purely a defensive workaround, so kept
  it independent of the eve bug status.
- Updated the stale `SafeSinh`-referencing comment on the regression
  test, kept the test itself as a permanent guard.

## Verification

- Standalone before/after repro (built at operon's actual
  `-march=x86-64-v3` target) against both eve pins: all 6 functions
  (`sinh`, `tanh`, `expm1`, `coth`, `csch`, `gd`) show cross-lane
  corruption under the old pin, clean under the new one.
- Full test suite (`~[performance]`) passes both *with* the defense in
  place (confirms the eve bump alone doesn't regress anything) and
  *without* it (confirms nothing else depended on `SafeSinh`
  incidentally) — 0 failures in both runs.

## Test plan

- [x] Standalone cross-lane repro, old vs new eve pin
- [x] Full suite passes with defense removed