### PR TITLE
fix(core): refresh default inputs after target changes

### DIFF
--- a/include/operon/core/problem.hpp
+++ b/include/operon/core/problem.hpp
@@ -40,6 +40,7 @@ class Problem {
     Operon::Variable target_;
     Operon::Set<Operon::Hash> inputs_;
 
+    bool defaultInputs_{true};
 
     // Problem owns the PrimitiveSet, so it represents the problem formulation
     // rather than a bare dataset view; whether the fitted model is
@@ -69,6 +70,7 @@ public:
     template<typename T>
     auto SetTarget(T t) {
         target_ = GetVariable<std::remove_cvref_t<T>>(t);
+        if (defaultInputs_) { SetDefaultInputs(); }
     }
 
     auto SetTrainingRange(Operon::Range range) { training_ = range; }
@@ -82,6 +84,7 @@ public:
 
     auto SetInputs(auto const& inputs) {
         ValidateInputs(inputs);
+        defaultInputs_ = false;
         inputs_.clear();
         for (auto const& x : inputs) {
             inputs_.insert(GetVariable(x).Hash);
@@ -94,6 +97,7 @@ public:
 
     // set all variables except the target as inputs
     auto SetDefaultInputs() -> void {
+        defaultInputs_ = true;
         inputs_.clear();
         for (auto const& v : dataset_->GetVariables()) {
             if (v.Hash != target_.Hash) { inputs_.insert(v.Hash); }

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -18,6 +18,7 @@
 #include "operon/core/node.hpp"
 #include "operon/core/tree.hpp"
 #include "operon/core/dataset.hpp"
+#include "operon/core/problem.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/core/types.hpp"
 

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -87,6 +87,23 @@ TEST_CASE("Tree coefficients", "[core]")
     CHECK(coeff2[1] == Catch::Approx(2.0F));
 }
 
+TEST_CASE("Problem target selection refreshes default inputs", "[core]")
+{
+    Operon::Dataset dataset{{"X1", "Y", "X2"}, {{1.0F}, {2.0F}, {3.0F}}};
+    Operon::Problem problem{&dataset};
+
+    problem.SetTarget("Y");
+
+    auto const target = dataset.GetVariable("Y")->Hash;
+    CHECK(std::ranges::find(problem.GetInputs(), target) == problem.GetInputs().end());
+    CHECK(problem.GetInputs().size() == 2);
+
+    auto const x1 = dataset.GetVariable("X1")->Hash;
+    problem.SetInputs(std::vector<Operon::Hash>{x1});
+    problem.SetTarget("X2");
+    CHECK(problem.GetInputs() == std::vector<Operon::Hash>{x1});
+}
+
 TEST_CASE("Dataset loading and access", "[core]")
 {
     auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);


### PR DESCRIPTION
Keep default inputs synchronized with the selected target while preserving explicit caller input selections.