### PR TITLE
fix(formatter): fix crashes and silent data loss in tree formatters

### DIFF
--- a/source/formatter/dot.cpp
+++ b/source/formatter/dot.cpp
@@ -32,6 +32,14 @@ auto DotFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::strin
 
     auto format = [&](auto const& s) -> auto {
         if (s.IsLeaf()) { return formatLeaf(s); }
+        if (s.Value != Operon::Scalar{1}) {
+            // Function-node weights are real, evaluated state (see
+            // Tree::AdjustedLength()/the interpreter's weighted apply) --
+            // omitting them here made the label describe a different
+            // model than the one actually evaluated.
+            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "(({{:.{}f}}) * {{}})" : "({{:.{}f}} * {{}})"), decimalPrecision);
+            return fmt::format(fmt::runtime(formatString), s.Value, s.Name());
+        }
         return s.Name();
     };
 

--- a/source/formatter/infix.cpp
+++ b/source/formatter/infix.cpp
@@ -121,10 +121,27 @@ auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std:
                 fmt::format_to(std::back_inserter(current), "sqrt(abs(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
                 fmt::format_to(std::back_inserter(current), "))");
-            } else {
+            } else if (s.Arity == 1) {
                 fmt::format_to(std::back_inserter(current), "{}", s.Name());
                 fmt::format_to(std::back_inserter(current), "(");
                 FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
+                fmt::format_to(std::back_inserter(current), ")");
+            } else {
+                // A registered binary/n-ary function (RegisterBinaryFunction/
+                // RegisterNaryFunction) has a user hash outside the built-in
+                // Add..Powabs range, so it falls through to this branch --
+                // formatting only `i - 1` here would silently drop every
+                // argument but the last for Arity > 1. Render every actual
+                // child as a proper call: name(a, b, ...).
+                fmt::format_to(std::back_inserter(current), "{}", s.Name());
+                fmt::format_to(std::back_inserter(current), "(");
+                size_t count = 0;
+                for (auto j : tree.Indices(i)) {
+                    FormatNode(tree, variableNames, j, current, decimalPrecision);
+                    if (++count < s.Arity) {
+                        fmt::format_to(std::back_inserter(current), ", ");
+                    }
+                }
                 fmt::format_to(std::back_inserter(current), ")");
             }
         }

--- a/source/formatter/postfix.cpp
+++ b/source/formatter/postfix.cpp
@@ -49,7 +49,25 @@ auto PostfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, st
             break;
         }
         default: {
-            fmt::format_to(std::back_inserter(current), fmt::runtime(s.Name()));
+            // s.Name() is data, not a format string -- fmt::runtime(s.Name())
+            // previously reparsed the function's own display name as a spec,
+            // throwing fmt::format_error for any registered name containing
+            // '{'/'}' (braces are otherwise legal in a registered name; only
+            // empty names and reserved hashes are rejected).
+            fmt::format_to(std::back_inserter(current), "{}", s.Name());
+            if (s.Value != Operon::Scalar{1}) {
+                // Unlike the leaf/variable case above (a single "(w * name)"
+                // token, not real RPN), a function node already has its own
+                // argument tokens preceding it in the stream, so its weight
+                // is represented as genuine trailing RPN: "... name w *"
+                // pushes the weight and multiplies it onto the function's
+                // result, exactly mirroring what the interpreter evaluates.
+                // Omitting this made postfix describe a different model
+                // than the one actually evaluated (weights are real,
+                // evaluated state -- see Tree::AdjustedLength()).
+                auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? " ({{:.{}f}}) *" : " {{:.{}f}} *"), decimalPrecision);
+                fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
+            }
         }
     }
 }

--- a/source/formatter/tree.cpp
+++ b/source/formatter/tree.cpp
@@ -34,7 +34,12 @@ auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::
         }
     } else {
         if (s.Value != Operon::Scalar{1}) {
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}f}}) * {{}}" : "{{:.{}f}} * {{}}"), decimalPrecision);
+            // Only ONE placeholder here (value) -- unlike the IsVariable
+            // branch above, the name is appended separately below, not
+            // via this format string. Reusing the two-placeholder
+            // "{:.Nf} * {}" pattern here previously threw fmt::format_error
+            // ("argument not found") because only s.Value was ever passed.
+            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}f}})" : "{{:.{}f}}"), decimalPrecision);
             fmt::format_to(std::back_inserter(current), "(");
             fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
             fmt::format_to(std::back_inserter(current), " * ");
