### PR TITLE
Fix --jit=jac crash: CompileJacobian never set nVars/nConsts

### DIFF
--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -669,12 +669,6 @@ auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<Co
     auto result = std::make_unique<CompileMeta>();
     result->rtJac = &rt;
     result->jacFn = fnPtr;
-    // Unlike CompileAVX2, this was previously left unset (default 0), which
-    // JitLMCostFunction::Evaluate's ENSURE(nVars_ < 0 || jacColPtrs_.size()
-    // == nVars_) trips on for any tree with variables -- fatal for --jit=jac
-    // mode, which (unlike --jit=all) never falls through to GetOrCompile's
-    // merge branch that would otherwise backfill these from the residual
-    // compile.
     result->nVars = static_cast<int>(varOrder.size());
     result->nConsts = nConsts;
     return result;

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -669,6 +669,14 @@ auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<Co
     auto result = std::make_unique<CompileMeta>();
     result->rtJac = &rt;
     result->jacFn = fnPtr;
+    // Unlike CompileAVX2, this was previously left unset (default 0), which
+    // JitLMCostFunction::Evaluate's ENSURE(nVars_ < 0 || jacColPtrs_.size()
+    // == nVars_) trips on for any tree with variables -- fatal for --jit=jac
+    // mode, which (unlike --jit=all) never falls through to GetOrCompile's
+    // merge branch that would otherwise backfill these from the residual
+    // compile.
+    result->nVars = static_cast<int>(varOrder.size());
+    result->nConsts = nConsts;
     return result;
     } catch (std::exception const&) {
         return nullptr;


### PR DESCRIPTION
## Summary
`--jit=jac` (JIT-compile only the Jacobian, interpreter residuals) crashed for any tree with variables, tripping `ENSURE(nVars_ < 0 || jacColPtrs_.size() == nVars_)` in `JitLMCostFunction::Evaluate`.

Cause: `TreeCompiler::CompileJacobian` never set `CompileMeta::nVars` or `nConsts` on its result, so both stayed at their default of 0. `TreeCompiler::CompileAVX2` does set them. `--jit=all` never exposed this bug because it always falls through to `GetOrCompile`, and that function's cache-merge branch backfills `nVars`/`nConsts` from the residual compile. `--jit=jac` never takes that fallback path, so the zeroed metadata reached `JitLMCostFunction` directly.

Fix: set `nVars` and `nConsts` in `CompileJacobian`, mirroring `CompileAVX2`.

## Test plan
- All jit tests pass (`./build/test/operon_test '[jit]~[performance]'`).
- Full suite otherwise unaffected, aside from one pre-existing failure unrelated to this change.
- Reproduced the crash before the fix; confirmed a clean run with correct model output after.
