### PR TITLE
Avoid per-call heap allocation in JitLMCostFunction::Evaluate

### DIFF
--- a/include/operon/optimizer/jit_lm_cost_function.hpp
+++ b/include/operon/optimizer/jit_lm_cost_function.hpp
@@ -61,6 +61,15 @@ struct JitLMCostFunction : public LMCostFunctionBase<JitLMCostFunction<T, Storag
         , nConsts_(nConsts)
     {
         ValidateLMWeights(weights_, this->numResiduals_);
+        // Precomputed once: these point into scratchJac_'s fixed layout, which
+        // never changes across Evaluate() calls, so recomputing them per call
+        // (as a freshly heap-allocated std::vector, no less) was pure waste on
+        // what can be a very hot path (up to population x selection-pressure x
+        // LM-iterations calls per generation).
+        jacOutPtrs_.resize(this->numParameters_);
+        for (std::size_t k = 0; k < this->numParameters_; ++k) {
+            jacOutPtrs_[k] = scratchJac_.data() + k * nRowsPad_;
+        }
     }
 
     inline auto Evaluate(Scalar const* parameters, Scalar* residuals, Scalar* jacobian) const -> bool // NOLINT
@@ -77,11 +86,7 @@ struct JitLMCostFunction : public LMCostFunctionBase<JitLMCostFunction<T, Storag
                 ENSURE(nVars_   < 0 || static_cast<int>(jacColPtrs_.size()) == nVars_);
                 ENSURE(nConsts_ < 0 || static_cast<int>(this->numParameters_) == nConsts_);
                 // Write into padded per-column scratch, then copy valid rows to jacobian.
-                std::vector<float*> outs(this->numParameters_);
-                for (std::size_t k = 0; k < this->numParameters_; ++k) {
-                    outs[k] = scratchJac_.data() + k * nRowsPad_;
-                }
-                jacFn_(outs.data(), jacColPtrs_.data(), nRowsPad, parameters);
+                jacFn_(jacOutPtrs_.data(), jacColPtrs_.data(), nRowsPad, parameters);
                 for (std::size_t k = 0; k < this->numParameters_; ++k) {
                     std::copy_n(scratchJac_.data() + k * nRowsPad_, this->numResiduals_,
                                 jacobian + k * static_cast<std::ptrdiff_t>(this->numResiduals_));
@@ -125,6 +130,7 @@ private:
     std::size_t                              nRowsPad_;
     mutable std::vector<Scalar>              scratchResiduals_;
     mutable std::vector<Scalar>              scratchJac_;
+    std::vector<float*>                      jacOutPtrs_; // precomputed pointers into scratchJac_, see ctor
 
     int                                      nVars_   = -1;
     int                                      nConsts_ = -1;

--- a/include/operon/optimizer/jit_lm_cost_function.hpp
+++ b/include/operon/optimizer/jit_lm_cost_function.hpp
@@ -65,12 +65,22 @@ struct JitLMCostFunction : public LMCostFunctionBase<JitLMCostFunction<T, Storag
         // never changes across Evaluate() calls, so recomputing them per call
         // (as a freshly heap-allocated std::vector, no less) was pure waste on
         // what can be a very hot path (up to population x selection-pressure x
-        // LM-iterations calls per generation).
-        jacOutPtrs_.resize(this->numParameters_);
-        for (std::size_t k = 0; k < this->numParameters_; ++k) {
-            jacOutPtrs_[k] = scratchJac_.data() + k * nRowsPad_;
+        // LM-iterations calls per generation). Skipped for residual-only objects
+        // (jacFn_ == nullptr), which never dereference jacOutPtrs_.
+        if (jacFn_ != nullptr) {
+            jacOutPtrs_.resize(this->numParameters_);
+            for (std::size_t k = 0; k < this->numParameters_; ++k) {
+                jacOutPtrs_[k] = scratchJac_.data() + k * nRowsPad_;
+            }
         }
     }
+
+    // jacOutPtrs_ points into this object's own scratchJac_; a copy would leave
+    // the copy's pointers aimed at the source's buffer, silently returning stale
+    // Jacobians. All current call sites hold this by reference, so deleting the
+    // copy ops just fences the footgun rather than fixing a live bug.
+    JitLMCostFunction(JitLMCostFunction const&) = delete;
+    auto operator=(JitLMCostFunction const&) -> JitLMCostFunction& = delete;
 
     inline auto Evaluate(Scalar const* parameters, Scalar* residuals, Scalar* jacobian) const -> bool // NOLINT
     {


### PR DESCRIPTION
## Summary
Each call to `JitLMCostFunction::Evaluate` heap-allocated its Jacobian output pointer array, even though the array's contents are fully determined by `numParameters_` and the fixed layout of `scratchJac_`, both constant for the object's lifetime. Fix: precompute the pointer array once, in the constructor.

The fix also skips this precompute for residual-only objects (`jacFn_ == nullptr`), which never dereference it, and deletes the copy constructor and copy assignment operator: a copy would leave its `jacOutPtrs_` pointing into the source object's `scratchJac_`, silently returning stale Jacobians.

## Test plan
- All jit tests pass (`./build/test/operon_test '[jit]~[performance]'`).
- Full suite otherwise unaffected, aside from one pre-existing failure unrelated to this change.
- Confirmed identical model output before and after, same seed and same final model: this is a pure allocation elimination with no behavior change.
