### PR TITLE
Fix JIT compiler reuse and cache statistics

### DIFF
--- a/include/operon/interpreter/backend/jit/jit_evaluator.hpp
+++ b/include/operon/interpreter/backend/jit/jit_evaluator.hpp
@@ -69,9 +69,13 @@ public:
 
     auto Evaluate(RandomGenerator& rng, Individual const& ind, Span<Scalar> buf) const -> ReturnType override;
 
-    [[nodiscard]] auto CacheSize()   const -> std::size_t;
-    [[nodiscard]] auto CacheHits()   const -> std::size_t { return hits_.load(); }
-    [[nodiscard]] auto CacheMisses() const -> std::size_t { return misses_.load(); }
+    [[nodiscard]] auto CacheSize() const -> std::size_t;
+    // Counts only lookups that find an already-compiled forward function.
+    [[nodiscard]] auto CacheHits() const -> std::size_t { return cacheHits_.load(); }
+    // Counts JIT-eligible forward lookups with no compiled forward function.
+    [[nodiscard]] auto CacheMisses() const -> std::size_t { return cacheMisses_.load(); }
+    // Counts successful forward compilations initiated by this evaluator.
+    [[nodiscard]] auto CompileSuccesses() const -> std::size_t { return compileSuccesses_.load(); }
 
     void ResetCounters(); // not thread-safe; call only when no evaluations are in flight
     // Releases cached code. Call only when no returned CompileMeta pointer is
@@ -108,8 +112,9 @@ private:
     int         maxLength_{0};
     std::size_t minVisits_{1};
 
-    mutable std::atomic<std::size_t> hits_{0};
-    mutable std::atomic<std::size_t> misses_{0};
+    mutable std::atomic<std::size_t> cacheHits_{0};
+    mutable std::atomic<std::size_t> cacheMisses_{0};
+    mutable std::atomic<std::size_t> compileSuccesses_{0};
     mutable std::atomic<std::size_t> avx2Fails_{0};
     mutable std::atomic<std::size_t> compileFails_{0};
 };

--- a/source/interpreter/backend/jit/jit_compiler.cpp
+++ b/source/interpreter/backend/jit/jit_compiler.cpp
@@ -427,9 +427,18 @@ auto TreeCompiler::CompileAVX2(Operon::Tree const& tree) -> std::unique_ptr<Comp
         }
     }
 
-    CodeHolder code;
+    // Keep the compiler and CodeHolder's soft-reset arena. `reinit()` is
+    // intentionally avoided: with this AsmJit build it can emit stale direct
+    // call relocations; see the [jit][repro] regression test.
+    thread_local CodeHolder code;
+    thread_local Compiler   cc;
+    thread_local bool       initialized = false;
+    if (initialized) {
+        code.reset();
+    }
     code.init(rt.environment(), rt.cpu_features());
-    Compiler cc(&code);
+    code.attach(&cc);
+    initialized = true;
 
     FuncNode* fnNode = cc.add_func(
         FuncSignature::build<void, float*, float const* const*, int32_t, float const*>());
@@ -558,9 +567,17 @@ auto TreeCompiler::CompileJacobian(JacobianDag const& dag) -> std::unique_ptr<Co
         }
     }
 
-    CodeHolder code;
+    // Keep the compiler and CodeHolder's soft-reset arena. See CompileAVX2
+    // for why this uses AsmJit's init()/reset() reuse strategy.
+    thread_local CodeHolder code;
+    thread_local Compiler   cc;
+    thread_local bool       initialized = false;
+    if (initialized) {
+        code.reset();
+    }
     code.init(rt.environment(), rt.cpu_features());
