### PR TITLE
fix(optimizer): accept Poisson NLL improvements

### DIFF
--- a/include/operon/optimizer/likelihood/poisson_likelihood.hpp
+++ b/include/operon/optimizer/likelihood/poisson_likelihood.hpp
@@ -101,12 +101,12 @@ template<typename T = Operon::Scalar, bool LogInput = true>
 struct PoissonLoss : public LikelihoodBase<T> {
     static constexpr bool UsesSigma = false;
 
-    // See GaussianLoss::Cost - weights are intentionally ignored here (see
-    // the constructor comment below for why), so this stays unweighted
-    // regardless of what's passed in.
+    // Diagnostic cost reported in OptimizerSummary. It must differ from
+    // operator() only by coefficient-independent constants, so optimizer
+    // acceptance and the Poisson gradient use the same objective.
     template<typename Pred>
-    static auto Cost(Pred const& pred, Operon::Span<Operon::Scalar const> target, Operon::Span<Operon::Scalar const> /*weights*/) noexcept -> Operon::Scalar {
-        return static_cast<Operon::Scalar>(0.5 * Operon::SumOfSquaredErrors(pred.begin(), pred.end(), target.begin()));
+    static auto Cost(Pred const& pred, Operon::Span<Operon::Scalar const> target, Operon::Span<Operon::Scalar const> /*weights*/) -> Operon::Scalar {
+        return PoissonLikelihood<T, LogInput>::ComputeLikelihood(pred, target, {});
     }
 
     // `weights` is accepted only so PoissonLoss shares LBFGSOptimizer/SGDOptimizer's

--- a/test/source/implementation/optimizer.cpp
+++ b/test/source/implementation/optimizer.cpp
@@ -112,6 +112,16 @@ TEST_CASE("Gaussian likelihood static methods", "[likelihood]")
     }
 }
 
+TEST_CASE("Poisson optimizer diagnostics use Poisson NLL", "[optimizer][likelihood]")
+{
+    using Loss = PoissonLoss<Operon::Scalar>;
+    std::vector<Operon::Scalar> const prediction{0.0F, std::log(2.0F)};
+    std::vector<Operon::Scalar> const target{1.0F, 3.0F};
+
+    CHECK(Loss::Cost(prediction, target, {})
+        == PoissonLikelihood<Operon::Scalar>::ComputeLikelihood(prediction, target, {}));
+}
+
 TEST_CASE("Parameter optimization", "[optimizer]") // NOLINT(readability-function-cognitive-complexity)
 {
     OptimizerFixture fix;


### PR DESCRIPTION
PoissonLoss optimized Poisson NLL but reported SSE for FitOutcome acceptance. Use full-data Poisson NLL for diagnostics and acceptance, with regression coverage.