### PR TITLE
fix(core): validate tree coefficient spans

### DIFF
--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <optional>
 #include <vector>
+#include <stdexcept>
 
 #include "operon/core/tree.hpp"
 #include "operon/hash/hash.hpp"
@@ -142,6 +143,9 @@ void Tree::GetCoefficients(std::vector<Operon::Scalar>& out) const
 
 void Tree::SetCoefficients(Operon::Span<Operon::Scalar const> coefficients)
 {
+    if (coefficients.size() != static_cast<size_t>(CoefficientsCount())) {
+        throw std::invalid_argument("coefficient count must match the number of optimizable tree nodes");
+    }
     size_t idx = 0;
     for (auto& s : nodes_) {
         if (s.Optimize) { s.Value = coefficients[idx++]; }

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -105,6 +105,19 @@ TEST_CASE("Problem target selection refreshes default inputs", "[core]")
     CHECK(problem.GetInputs() == std::vector<Operon::Hash>{x1});
 }
 
+TEST_CASE("Tree rejects mismatched coefficient spans", "[core]")
+{
+    Node c1(NodeType::Constant); c1.Optimize = true;
+    Node c2(NodeType::Constant); c2.Optimize = true;
+    Tree tree({c1, c2, Util::MakeOp<BuiltinOp::Add>()});
+    tree.UpdateNodes();
+
+    std::vector<Operon::Scalar> const shortCoefficients{1.0F};
+    std::vector<Operon::Scalar> const longCoefficients{1.0F, 2.0F, 3.0F};
+    CHECK_THROWS_AS(tree.SetCoefficients(shortCoefficients), std::invalid_argument);
+    CHECK_THROWS_AS(tree.SetCoefficients(longCoefficients), std::invalid_argument);
+}
+
 TEST_CASE("Dataset loading and access", "[core]")
 {
     auto ds = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);


### PR DESCRIPTION
Reject undersized and oversized coefficient spans rather than reading out of bounds or ignoring values.