-    Compiler cc(&code);
+    code.attach(&cc);
+    initialized = true;
 
     // void fn(float* const* outs, float const* const* cols, int32_t nRows, float const* consts)
     FuncNode* fnNode = cc.add_func(

--- a/source/interpreter/backend/jit/jit_evaluator.cpp
+++ b/source/interpreter/backend/jit/jit_evaluator.cpp
@@ -42,16 +42,18 @@ auto JitEvaluator::GetOrCompile(Tree const& tree) const -> CompileMeta const*
 
 auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMeta const*
 {
-    if (maxLength_ > 0 && std::cmp_greater(tree.Length(), maxLength_)) { ++misses_; return nullptr; }
+    if (maxLength_ > 0 && std::cmp_greater(tree.Length(), maxLength_)) { return nullptr; }
 
     // Fast path: already compiled.
     CompileMeta const* result{};
     if (zobrist_->JitCache().IfContains(hash, [&](JitEntry const& e) -> void {
             if (e.meta && e.meta->fn) { result = e.meta.get(); }
         }) && result != nullptr) {
-        ++hits_;
+        ++cacheHits_;
         return result;
     }
+
+    ++cacheMisses_;
 
     // Increment visit counter; return nullptr until frequency threshold is met.
     std::size_t visits{};
@@ -59,7 +61,7 @@ auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMet
         [&](JitEntry& e) -> void { visits = ++e.Visits; },
         [&](JitEntry& e) -> void { visits = ++e.Visits; }
     );
-    if (visits < minVisits_) { ++misses_; return nullptr; }
+    if (visits < minVisits_) { return nullptr; }
 
     // Compile outside the map lock so cc.finalize() runs in parallel.
     // AVX2-only: no scalar/SSE fallback attempt (see jit_compiler.hpp) — a
@@ -67,7 +69,12 @@ auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMet
     // asmjit failure) falls straight through to interpreter evaluation via
     // the nullptr compiled result below.
     auto compiled = compiler_.CompileAVX2(tree);
-    if (!compiled) { ++avx2Fails_; ++compileFails_; }
+    if (compiled) {
+        ++compileSuccesses_;
+    } else {
+        ++avx2Fails_;
+        ++compileFails_;
+    }
 
     zobrist_->JitCache().ModifyIf(hash, [&](JitEntry& e) -> void {
         if (!e.meta) {
@@ -80,7 +87,6 @@ auto JitEvaluator::GetOrCompile(Tree const& tree, Hash hash) const -> CompileMet
         }
         if (e.meta && e.meta->fn) { result = e.meta.get(); }
     });
-    if (result != nullptr) { ++hits_; } else { ++misses_; }
     return result;
 }
 
@@ -203,8 +209,9 @@ void JitEvaluator::ClearCache()
 
 void JitEvaluator::ResetCounters()
 {
-    hits_.store(0);
-    misses_.store(0);
+    cacheHits_.store(0);
+    cacheMisses_.store(0);
+    compileSuccesses_.store(0);
     avx2Fails_.store(0);
     compileFails_.store(0);
 }

--- a/source/interpreter/backend/jit/jit_factory.cpp
+++ b/source/interpreter/backend/jit/jit_factory.cpp
@@ -52,12 +52,13 @@ auto MakeJitObjects(
         jev->SetMaxLength(jitMaxLength);
         jev->SetMinVisits(jitMinVisits);
         out.Report = [jev]() -> void {
-            auto const hits   = jev->CacheHits();
-            auto const misses = jev->CacheMisses();
-            auto const total  = hits + misses;
-            auto const rate   = total > 0U ? 100.0 * static_cast<double>(hits) / static_cast<double>(total) : 0.0;
-            fmt::print(stderr, "jit | cache {:5} | hits {:6} | misses {:6} | hit% {:5.1f}\n",
-                       jev->CacheSize(), hits, misses, rate);
+            auto const hits     = jev->CacheHits();
+            auto const misses   = jev->CacheMisses();
+            auto const compiled = jev->CompileSuccesses();
+            auto const total    = hits + misses;
+            auto const rate     = total > 0U ? 100.0 * static_cast<double>(hits) / static_cast<double>(total) : 0.0;
+            fmt::print(stderr, "jit | cache {:5} | hits {:6} | misses {:6} | compiled {:6} | hit% {:5.1f}\n",
+                       jev->CacheSize(), hits, misses, compiled, rate);
             jev->ResetCounters();
         };
     }

--- a/test/source/implementation/jit.cpp
+++ b/test/source/implementation/jit.cpp
@@ -316,23 +316,27 @@ TEST_CASE("JitEvaluator correctness", "[jit][evaluator]")
         CHECK(jitEval.CacheHits() >= 1);
     }
 