@@ -69,6 +74,8 @@ auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::
 
 auto TreeFormatter::Format(Tree const& tree, Dataset const& dataset, int decimalPrecision) -> std::string
 {
+    if (tree.Nodes().empty()) { return std::string{}; }
+
     Operon::Map<Operon::Hash, std::string> variableNames;
     for (auto const& var : dataset.GetVariables()) {
         variableNames.insert({ var.Hash, var.Name });
@@ -81,6 +88,8 @@ auto TreeFormatter::Format(Tree const& tree, Dataset const& dataset, int decimal
 
 auto TreeFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision) -> std::string
 {
+    if (tree.Nodes().empty()) { return std::string{}; }
+
     std::string result;
     FormatNode(tree, variableNames, tree.Length() - 1, result, "", /*isLast=*/true, /*initialMarker=*/false, decimalPrecision);
     return result;

--- a/test/source/implementation/dispatch_table.cpp
+++ b/test/source/implementation/dispatch_table.cpp
@@ -7,6 +7,7 @@
 
 #include "../operon_test.hpp"
 
+#include <algorithm>
 #include <numbers>
 #include <numeric>
 
@@ -445,6 +446,149 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         auto dot = DotFormatter::Format(builtInTree, ds);
         CHECK(dot.find("[label=\"sin\"]") != std::string::npos);
         CHECK(dot.find("0 -> 1") != std::string::npos);
+    }
+}
+
+TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, unsafe format strings, empty trees", "[interpreter]")
+{
+    using DT     = Operon::DispatchTable<Operon::Scalar>;
+    using Scalar = Operon::Scalar;
+
+    std::string const x{"x"};
+    Operon::Dataset const ds({x}, {std::vector<Scalar>{0.0}});
+
+    SECTION("InfixFormatter renders every argument of a registered n-ary function") {
+        // Regression for a bug where a registered function whose hash fell
+        // outside the built-in Add..Powabs range (essentially every
+        // user-registered hash, since it is unrelated to BuiltinOp's
+        // ordinals) was routed into the "unary operator" fallback, which
+        // formatted only the LAST child (i - 1) regardless of actual arity
+        // -- silently dropping every other argument.
+        DT dt;
+        Operon::PrimitiveSet pset;
+        Operon::FunctionInfo const info{
+            .Name = "sum3", .Desc = "n-ary sum", .Arity = 3, .Frequency = 1
+        };
+        auto primal = [](auto acc, auto v) -> auto { return acc + v; };
+        Operon::RegisterNaryFunction<DT, Scalar>(dt, pset, info, /*maxArity=*/3, primal);
+        auto const hash = Operon::Hasher{}(info.Name);
+
+        auto dyn = Operon::Node::Function(hash, 3); // sets Arity=Length=3
+        Operon::Tree const tree({
+            Operon::Node::Constant(21.0),
+            Operon::Node::Constant(34.0),
+            Operon::Node::Constant(55.0),
+            dyn,
+        });
+
+        auto formatted = InfixFormatter::Format(tree, ds);
+        CHECK(formatted.find("sum3(") != std::string::npos);
+        CHECK(formatted.find("21") != std::string::npos);
+        CHECK(formatted.find("34") != std::string::npos);
+        CHECK(formatted.find("55") != std::string::npos);
+        CHECK(std::count(formatted.begin(), formatted.end(), ',') == 2);
+    }
+
+    SECTION("TreeFormatter does not throw on a weighted (non-unit Value) function node") {
+        // Regression for a bug where the weighted-function-node branch built
+        // a two-placeholder format string ("{:.Nf} * {}") but only ever
+        // passed s.Value as an argument, throwing fmt::format_error
+        // ("argument not found") for any function node with Value != 1 --
+        // real, reachable state: function-node weights are applied by the
+        // interpreter, not just a leaf/variable concept.
+        DT dt;
+        Operon::PrimitiveSet pset;
+        Operon::FunctionInfo const info{
+            .Name = "cube", .Desc = "", .Arity = 1, .Frequency = 1
+        };
+        auto primal  = [](auto v) -> auto { return v * v * v; };
+        auto dprimal = [](auto v) -> auto { return 3 * v * v; };
+        Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
+        auto const hash = Operon::Hasher{}(info.Name);
+
+        auto dyn = Operon::Node::Function(hash, 1);
+        dyn.Value = 2.5;
+        Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
+
+        std::string formatted;
+        CHECK_NOTHROW(formatted = TreeFormatter::Format(tree, ds));
+        CHECK(formatted.find("2.50") != std::string::npos);
+        CHECK(formatted.find("cube") != std::string::npos);
+    }
+
+    SECTION("DotFormatter includes a weighted function node's weight in its label") {
+        DT dt;
+        Operon::PrimitiveSet pset;
+        Operon::FunctionInfo const info{
+            .Name = "cube", .Desc = "", .Arity = 1, .Frequency = 1
+        };
+        auto primal  = [](auto v) -> auto { return v * v * v; };
+        auto dprimal = [](auto v) -> auto { return 3 * v * v; };
+        Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
+        auto const hash = Operon::Hasher{}(info.Name);
+
+        auto dyn = Operon::Node::Function(hash, 1);
+        dyn.Value = 2.5;
+        Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
+
+        auto dot = DotFormatter::Format(tree, ds);
+        CHECK(dot.find("2.50") != std::string::npos);
+        CHECK(dot.find("cube") != std::string::npos);
+    }
+
+    SECTION("PostfixFormatter represents a weighted function node's weight as valid trailing RPN") {
+        DT dt;
+        Operon::PrimitiveSet pset;
+        Operon::FunctionInfo const info{
+            .Name = "cube", .Desc = "", .Arity = 1, .Frequency = 1
+        };
+        auto primal  = [](auto v) -> auto { return v * v * v; };
+        auto dprimal = [](auto v) -> auto { return 3 * v * v; };
+        Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
+        auto const hash = Operon::Hasher{}(info.Name);
+
+        auto dyn = Operon::Node::Function(hash, 1);
+        dyn.Value = 2.5;
+        Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
+
+        auto postfix = PostfixFormatter::Format(tree, ds);
+        CHECK(postfix == "(1.00 cube 2.50 *) ");
+    }
+
+    SECTION("PostfixFormatter treats a registered function's name as data, not a format string") {
+        // Regression for fmt::format_to(..., fmt::runtime(s.Name())), which
+        // reparsed the function's own display name as a format spec --
+        // registered names are validated only for emptiness/hash
+        // collisions, so '{'/'}' in a name is legal and previously threw.
+        DT dt;
+        Operon::PrimitiveSet pset;
+        Operon::FunctionInfo const info{
+            .Name = "f{brace}", .Desc = "", .Arity = 1, .Frequency = 1
+        };
+        auto primal  = [](auto v) -> auto { return v; };
+        auto dprimal = [](auto) -> auto { return Scalar{1}; };
+        Operon::RegisterUnaryFunction<DT, Scalar>(dt, pset, info, primal, dprimal);
+        auto const hash = Operon::Hasher{}(info.Name);
+
+        auto dyn = Operon::Node::Function(hash, 1);
+        Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
+
+        std::string formatted;
+        CHECK_NOTHROW(formatted = PostfixFormatter::Format(tree, ds));
+        CHECK(formatted.find("f{brace}") != std::string::npos);
+    }
+
+    SECTION("Tree/Postfix/Dot formatters do not crash on an empty tree") {
+        Operon::Tree const empty;
+        std::string treeOut;
+        std::string postfixOut;
+        std::string dotOut;
+        CHECK_NOTHROW(treeOut = TreeFormatter::Format(empty, ds));
+        CHECK_NOTHROW(postfixOut = PostfixFormatter::Format(empty, ds));
+        CHECK_NOTHROW(dotOut = DotFormatter::Format(empty, ds));
+        CHECK(treeOut.empty());
+        CHECK(postfixOut.empty());
+        CHECK(dotOut.find("digraph") != std::string::npos);
     }
 }
 


### PR DESCRIPTION
## Summary
Five correctness bugs across `TreeFormatter`/`InfixFormatter`/`PostfixFormatter`/`DotFormatter`, found while scoping a broader formatter redesign (kept out of this PR).

- `TreeFormatter` threw `fmt::format_error` on any weighted function node (`Value != 1`) — its format string carried two placeholders but only one argument was ever passed.
- `TreeFormatter::Format` underflowed on an empty tree (`tree.Length() - 1` on `size_t` wraps to `SIZE_MAX`) — an actual SIGSEGV, not just an exception.
- `PostfixFormatter` passed a registered function's own display name through `fmt::runtime()` as if it were a format spec, throwing for any name containing `{`/`}` (braces are legal in a registered name; only emptiness/hash collisions are rejected).
- `InfixFormatter` silently dropped every argument but the last for a registered binary/n-ary function whenever its hash fell outside the built-in `Add..Powabs` range — essentially every user-registered hash, since that's unrelated to `BuiltinOp`'s ordinals.
- `DotFormatter` and `PostfixFormatter` both silently omitted function-node weights, describing a different model than the one actually evaluated. `PostfixFormatter` now represents the weight as genuine trailing RPN (`... name w *`), matching real evaluation order rather than reusing the non-RPN `(w * name)` leaf convention.

## Validation
- New regression test per bug in `test/source/implementation/dispatch_table.cpp`, each verified to fail against the pre-fix code (including reproducing the live SIGSEGV) via a `git stash` round-trip, then pass after the fix.
- Full suite: `./build/test/operon_test '~[performance]'` — 69436 assertions / 378 test cases, all pass.

## Out of scope
The broader formatter/`fmt::formatter` integration redesign this bug hunt was scoped alongside, and DOT label escaping — tracked separately, not blocking these correctness fixes.