-    SECTION("CacheMisses and ResetCounters") {
-        // Length gate forces a miss.
+    SECTION("Cache counters and ResetCounters") {
+        // The length gate rejects the tree before a JIT-cache lookup.
         jitEval.SetMaxLength(1);
 
         auto tree = InfixParser::Parse("X1 * X2 + X3", ds);  // length > 1
         auto const* c = jitEval.GetOrCompile(tree);
         CHECK(c == nullptr);
-        CHECK(jitEval.CacheMisses() >= 1);
-
-        // ResetCounters clears hit/miss/fail counters without touching the cache.
-        jitEval.SetMaxLength(0);
-        auto const* c2 = jitEval.GetOrCompile(tree);  // this will compile and increment hits
-        CHECK(c2 != nullptr);
-
-        jitEval.ResetCounters();
-        CHECK(jitEval.CacheHits()   == 0);
         CHECK(jitEval.CacheMisses() == 0);
+
+        // An eligible first lookup is a cache miss and compiles the entry.
+        jitEval.SetMaxLength(0);
+        auto const* c2 = jitEval.GetOrCompile(tree);
+        CHECK(c2 != nullptr);
+        CHECK(jitEval.CacheMisses() == 1);
+        CHECK(jitEval.CompileSuccesses() == 1);
+
+        // ResetCounters clears metrics without touching the cache.
+        jitEval.ResetCounters();
+        CHECK(jitEval.CacheHits() == 0);
+        CHECK(jitEval.CacheMisses() == 0);
+        CHECK(jitEval.CompileSuccesses() == 0);
         // Cache itself is unaffected — the compiled entry is still there.
         CHECK(jitEval.CacheSize() >= 1);
     }
@@ -1217,6 +1221,48 @@ TEST_CASE("JitLMCostFunction TinySolver convergence", "[jit][lm]")
         INFO("row " << i);
         CHECK(predVec[i] == Catch::Approx(y[i]).epsilon(1e-3F));
     }
+}
+
+TEST_CASE("JIT compiler CodeHolder reuse replay", "[jit][repro]")
+{
+    auto ds    = Dataset("./data/Poly-10.csv", /*hasHeader=*/true);
+    auto range = Range{0, 201};
+
+    JIT::JitRuntimePool compilerPool;
+    JIT::TreeCompiler compiler{&compilerPool};
+    if (!compiler.HasAVX2()) { SKIP("AVX2 not available"); }
+
+    auto first = InfixParser::Parse(
+        "((((((-5) * X4) + 1) - sin(2)) * (((2 * X5) - ((-3) * X3)) + ((-1) / (1 * X3)))) + ((((3 * X8) / 4) / (2 - ((-4) * X8))) / ((3 - ((-5) * X9)) + sin((0 * X8)))))",
+        ds);
+    auto second = InfixParser::Parse(
+        "sin((((((((2 * X10) * (0 * X1)) + sin(((-4) * X2))) + ((0 * X8) + ((-5) * X8))) * ((((-2) * X7) + ((-3) * X3)) / (3 * 0))) - sin(sin((1 + 2)))) - sin(sin(sin(((-1) / (2 * X10)))))))",
+        ds);
+
+    auto firstCompiled = compiler.CompileAVX2(first);
+    REQUIRE(firstCompiled != nullptr);
+    REQUIRE(firstCompiled->fn != nullptr);
+    auto firstResult = EvalCompiled(*firstCompiled, first, ds, range);
+
+    auto secondCompiled = compiler.CompileAVX2(second);
+    REQUIRE(secondCompiled != nullptr);
+    REQUIRE(secondCompiled->fn != nullptr);
+    auto secondResult = EvalCompiled(*secondCompiled, second, ds, range);
+
+    auto secondReference = EvalRef(second, ds, range);
+    REQUIRE(secondResult.size() == secondReference.size());
+    for (std::size_t i = 0; i < secondResult.size(); ++i) {
+        INFO("row " << i << ": ref=" << secondReference[i] << " avx2=" << secondResult[i]);
+        if (std::isnan(secondReference[i])) {
+            CHECK(std::isnan(secondResult[i]));
+        } else if (std::isinf(secondReference[i])) {
+            CHECK(std::isinf(secondResult[i]));
+            CHECK((secondReference[i] > 0) == (secondResult[i] > 0));
+        } else {
+            CHECK(secondResult[i] == Catch::Approx(secondReference[i]).epsilon(Tol));
+        }
+    }
+    REQUIRE_FALSE(firstResult.empty());
 }
 
 } // namespace Operon::Test


### PR DESCRIPTION
## Summary
- reuse each thread's AsmJit `CodeHolder` and `Compiler` through `reset()`, `init()`, and `attach()` rather than `reinit()`, which produced stale direct-call relocations
- add the two-tree AVX2 regression that deterministically exercised the stale-relocation failure
- distinguish eligible cache lookups, compile successes, and length-gated trees in JIT cache statistics

## Validation
- `nix develop -c ./build/test/operon_test "JitEvaluator correctness" --rng-seed 12345`
- `nix develop -c ./build/test/operon_test "JIT compiler CodeHolder reuse replay" --rng-seed 12345`
- Prior full JIT run: 24 of 25 test cases passed; the sole failure was the former counter expectation, updated here to match the corrected cache-statistics contract.
- Benchmark results: median compile time for tree sizes 1–50 improved 37.7%; 60 end-to-end GP runs completed without the previous JIT crash.