### PR TITLE
feat(formatter): redesign tree formatting as fmt formatters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
     source/core/tree_diff.cpp
     source/core/version.cpp
     source/formatter/dot.cpp
+    source/formatter/formatter.cpp
     source/formatter/infix.cpp
     source/formatter/postfix.cpp
     source/formatter/tree.cpp
@@ -104,7 +105,7 @@ find_package(glaze REQUIRED)
 # linking glaze PRIVATE does not upgrade the whole library to C++23; instead
 # we set CXX_STANDARD 23 on serialization.cpp alone via source properties.
 set_target_properties(glaze::glaze PROPERTIES INTERFACE_COMPILE_FEATURES "")
-find_package(fmt REQUIRED)
+find_package(fmt 10 REQUIRED)
 find_package(gtl REQUIRED)
 find_package(lbfgs REQUIRED)
 find_package(libassert REQUIRED)

--- a/cli/source/operon_enum.cpp
+++ b/cli/source/operon_enum.cpp
@@ -119,7 +119,7 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
             return EXIT_FAILURE;
         }
         for (auto const& [fitness, tree] : best) {
-            fmt::print("fitness={:.6g}\t{}\n", fitness, Operon::InfixFormatter::Format(tree, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::max_digits10));
+            fmt::print("fitness={:.6g}\t{:infix:roundtrip}\n", fitness, Operon::Fmt::WithNames{tree, *problem.GetDataset()});
         }
     } catch (std::exception& e) {
         fmt::print(stderr, "error: {}\n", e.what());

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -393,7 +393,7 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
                                                            : shapeViolationStorage->Measure(best.Genotype).Feasible;
             fmt::print(stderr, "shape-constraints: final model is {}\n", feasible ? "feasible" : "INFEASIBLE (not certified over the domain box)");
         }
-        fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::max_digits10));
+        fmt::print("{:infix:roundtrip}\n", Operon::Fmt::WithNames{best.Genotype, *problem.GetDataset()});
     } catch (std::exception& e) {
         fmt::print(stderr, "error: {}\n", e.what());
         return EXIT_FAILURE;

--- a/cli/source/operon_nsgp.cpp
+++ b/cli/source/operon_nsgp.cpp
@@ -472,7 +472,7 @@ auto main(int argc, char** argv) -> int
                                                  : shapePenaltyStorage->Measure(best.Genotype).Feasible;
             fmt::print(stderr, "shape-constraints: final model is {}\n", feasible ? "feasible" : "INFEASIBLE (not certified over the domain box)");
         }
-        fmt::print("{}\n", Operon::InfixFormatter::Format(best.Genotype, *problem.GetDataset(), std::numeric_limits<Operon::Scalar>::max_digits10));
+        fmt::print("{:infix:roundtrip}\n", Operon::Fmt::WithNames{best.Genotype, *problem.GetDataset()});
         if (result.contains("pareto-front")) {
             Operon::WriteParetoFront(result["pareto-front"].as<std::string>(), gp.Individuals(), dtable, problem);
         }

--- a/cli/source/operon_parse_model.cpp
+++ b/cli/source/operon_parse_model.cpp
@@ -202,7 +202,7 @@ namespace {
         if (opt->Iterations() > 0) {
             auto const& diag = Operon::Diagnostics(summary);
             if (summary.has_value()) {
-                fmt::print("optimized_model {}\n", Operon::InfixFormatter::Format(model, ds, std::numeric_limits<Operon::Scalar>::max_digits10));
+                fmt::print("optimized_model {:infix:roundtrip}\n", Operon::Fmt::WithNames{model, ds});
             }
             fmt::print("optimization summary:\n");
             fmt::print("status: {}\n", summary.has_value());
@@ -231,10 +231,9 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
         range = Operon::Range{a, b};
     }
 
-    int constexpr defaultPrecision{std::numeric_limits<Operon::Scalar>::max_digits10};
     if (result["debug"].as<bool>()) {
         fmt::print("\nInput string:\n{}\n", infix);
-        fmt::print("Parsed tree:\n{}\n", Operon::InfixFormatter::Format(model, ds, defaultPrecision));
+        fmt::print("Parsed tree:\n{:infix:roundtrip}\n", Operon::Fmt::WithNames{model, ds});
         fmt::print("Data range: {}:{}\n", range.Start(), range.End());
         fmt::print("Scale: {}\n", result["scale"].count() > 0 ? result["scale"].as<std::string>() : std::string("auto"));
     }

--- a/cli/source/pareto_front.cpp
+++ b/cli/source/pareto_front.cpp
@@ -126,7 +126,7 @@ auto WriteParetoFront(std::string const& path,
             "   \"nmse_train\": {}, \"nmse_test\": {},\n"
             "   \"mae_train\": {}, \"mae_test\": {},\n"
             "   \"mdl\": {}, \"fbf\": {}}}",
-            i, EscapeJson(InfixFormatter::Format(ind->Genotype, *ds, std::numeric_limits<Scalar>::max_digits10)),
+            i, EscapeJson(fmt::format("{:infix:roundtrip}", Fmt::WithNames{ind->Genotype, *ds})),
             ind->Genotype.AdjustedLength(), static_cast<size_t>(k), objArr,
             jsonNum(r2Train), jsonNum(r2Test),
             jsonNum(mseTrain), jsonNum(mseTest),

--- a/example/custom_primitives.cpp
+++ b/example/custom_primitives.cpp
@@ -187,10 +187,10 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
     auto const* best  = std::min_element(first, last,
         [](auto const& a, auto const& b) -> auto { return a[0] < b[0]; });
 
-    fmt::print("\nBest model (MSE={:.6f}, length={}):\n  {}\n",
+    fmt::print("\nBest model (MSE={:.6f}, length={}):\n  {:infix:roundtrip}\n",
         best->Fitness[0],
         best->Genotype.Length(),
-        Operon::InfixFormatter::Format(best->Genotype, dataset, std::numeric_limits<Operon::Scalar>::max_digits10));
+        Operon::Fmt::WithNames{best->Genotype, dataset});
 
     return 0;
 }

--- a/include/operon/core/dataset.hpp
+++ b/include/operon/core/dataset.hpp
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <gsl/pointers>
@@ -112,6 +113,14 @@ public:
     [[nodiscard]] auto GetVariable(std::string const& name) const noexcept -> tl::expected<Variable, DatasetError>;
     [[nodiscard]] auto GetVariable(Operon::Hash hash) const noexcept -> tl::expected<Variable, DatasetError>;
     [[nodiscard]] auto GetVariables() const noexcept -> std::vector<Operon::Variable>;
+
+    // Zero-copy variable-name lookup: a view into this Dataset's own
+    // long-lived storage, valid for the Dataset's lifetime (invalidated
+    // only by a call that mutates variable identity, e.g.
+    // SetVariableNames). Prefer this over GetVariable()/GetVariables()
+    // when only the name is needed -- those copy a Variable (or every
+    // Variable) by value.
+    [[nodiscard]] auto FindVariableName(Operon::Hash hash) const noexcept -> std::optional<std::string_view>;
 
     void SetWeights(Span<Scalar const> w);
     [[nodiscard]] auto Weights() const noexcept -> std::optional<Span<Scalar const>>;

--- a/include/operon/core/standard_library.hpp
+++ b/include/operon/core/standard_library.hpp
@@ -78,6 +78,19 @@ struct StandardLibrary {
         return { 0, 0 };
     }
 
+    // How a built-in op's infix rendering diverges from plain call syntax,
+    // sourced from the same registry entry ArityLimits reads (see
+    // FormatRule above). Consumed by InfixFormatter so its dispatch table
+    // doesn't duplicate this classification via a second, separately
+    // maintained mapping.
+    [[nodiscard]] static constexpr auto FormattingRule(BuiltinOp op) -> Operon::FormatRule
+    {
+        for (auto const& entry : BuiltinEntries) {
+            if (entry.Op == op) { return entry.Rule; }
+        }
+        return FormatRule::GenericCall;
+    }
+
 private:
     struct BuiltinEntry {
         BuiltinOp Op;

--- a/include/operon/formatter/formatter.hpp
+++ b/include/operon/formatter/formatter.hpp
@@ -5,49 +5,228 @@
 #ifndef OPERON_FORMAT_HPP
 #define OPERON_FORMAT_HPP
 
-#include <unordered_map>
+#include <algorithm>
+#include <concepts>
+#include <fmt/base.h>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
 
 #include "operon/core/tree.hpp"
+#include "operon/core/types.hpp"
+#include "operon/operon_export.hpp"
 
 namespace Operon {
-
 class Dataset;
-
-class OPERON_EXPORT TreeFormatter {
-    static auto FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> variableNames, size_t i, std::string& current, std::string indent, bool isLast, bool initialMarker, int decimalPrecision) -> void;
-
-public:
-    static auto Format(Tree const& tree, Dataset const& dataset, int decimalPrecision = 2) -> std::string;
-    static auto Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision = 2) -> std::string;
-};
-
-class OPERON_EXPORT InfixFormatter {
-    static auto FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, size_t i, std::string& current, int decimalPrecision) -> void;
-
-public:
-    // decimalPrecision is significant digits (general/%g-style formatting,
-    // fixed or scientific chosen automatically), not decimal places -- pass
-    // std::numeric_limits<Operon::Scalar>::max_digits10 for output that must
-    // round-trip exactly back through InfixParser (e.g. any model printed
-    // for a caller to re-parse). A smaller value trades round-trip fidelity
-    // for brevity; coefficients below the chosen precision's threshold can
-    // print as 0 and silently change the model's behavior when re-parsed.
-    static auto Format(Tree const& tree, Dataset const& dataset, int decimalPrecision = 2) -> std::string;
-    static auto Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision = 2) -> std::string;
-};
-
-class OPERON_EXPORT PostfixFormatter {
-    static auto FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, size_t i, std::string& current, int decimalPrecision) -> void;
-
-public:
-    static auto Format(Tree const& tree, Dataset const& dataset, int decimalPrecision = 2) -> std::string;
-    static auto Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision = 2) -> std::string;
-};
-
-struct OPERON_EXPORT DotFormatter {
-    static auto Format(Tree const& tree, Dataset const& dataset, int decimalPrecision = 2) -> std::string;
-    static auto Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision = 2) -> std::string;
-};
 } // namespace Operon
+
+namespace Operon::Fmt {
+
+using VariableNameMap = Operon::Map<Operon::Hash, std::string>;
+
+// Rendering mode selected by the `fmt` format-spec grammar (see
+// TreeFormatSpec::parse below): `{}`/`{:infix}`, `{:postfix}`, `{:tree}`,
+// `{:dot}`.
+enum class Mode : std::uint8_t { Infix, Postfix, Tree, Dot };
+
+// Only Dataset and an explicit Hash->name map are legitimate variable-name
+// sources in this codebase; constraining WithNames<Names> to this concept
+// turns "wrong type passed" into a clear error at the WithNames call site
+// instead of a deep NameView overload-resolution failure.
+template <typename T>
+concept NameSource = std::same_as<T, Operon::Dataset> || std::same_as<T, VariableNameMap>;
+
+// Type-erased, non-owning view over "resolve a variable Hash to its
+// display name," constructed once per fmt::format() call (not once per
+// node -- this is what fixes the historical TreeFormatter bug where the
+// name map was copied on every recursive call). A default-constructed
+// NameView (no Dataset/map supplied) is the bare-Tree fallback: Resolve()
+// always returns nullopt, and callers render a deterministic
+// X_<hex hash> placeholder instead (see FormatValue's caller in
+// source/formatter/detail.hpp) -- diagnostic-only, since a Tree does not
+// itself own variable names.
+class OPERON_EXPORT NameView {
+public:
+    NameView() noexcept = default;
+    explicit NameView(Operon::Dataset const& dataset) noexcept
+        : kind_(Kind::Dataset), source_(&dataset) {}
+    explicit NameView(VariableNameMap const& names) noexcept
+        : kind_(Kind::Map), source_(&names) {}
+
+    // Resolve() returning nullopt is ambiguous on its own (missing hash vs.
+    // no source supplied at all) -- callers needing to throw on a genuinely
+    // missing hash from an explicit source, while still falling back to a
+    // placeholder when no source was supplied (bare Tree formatting), must
+    // check HasSource() first. See FormatVariableName in
+    // source/formatter/detail.hpp for the shared implementation of that
+    // policy.
+    [[nodiscard]] auto HasSource() const noexcept -> bool { return kind_ != Kind::None; }
+    [[nodiscard]] auto Resolve(Operon::Hash hash) const -> std::optional<std::string_view>;
+
+private:
+    enum class Kind : std::uint8_t { None, Dataset, Map };
+    Kind kind_{Kind::None};
+    void const* source_{nullptr};
+};
+
+// Resolved, per-call (not per-node) value-formatting policy. Infix
+// defaults to Fixed=false (significant-digits/general "%g" formatting --
+// pass std::numeric_limits<Operon::Scalar>::max_digits10 as Precision, or
+// use the ":roundtrip" spec keyword, for output that must round-trip
+// exactly back through InfixParser). Tree/Postfix/Dot default to
+// Fixed=true (fixed decimal places), matching their long-standing visual
+// convention -- see TreeFormatSpec::Resolve.
+struct ValueSpec {
+    int Precision{2};
+    bool Fixed{false};
+};
+
+// Wraps a Tree with the variable-name source used to resolve its
+// Variable nodes' display names -- what callers actually pass to
+// fmt::format/fmt::print: fmt::format("{:infix}", WithNames{tree, dataset}).
+// Non-owning; both Subject and Variables must outlive the format call
+// (ordinary fmt::format/fmt::print usage, which consumes its arguments
+// synchronously, is always safe -- storing a WithNames for later/async
+// formatting is not).
+// Non-owning formatting arguments: both references are consumed synchronously
+// by fmt::format/fmt::print and must therefore remain references.
+template <NameSource Names>
+struct WithNames {
+    Operon::Tree const& Subject; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    Names const& Variables; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    int Precision{2};
+};
+
+template <NameSource Names>
+WithNames(Operon::Tree const&, Names const&) -> WithNames<Names>;
+template <NameSource Names>
+WithNames(Operon::Tree const&, Names const&, int) -> WithNames<Names>;
+
+// Shared `fmt` format-spec grammar for both fmt::formatter<Operon::Tree>
+// and fmt::formatter<Operon::Fmt::WithNames<Names>> (inherited by both, so
+// the grammar is parsed in exactly one place):
+//
+//   tree-spec ::= [mode] [":" precision]
+//   mode      ::= "infix" | "postfix" | "tree" | "dot"      (default: infix)
+//   precision ::= "roundtrip" | digit+ ["g" | "f"]
+//
+// Examples: "{}", "{:infix}", "{:tree}", "{:infix:roundtrip}",
+// "{:infix:6g}", "{:tree:3f}", "{:dot:6g}". An explicit digit-precision
+// override (with or without a trailing presentation letter) always wins
+// over WithNames::Precision; "roundtrip" is shorthand for
+// max_digits10 significant digits. An unrecognized mode word or trailing
+// spec text is a compile error for a literal format string (fmt's
+// consteval parse check) or an fmt::format_error at runtime for
+// fmt::runtime(...).
+struct TreeFormatSpec {
+    Mode RenderMode{Mode::Infix};
+    std::optional<int> PrecisionOverride;
+    std::optional<bool> FixedOverride;
+
+    constexpr auto parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator; // NOLINT(readability-identifier-naming)
+
+    [[nodiscard]] auto Resolve(int basePrecision) const noexcept -> ValueSpec
+    {
+        return ValueSpec{
+            .Precision = PrecisionOverride.value_or(basePrecision),
+            .Fixed = FixedOverride.value_or(RenderMode != Mode::Infix),
+        };
+    }
+};
+
+// Compiled (non-template) rendering entry point. The four traversal
+// implementations (infix/postfix/tree-diagram/dot) stay in their own
+// source/formatter/{infix,postfix,tree,dot}.cpp files, exactly as
+// before -- see source/formatter/detail.hpp for their internal
+// declarations. Only this dispatcher needs to be public/header-visible.
+namespace Detail {
+    OPERON_EXPORT auto Render(Tree const& tree, Mode mode, NameView const& names, ValueSpec spec) -> std::string;
+} // namespace Detail
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity, readability-identifier-naming)
+constexpr auto TreeFormatSpec::parse(fmt::format_parse_context& ctx) -> fmt::format_parse_context::iterator
+{
+    auto it = ctx.begin(); // NOLINT(llvm-qualified-auto, readability-qualified-auto)
+    auto const end = ctx.end(); // NOLINT(llvm-qualified-auto, readability-qualified-auto)
+
+    auto consumeWord = [&](std::string_view word) -> bool {
+        auto const n = word.size();
+        if (std::cmp_less(end - it, n) || !std::equal(word.begin(), word.end(), it)) {
+            return false;
+        }
+        // Reject a mode word that's actually a prefix of some longer,
+        // unrecognized token (e.g. "treexyz") rather than silently
+        // accepting "tree" out of it.
+        if (it + static_cast<std::ptrdiff_t>(n) != end) {
+            auto next = *(it + static_cast<std::ptrdiff_t>(n));
+            if (next != ':' && next != '}') { return false; }
+        }
+        it += static_cast<std::ptrdiff_t>(n);
+        return true;
+    };
+
+    if (consumeWord("infix")) { RenderMode = Mode::Infix; }
+    else if (consumeWord("postfix")) { RenderMode = Mode::Postfix; }
+    else if (consumeWord("tree")) { RenderMode = Mode::Tree; }
+    else if (consumeWord("dot")) { RenderMode = Mode::Dot; }
+
+    if (it != end && *it == ':') {
+        ++it;
+        if (consumeWord("roundtrip")) {
+            PrecisionOverride = std::numeric_limits<Operon::Scalar>::max_digits10;
+            FixedOverride = false;
+        } else {
+            int value = 0;
+            bool any = false;
+            while (it != end && *it >= '0' && *it <= '9') {
+                any = true;
+                auto const digit = *it - '0';
+                if (value > (std::numeric_limits<int>::max() - digit) / 10) {
+                    fmt::report_error("Operon tree format spec: precision too large");
+                }
+                value = (value * 10) + digit;
+                ++it;
+            }
+            if (!any) {
+                fmt::report_error("Operon tree format spec: expected a precision digit after ':'");
+            }
+            PrecisionOverride = value;
+            if (it != end && (*it == 'g' || *it == 'f')) {
+                FixedOverride = (*it == 'f');
+                ++it;
+            }
+        }
+    }
+
+    if (it != end && *it != '}') {
+        fmt::report_error("Operon tree format spec: expected 'infix'/'postfix'/'tree'/'dot', an optional ':' precision, then '}'");
+    }
+
+    return it;
+}
+
+} // namespace Operon::Fmt
+
+template <>
+struct fmt::formatter<Operon::Tree> : Operon::Fmt::TreeFormatSpec {
+    template <typename FormatContext>
+    auto format(Operon::Tree const& tree, FormatContext& ctx) const -> decltype(ctx.out()) // NOLINT(readability-identifier-naming)
+    {
+        auto text = Operon::Fmt::Detail::Render(tree, RenderMode, Operon::Fmt::NameView{}, Resolve(2));
+        return fmt::format_to(ctx.out(), "{}", text);
+    }
+};
+
+template <Operon::Fmt::NameSource Names>
+struct fmt::formatter<Operon::Fmt::WithNames<Names>> : Operon::Fmt::TreeFormatSpec {
+    template <typename FormatContext>
+    auto format(Operon::Fmt::WithNames<Names> const& w, FormatContext& ctx) const -> decltype(ctx.out()) // NOLINT(readability-identifier-naming)
+    {
+        auto text = Operon::Fmt::Detail::Render(w.Subject, RenderMode, Operon::Fmt::NameView{w.Variables}, Resolve(w.Precision));
+        return fmt::format_to(ctx.out(), "{}", text);
+    }
+};
 
 #endif

--- a/source/core/dataset.cpp
+++ b/source/core/dataset.cpp
@@ -310,6 +310,13 @@ auto Dataset::GetVariable(Operon::Hash hash) const noexcept -> tl::expected<Vari
     return it->second;
 }
 
+auto Dataset::FindVariableName(Operon::Hash hash) const noexcept -> std::optional<std::string_view>
+{
+    auto it = variables_.find(hash);
+    if (it == variables_.end()) { return std::nullopt; }
+    return std::string_view{it->second.Name};
+}
+
 auto Dataset::GetVariables() const noexcept -> std::vector<Operon::Variable>
 {
     std::vector<Operon::Variable> variables;

--- a/source/formatter/detail.hpp
+++ b/source/formatter/detail.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#ifndef OPERON_FORMATTER_DETAIL_HPP
+#define OPERON_FORMATTER_DETAIL_HPP
+
+// Private, not-installed header shared by formatter.cpp (the compiled
+// fmt::formatter entry point) and the four per-mode backends
+// (infix/postfix/tree/dot.cpp). Not part of the public API in
+// include/operon/formatter/formatter.hpp -- callers never include this
+// directly.
+
+#include <string>
+
+#include "operon/formatter/formatter.hpp"
+
+namespace Operon::Fmt::Detail {
+
+// Compiled per-mode traversal entry points, called only by Render()
+// (formatter.cpp) once the caller-facing policy already applies: Render()
+// guarantees `tree` is non-empty before calling FormatInfix/FormatPostfix/
+// FormatTreeDiagram (their traversal logic assumes at least a root node
+// exists); FormatDot handles an empty tree itself (a valid, node-less
+// digraph is well-defined, unlike an empty expression/diagram/token
+// stream).
+auto FormatInfix(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string;
+auto FormatPostfix(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string;
+auto FormatTreeDiagram(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string;
+auto FormatDot(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string;
+
+// Shared leaf-value rendering: a constant, or the numeric weight of a
+// weighted variable/function node -- byte-for-byte the same operation in
+// every mode (only the surrounding punctuation differs, which stays
+// mode-local). Uses fmt's own dynamic-precision replacement field
+// ("{:.{}g}"/"{:.{}f}") so the spec is parsed exactly once per call as a
+// checked literal, never built as a string and re-parsed via
+// fmt::runtime(...) the way the pre-redesign formatters did.
+void AppendValue(std::string& out, Operon::Scalar value, ValueSpec spec);
+
+// Resolves a Variable/Ref-target node's display name against `names`,
+// appending it to `out`: the resolved name for a Dataset/map source, or a
+// deterministic "X_<16 hex digit hash>" placeholder if no source was
+// supplied (bare Tree formatting -- a Tree does not itself own variable
+// names). Throws std::runtime_error if a source WAS supplied but doesn't
+// contain `hash` -- see NameView::HasSource's doc comment in formatter.hpp.
+void AppendVariableName(std::string& out, NameView const& names, Operon::Hash hash);
+
+} // namespace Operon::Fmt::Detail
+
+#endif

--- a/source/formatter/dot.cpp
+++ b/source/formatter/dot.cpp
@@ -4,49 +4,73 @@
 
 #include <fmt/format.h>
 
-#include "operon/core/dataset.hpp"
-#include "operon/formatter/formatter.hpp"
+#include "detail.hpp"
 
-namespace Operon {
+namespace Operon::Fmt::Detail {
 
-auto DotFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision) -> std::string
+namespace {
+
+// Graphviz quoted-string escaping: a variable/registered-function name
+// containing a quote, backslash, or line break previously went straight
+// into `label="..."` unescaped, producing invalid or silently
+// reinterpreted DOT.
+void AppendEscapedLabel(std::string& out, std::string_view text)
+{
+    for (char const c : text) {
+        switch (c) {
+        case '\\': out += "\\\\"; break;
+        case '"':  out += "\\\""; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        default:   out += c;
+        }
+    }
+}
+
+auto FormatLabel(Tree const& tree, NameView const& names, std::size_t i, ValueSpec spec) -> std::string
+{
+    auto const& s = tree[i];
+    std::string label;
+    if (s.IsConstant()) {
+        AppendValue(label, s.Value, spec);
+        return label;
+    }
+    if (s.IsVariable()) {
+        label += "(";
+        AppendValue(label, s.Value, spec);
+        label += " * ";
+        AppendVariableName(label, names, s.HashValue);
+        label += ")";
+        return label;
+    }
+    // Function node. Weights are real, evaluated state (see
+    // Tree::AdjustedLength()/the interpreter's weighted apply) -- omitting
+    // them here made the label describe a different model than the one
+    // actually evaluated.
+    if (s.Value != Operon::Scalar{1}) {
+        label += "(";
+        AppendValue(label, s.Value, spec);
+        label += " * ";
+        label += s.Name();
+        label += ")";
+    } else {
+        label = s.Name();
+    }
+    return label;
+}
+
+} // namespace
+
+auto FormatDot(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string
 {
     std::string result;
     result += "strict digraph {\n";
     result += "\trankdir=BT\n";
 
-    auto formatLeaf = [&](auto const& s) -> auto {
-        if (s.IsConstant()) {
-            auto formatString = fmt::format(fmt::runtime("{{:.{}f}}"), decimalPrecision);
-            return fmt::format(fmt::runtime(formatString), s.Value);
-        }
-        if (s.IsVariable()) {
-            auto formatString = fmt::format(fmt::runtime("({{:.{}f}} * {{}})"), decimalPrecision);
-            if (auto it = variableNames.find(s.HashValue); it != variableNames.end()) {
-                return fmt::format(fmt::runtime(formatString), s.Value, it->second);
-            }
-            throw std::runtime_error(fmt::format("A key with hash value {} could not be found in the variable map.\n", s.HashValue));
-        }
-        throw std::runtime_error("node is not a leaf (constant or variable)");
-    };
-
-    auto format = [&](auto const& s) -> auto {
-        if (s.IsLeaf()) { return formatLeaf(s); }
-        if (s.Value != Operon::Scalar{1}) {
-            // Function-node weights are real, evaluated state (see
-            // Tree::AdjustedLength()/the interpreter's weighted apply) --
-            // omitting them here made the label describe a different
-            // model than the one actually evaluated.
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "(({{:.{}f}}) * {{}})" : "({{:.{}f}} * {{}})"), decimalPrecision);
-            return fmt::format(fmt::runtime(formatString), s.Value, s.Name());
-        }
-        return s.Name();
-    };
-
     // A Ref is a pointer, not an independent DAG node -- chase it to the
     // node it actually points at so edges connect to the shared node
     // itself rather than to a dangling/duplicated placeholder.
-    auto resolve = [&](auto idx) {
+    auto resolve = [&](std::size_t idx) -> std::size_t {
         while (tree[idx].IsRef()) { idx = tree[idx].RefTo; }
         return idx;
     };
@@ -54,8 +78,9 @@ auto DotFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::strin
     for (auto i = 0UL; i < tree.Length(); ++i) {
         if (tree[i].IsRef()) { continue; }
 
-        auto label = format(tree[i]);
-        fmt::format_to(std::back_inserter(result), "\t{} [label=\"{}\"]\n", i, label);
+        fmt::format_to(std::back_inserter(result), "\t{} [label=\"", i);
+        AppendEscapedLabel(result, FormatLabel(tree, names, i, spec));
+        result += "\"]\n";
 
         if (tree[i].IsLeaf()) { continue; }
 
@@ -68,13 +93,4 @@ auto DotFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::strin
     return result;
 }
 
-auto DotFormatter::Format(Tree const& tree, Dataset const& dataset, int decimalPrecision) -> std::string
-{
-    Operon::Map<Operon::Hash, std::string> variableNames;
-    for (auto const& var : dataset.GetVariables()) {
-        variableNames.insert({ var.Hash, var.Name });
-    }
-    return DotFormatter::Format(tree, variableNames, decimalPrecision);
-}
-
-} // namespace Operon
+} // namespace Operon::Fmt::Detail

--- a/source/formatter/formatter.cpp
+++ b/source/formatter/formatter.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
+#include <fmt/format.h>
+
+#include "operon/core/dataset.hpp"
+#include "operon/formatter/formatter.hpp"
+#include "detail.hpp"
+
+namespace Operon::Fmt {
+
+auto NameView::Resolve(Operon::Hash hash) const -> std::optional<std::string_view>
+{
+    switch (kind_) {
+    case Kind::None:
+        return std::nullopt;
+    case Kind::Dataset:
+        return static_cast<Operon::Dataset const*>(source_)->FindVariableName(hash);
+    case Kind::Map: {
+        auto const& map = *static_cast<VariableNameMap const*>(source_);
+        auto it = map.find(hash);
+        return it == map.end() ? std::nullopt : std::optional<std::string_view>{it->second};
+    }
+    }
+    return std::nullopt;
+}
+
+namespace Detail {
+
+void AppendValue(std::string& out, Operon::Scalar value, ValueSpec spec)
+{
+    if (spec.Fixed) {
+        if (value < 0) { fmt::format_to(std::back_inserter(out), "({:.{}f})", value, spec.Precision); }
+        else            { fmt::format_to(std::back_inserter(out), "{:.{}f}", value, spec.Precision); }
+    } else {
+        if (value < 0) { fmt::format_to(std::back_inserter(out), "({:.{}g})", value, spec.Precision); }
+        else            { fmt::format_to(std::back_inserter(out), "{:.{}g}", value, spec.Precision); }
+    }
+}
+
+void AppendVariableName(std::string& out, NameView const& names, Operon::Hash hash)
+{
+    if (auto name = names.Resolve(hash)) {
+        out.append(*name);
+        return;
+    }
+    if (names.HasSource()) {
+        throw std::runtime_error(fmt::format("Operon tree formatting: no variable name registered for hash {}", hash));
+    }
+    fmt::format_to(std::back_inserter(out), "X_{:016x}", hash);
+}
+
+auto Render(Tree const& tree, Mode mode, NameView const& names, ValueSpec spec) -> std::string
+{
+    // Dot always produces valid output (a possibly empty digraph) --
+    // FormatDot handles the empty-tree case internally. The other three
+    // modes are undefined on an empty tree (no root node to start
+    // traversal from); their contract is simply "empty tree -> empty
+    // string," matching InfixFormatter's pre-existing, already-correct
+    // behavior (extended here to Postfix/Tree, which previously lacked
+    // this guard -- TreeFormatter in particular underflowed on
+    // tree.Length() - 1 and crashed).
+    if (mode == Mode::Dot) { return FormatDot(tree, names, spec); }
+    if (tree.Empty()) { return {}; }
+
+    switch (mode) {
+    case Mode::Infix:   return FormatInfix(tree, names, spec);
+    case Mode::Postfix: return FormatPostfix(tree, names, spec);
+    case Mode::Tree:     return FormatTreeDiagram(tree, names, spec);
+    case Mode::Dot:      break; // unreachable, handled above
+    }
+    return {};
+}
+
+} // namespace Detail
+} // namespace Operon::Fmt

--- a/source/formatter/infix.cpp
+++ b/source/formatter/infix.cpp
@@ -4,170 +4,174 @@
 
 #include <fmt/format.h>
 
-#include "operon/core/dataset.hpp"
-#include "operon/formatter/formatter.hpp"
+#include "operon/core/standard_library.hpp"
+#include "detail.hpp"
 
-namespace Operon {
+namespace Operon::Fmt::Detail {
 
-auto InfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, size_t i, std::string& current, int decimalPrecision) -> void // NOLINT(readability-function-cognitive-complexity)
+namespace {
+
+void FormatNode(Tree const& tree, NameView const& names, std::size_t i, std::string& current, ValueSpec spec) // NOLINT(readability-function-cognitive-complexity)
 {
-    const auto& s = tree[i];
+    auto const& s = tree[i];
     if (s.IsConstant()) {
-        auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}}})" : "{{:.{}}}"), decimalPrecision);
-        fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
-    } else if (s.IsVariable()) {
-        auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "(({{:.{}}}) * {{}})" : "({{:.{}}} * {{}})"), decimalPrecision);
-        if (auto it = variableNames.find(s.HashValue); it != variableNames.end()) {
-            fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value, it->second);
-        } else {
-            throw std::runtime_error(fmt::format("A key with hash value {} could not be found in the variable map.\n", s.HashValue));
-        }
-    } else if (s.IsRef()) {
+        AppendValue(current, s.Value, spec);
+        return;
+    }
+    if (s.IsVariable()) {
+        current += "(";
+        AppendValue(current, s.Value, spec);
+        current += " * ";
+        AppendVariableName(current, names, s.HashValue);
+        current += ")";
+        return;
+    }
+    if (s.IsRef()) {
         // Ref is a leaf (Arity == 0) that points backward to a shared
         // subtree via RefTo, not the physically preceding node -- without
         // this case the generic operator fallback below would recurse into
         // `i-1`, silently formatting the wrong subtree for any tree with
         // structural sharing (e.g. a symbolic-derivative DAG).
-        FormatNode(tree, variableNames, s.RefTo, current, decimalPrecision);
-    } else {
-        if (s.Value != 1) {
-            fmt::format_to(std::back_inserter(current), "(");
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}}})" : "{{:.{}}}"), decimalPrecision);
-            fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
-            fmt::format_to(std::back_inserter(current), " * ");
-        }
-        // BuiltinOp's ordinals preserve the same relative order the old
-        // NodeType math-op subset had, so this boundary (Add..Powabs vs.
-        // Abs onward) is still exactly `< Hash(BuiltinOp::Abs)`.
-        if (s.HashValue < Operon::Hash(BuiltinOp::Abs)) // add, sub, mul, div, aq, fmax, fmin, pow
-        {
-            fmt::format_to(std::back_inserter(current), "(");
-            if (s.Arity == 1) {
-                if (s.IsOp<BuiltinOp::Sub>()) {
-                    // subtraction with a single argument is a negation -x
-                    fmt::format_to(std::back_inserter(current), "-");
-                } else if (s.IsOp<BuiltinOp::Div>()) {
-                    // division with a single argument is an inversion 1/x
-                    fmt::format_to(std::back_inserter(current), "1 / ");
-                }
-                FormatNode(tree, variableNames, i-1, current, decimalPrecision);
-            } else if (s.IsOp<BuiltinOp::Pow>()) {
-                // format pow(a,b) as a^b
-                auto j = i - 1;
-                auto k = j - tree[j].Length - 1;
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), " ^ ");
-                FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.IsOp<BuiltinOp::Powabs>()) {
-                // format powabs(a,b) as abs(a)^b
-                auto j = i - 1;
-                auto k = j - tree[j].Length - 1;
-                fmt::format_to(std::back_inserter(current), "abs(");
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ") ^ ");
-                FormatNode(tree, variableNames, k, current, decimalPrecision);
-            } else if (s.IsOp<BuiltinOp::Aq>()) {
-                // format aq(a,b) as a / (1 + b^2)
-                auto j = i - 1;
-                auto k = j - tree[j].Length - 1;
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), " / (sqrt(1 + ");
-                FormatNode(tree, variableNames, k, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), " ^ 2))");
-            } else if (s.IsOp<BuiltinOp::Fmin>()) {
-                auto j = i - 1;
-                auto k = j - tree[j].Length - 1;
-                fmt::format_to(std::back_inserter(current), "min(");
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ", ");
-                FormatNode(tree, variableNames, k, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ")");
-            } else if (s.IsOp<BuiltinOp::Fmax>()) {
-                auto j = i - 1;
-                auto k = j - tree[j].Length - 1;
-                fmt::format_to(std::back_inserter(current), "max(");
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ", ");
-                FormatNode(tree, variableNames, k, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ")");
-            } else {
-                size_t count = 0;
-                for (auto j : tree.Indices(i)) {
-                    FormatNode(tree, variableNames, j, current, decimalPrecision);
-                    if (++count < s.Arity) {
-                        fmt::format_to(std::back_inserter(current), " {} ", s.Name());
-                    }
+        FormatNode(tree, names, s.RefTo, current, spec);
+        return;
+    }
+
+    // s is a Function node: a built-in math op or a registered
+    // user-defined function, distinguished only by HashValue.
+    // StandardLibrary::FormattingRule(HashValue) is well-defined for any
+    // Hash, built-in or not -- a hash outside the built-in table simply
+    // falls through to its GenericCall default, which is exactly the
+    // right rendering for a registered function.
+    if (s.Value != Operon::Scalar{1}) {
+        current += "(";
+        AppendValue(current, s.Value, spec);
+        current += " * ";
+    }
+
+    switch (Operon::StandardLibrary::FormattingRule(static_cast<Operon::BuiltinOp>(s.HashValue))) {
+    case Operon::FormatRule::Infix: {
+        current += "(";
+        if (s.Arity == 1) {
+            // Sub/Div's fixed-arity registration (see FormatRule::Infix's
+            // declaration) never produces an arity-1 node via ordinary GP
+            // construction, but a manually-built or post-simplification
+            // tree can: unary Sub is negation (-a), unary Div is
+            // inversion (1 / a).
+            if (s.IsOp<Operon::BuiltinOp::Sub>()) { current += "-"; }
+            else if (s.IsOp<Operon::BuiltinOp::Div>()) { current += "1 / "; }
+            FormatNode(tree, names, i - 1, current, spec);
+        } else {
+            std::size_t count = 0;
+            for (auto j : tree.Indices(i)) {
+                FormatNode(tree, names, j, current, spec);
+                if (++count < s.Arity) {
+                    fmt::format_to(std::back_inserter(current), " {} ", s.Name());
                 }
             }
-            fmt::format_to(std::back_inserter(current), ")");
-        } else { // unary operators abs, asin, ... log, exp, sin, etc.
-            if (s.IsOp<BuiltinOp::Square>()) {
-                // format square(a) as a ^ 2
-                fmt::format_to(std::back_inserter(current), "(");
-                FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), " ^ 2)");
-            } else if (s.IsOp<BuiltinOp::Logabs>()) {
-                // format logabs(a) as log(abs(a))
-                fmt::format_to(std::back_inserter(current), "log(abs(");
-                FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), "))");
-            } else if (s.IsOp<BuiltinOp::Log1p>()) {
-                // format log1p(a) as log(a+1)
-                fmt::format_to(std::back_inserter(current), "log(");
-                FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), "+1)");
-            } else if (s.IsOp<BuiltinOp::Sqrtabs>()) {
-                // format sqrtabs(a) as sqrt(abs(a))
-                fmt::format_to(std::back_inserter(current), "sqrt(abs(");
-                FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), "))");
-            } else if (s.Arity == 1) {
-                fmt::format_to(std::back_inserter(current), "{}", s.Name());
-                fmt::format_to(std::back_inserter(current), "(");
-                FormatNode(tree, variableNames, i - 1, current, decimalPrecision);
-                fmt::format_to(std::back_inserter(current), ")");
-            } else {
-                // A registered binary/n-ary function (RegisterBinaryFunction/
-                // RegisterNaryFunction) has a user hash outside the built-in
-                // Add..Powabs range, so it falls through to this branch --
-                // formatting only `i - 1` here would silently drop every
-                // argument but the last for Arity > 1. Render every actual
-                // child as a proper call: name(a, b, ...).
-                fmt::format_to(std::back_inserter(current), "{}", s.Name());
-                fmt::format_to(std::back_inserter(current), "(");
-                size_t count = 0;
-                for (auto j : tree.Indices(i)) {
-                    FormatNode(tree, variableNames, j, current, decimalPrecision);
-                    if (++count < s.Arity) {
-                        fmt::format_to(std::back_inserter(current), ", ");
-                    }
-                }
-                fmt::format_to(std::back_inserter(current), ")");
+        }
+        current += ")";
+        break;
+    }
+    case Operon::FormatRule::PowerNotation: {
+        current += "(";
+        if (s.Arity == 1) { // Square: a ^ 2
+            FormatNode(tree, names, i - 1, current, spec);
+            current += " ^ 2";
+        } else { // Pow: a ^ b
+            auto j = i - 1;
+            auto k = j - tree[j].Length - 1;
+            FormatNode(tree, names, j, current, spec);
+            current += " ^ ";
+            FormatNode(tree, names, k, current, spec);
+        }
+        current += ")";
+        break;
+    }
+    case Operon::FormatRule::MinMaxCall: {
+        auto j = i - 1;
+        auto k = j - tree[j].Length - 1;
+        current += s.IsOp<Operon::BuiltinOp::Fmin>() ? "(min(" : "(max(";
+        FormatNode(tree, names, j, current, spec);
+        current += ", ";
+        FormatNode(tree, names, k, current, spec);
+        current += "))";
+        break;
+    }
+    case Operon::FormatRule::Composite: {
+        if (s.IsOp<Operon::BuiltinOp::Aq>()) {
+            // a / (sqrt(1 + b ^ 2))
+            auto j = i - 1;
+            auto k = j - tree[j].Length - 1;
+            current += "(";
+            FormatNode(tree, names, j, current, spec);
+            current += " / (sqrt(1 + ";
+            FormatNode(tree, names, k, current, spec);
+            current += " ^ 2)))";
+        } else if (s.IsOp<Operon::BuiltinOp::Powabs>()) {
+            // abs(a) ^ b
+            auto j = i - 1;
+            auto k = j - tree[j].Length - 1;
+            current += "(abs(";
+            FormatNode(tree, names, j, current, spec);
+            current += ") ^ ";
+            FormatNode(tree, names, k, current, spec);
+            current += ")";
+        } else if (s.IsOp<Operon::BuiltinOp::Logabs>()) {
+            current += "log(abs(";
+            FormatNode(tree, names, i - 1, current, spec);
+            current += "))";
+        } else if (s.IsOp<Operon::BuiltinOp::Log1p>()) {
+            current += "log(";
+            FormatNode(tree, names, i - 1, current, spec);
+            current += "+1)";
+        } else { // Sqrtabs
+            current += "sqrt(abs(";
+            FormatNode(tree, names, i - 1, current, spec);
+            current += "))";
+        }
+        break;
+    }
+    case Operon::FormatRule::PrefixNegation:
+    case Operon::FormatRule::Inversion:
+        // Never returned by FormattingRule -- Sub/Div always report
+        // FormatRule::Infix (see the enum's own doc comment); the
+        // arity-1 special case is handled inline above. Kept as
+        // exhaustive switch labels rather than a `default:` so a future
+        // FormatRule addition fails to compile here instead of silently
+        // falling through to GenericCall.
+    case Operon::FormatRule::GenericCall: {
+        current += s.Name();
+        current += "(";
+        if (s.Arity == 1) {
+            FormatNode(tree, names, i - 1, current, spec);
+        } else {
+            // A registered binary/n-ary function (RegisterBinaryFunction/
+            // RegisterNaryFunction) reports GenericCall here (its hash is
+            // outside the built-in table) -- render every actual child,
+            // not just the last one.
+            std::size_t count = 0;
+            for (auto j : tree.Indices(i)) {
+                FormatNode(tree, names, j, current, spec);
+                if (++count < s.Arity) { current += ", "; }
             }
         }
-        if (s.Value != 1) {
-            fmt::format_to(std::back_inserter(current), ")");
-        }
+        current += ")";
+        break;
+    }
+    }
+
+    if (s.Value != Operon::Scalar{1}) {
+        current += ")";
     }
 }
 
+} // namespace
 
-
-auto InfixFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision) -> std::string
+auto FormatInfix(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string
 {
-    if (tree.Nodes().empty()) { return std::string{}; }
     std::string result;
-    FormatNode(tree, variableNames, tree.Length() - 1, result, decimalPrecision);
-    return { result.begin(), result.end() };
+    FormatNode(tree, names, tree.Length() - 1, result, spec);
+    return result;
 }
 
-auto InfixFormatter::Format(Tree const& tree, Dataset const& dataset, int decimalPrecision) -> std::string
-{
-    Operon::Map<Operon::Hash, std::string> variableNames;
-    for (auto const& var : dataset.GetVariables()) {
-        variableNames.insert({ var.Hash, var.Name });
-    }
-    return Format(tree, variableNames, decimalPrecision);
-}
-
-} // namespace Operon
+} // namespace Operon::Fmt::Detail

--- a/source/formatter/postfix.cpp
+++ b/source/formatter/postfix.cpp
@@ -2,98 +2,88 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
-#include <fmt/format.h>
+#include "detail.hpp"
 
-#include "operon/core/dataset.hpp"
-#include "operon/formatter/formatter.hpp"
+namespace Operon::Fmt::Detail {
 
-namespace Operon {
+namespace {
 
-auto PostfixFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, size_t i, std::string& current, int decimalPrecision) -> void
+void FormatNode(Tree const& tree, NameView const& names, std::size_t i, std::string& current, ValueSpec spec)
 {
     auto const& s = tree[i];
 
-    switch(s.Type) {
-        case NodeType::Constant: {
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}f}})" : "{{:.{}f}}"), decimalPrecision);
-            fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
-            break;
-        }
-        case NodeType::Variable: {
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "(({{:.{}f}}) * {{}})" : "({{:.{}f}} * {{}})"), decimalPrecision);
-            if (auto it = variableNames.find(s.HashValue); it != variableNames.end()) {
-                fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value, it->second);
-            } else {
-                throw std::runtime_error(fmt::format("A variable with hash value {} could not be found in the dataset.\n", s.HashValue));
+    switch (s.Type) {
+    case NodeType::Constant: {
+        AppendValue(current, s.Value, spec);
+        break;
+    }
+    case NodeType::Variable: {
+        current += "(";
+        AppendValue(current, s.Value, spec);
+        current += " * ";
+        AppendVariableName(current, names, s.HashValue);
+        current += ")";
+        break;
+    }
+    case NodeType::Ref: {
+        // Ref has no tokens of its own -- replay the referenced subtree's
+        // token range (it occupies the contiguous flat range
+        // [RefTo-Length, RefTo], same as any other subtree) instead of
+        // emitting a bare, non-evaluable "ref" token.
+        auto const& target = tree[s.RefTo];
+        auto const first = static_cast<std::size_t>(s.RefTo - target.Length);
+        auto const last = static_cast<std::size_t>(s.RefTo);
+        for (auto j = first;; ++j) {
+            auto const parentStart = static_cast<std::size_t>(tree[j].Parent - tree[tree[j].Parent].Length);
+            if (j == parentStart) {
+                current += "(";
             }
-            break;
-        }
-        case NodeType::Ref: {
-            // Ref has no tokens of its own -- replay the referenced
-            // subtree's token range (it occupies the contiguous flat
-            // range [RefTo-Length, RefTo], same as any other subtree)
-            // instead of emitting a bare, non-evaluable "ref" token.
-            auto const& t = tree[s.RefTo];
-            for (auto j = s.RefTo - t.Length; j <= s.RefTo; ++j) {
-                if (static_cast<int>(j) == tree[j].Parent - tree[tree[j].Parent].Length) {
-                    fmt::format_to(std::back_inserter(current), "(");
-                }
-                FormatNode(tree, variableNames, j, current, decimalPrecision);
-                if (!tree[j].IsLeaf()) {
-                    fmt::format_to(std::back_inserter(current), ")");
-                }
-                if (j != s.RefTo) {
-                    fmt::format_to(std::back_inserter(current), " ");
-                }
+            FormatNode(tree, names, j, current, spec);
+            if (!tree[j].IsLeaf()) {
+                current += ")";
             }
-            break;
+            if (j == last) { break; }
+            current += " ";
         }
-        default: {
-            // s.Name() is data, not a format string -- fmt::runtime(s.Name())
-            // previously reparsed the function's own display name as a spec,
-            // throwing fmt::format_error for any registered name containing
-            // '{'/'}' (braces are otherwise legal in a registered name; only
-            // empty names and reserved hashes are rejected).
-            fmt::format_to(std::back_inserter(current), "{}", s.Name());
-            if (s.Value != Operon::Scalar{1}) {
-                // Unlike the leaf/variable case above (a single "(w * name)"
-                // token, not real RPN), a function node already has its own
-                // argument tokens preceding it in the stream, so its weight
-                // is represented as genuine trailing RPN: "... name w *"
-                // pushes the weight and multiplies it onto the function's
-                // result, exactly mirroring what the interpreter evaluates.
-                // Omitting this made postfix describe a different model
-                // than the one actually evaluated (weights are real,
-                // evaluated state -- see Tree::AdjustedLength()).
-                auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? " ({{:.{}f}}) *" : " {{:.{}f}} *"), decimalPrecision);
-                fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
-            }
+        break;
+    }
+    default: {
+        // s.Name() is data, appended directly -- never passed through a
+        // runtime format string (a registered function's name may legally
+        // contain '{'/'}').
+        current += s.Name();
+        if (s.Value != Operon::Scalar{1}) {
+            // Unlike the leaf/variable case above (a single "(w * name)"
+            // token, not real RPN), a function node already has its own
+            // argument tokens preceding it in the stream, so its weight is
+            // represented as genuine trailing RPN: "... name w *" pushes
+            // the weight and multiplies it onto the function's result,
+            // exactly mirroring what the interpreter evaluates.
+            current += " ";
+            AppendValue(current, s.Value, spec);
+            current += " *";
         }
+    }
     }
 }
 
-auto PostfixFormatter::Format(Tree const& tree, Dataset const& dataset, int decimalPrecision) -> std::string
-{
-    Operon::Map<Operon::Hash, std::string> variableNames;
-    for (auto const& var : dataset.GetVariables()) {
-        variableNames.insert({ var.Hash, var.Name });
-    }
-    return Format(tree, variableNames, decimalPrecision);
-}
+} // namespace
 
-auto PostfixFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision) -> std::string
+auto FormatPostfix(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string
 {
     std::string result;
-    for (auto i = 0UL; i < tree.Length(); ++i) {
-        if (static_cast<int>(i) == tree[i].Parent - tree[tree[i].Parent].Length) {
-            fmt::format_to(std::back_inserter(result), "(");
+    for (auto i = std::size_t{0}; i < tree.Length(); ++i) {
+        auto const parentStart = static_cast<std::size_t>(tree[i].Parent - tree[tree[i].Parent].Length);
+        if (i == parentStart) {
+            result += "(";
         }
-        FormatNode(tree, variableNames, i, result, decimalPrecision);
+        FormatNode(tree, names, i, result, spec);
         if (!tree[i].IsLeaf()) {
-            fmt::format_to(std::back_inserter(result), ")");
+            result += ")";
         }
-        fmt::format_to(std::back_inserter(result), " ");
+        result += " ";
     }
-    return { result.begin(), result.end() };
+    return result;
 }
-} // namespace Operon
+
+} // namespace Operon::Fmt::Detail

--- a/source/formatter/tree.cpp
+++ b/source/formatter/tree.cpp
@@ -4,12 +4,14 @@
 
 #include <fmt/format.h>
 
-#include "operon/core/dataset.hpp"
-#include "operon/formatter/formatter.hpp"
+#include "detail.hpp"
 
-namespace Operon {
+namespace Operon::Fmt::Detail {
 
-auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::string> variableNames, size_t i, std::string& current, std::string indent, bool isLast, bool initialMarker, int decimalPrecision) -> void
+namespace {
+
+void FormatNode(Tree const& tree, NameView const& names, std::size_t i, std::string& current,
+                 std::string indent, bool isLast, bool initialMarker, ValueSpec spec)
 {
     std::string const last{"└── "};
     std::string const notLast{"├── "};
@@ -20,33 +22,22 @@ auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::
         current += isLast ? last : notLast;
     }
 
-    const auto& s = tree[i];
+    auto const& s = tree[i];
     if (s.IsConstant()) {
-        auto formatString = fmt::format("{{:.{}f}}", decimalPrecision);
-        fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
+        AppendValue(current, s.Value, spec);
     } else if (s.IsVariable()) {
-        auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}f}}) * {{}}" : "{{:.{}f}} * {{}}"), decimalPrecision);
-
-        if (auto it = variableNames.find(s.HashValue); it != variableNames.end()) {
-            fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value, it->second);
-        } else {
-            throw std::runtime_error(fmt::format("A variable with hash value {} could not be found in the dataset.\n", s.HashValue));
-        }
+        AppendValue(current, s.Value, spec);
+        current += " * ";
+        AppendVariableName(current, names, s.HashValue);
     } else {
         if (s.Value != Operon::Scalar{1}) {
-            // Only ONE placeholder here (value) -- unlike the IsVariable
-            // branch above, the name is appended separately below, not
-            // via this format string. Reusing the two-placeholder
-            // "{:.Nf} * {}" pattern here previously threw fmt::format_error
-            // ("argument not found") because only s.Value was ever passed.
-            auto formatString = fmt::format(fmt::runtime(s.Value < 0 ? "({{:.{}f}})" : "{{:.{}f}}"), decimalPrecision);
-            fmt::format_to(std::back_inserter(current), "(");
-            fmt::format_to(std::back_inserter(current), fmt::runtime(formatString), s.Value);
-            fmt::format_to(std::back_inserter(current), " * ");
-            fmt::format_to(std::back_inserter(current), "{}", s.Name());
-            fmt::format_to(std::back_inserter(current), ")");
+            current += "(";
+            AppendValue(current, s.Value, spec);
+            current += " * ";
+            current += s.Name();
+            current += ")";
         } else {
-            fmt::format_to(std::back_inserter(current), "{}", s.Name());
+            current += s.Name();
         }
     }
     fmt::format_to(std::back_inserter(current), " D:{} L:{} N:{}\n", s.Depth, s.Level, s.Length + 1);
@@ -62,37 +53,23 @@ auto TreeFormatter::FormatNode(Tree const& tree, Operon::Map<Operon::Hash, std::
     if (s.IsRef()) {
         // Ref has no children of its own -- nest the shared subtree's
         // diagram directly under it so it's visible rather than eliding it.
-        FormatNode(tree, variableNames, s.RefTo, current, indent, /*isLast=*/true, /*initialMarker=*/true, decimalPrecision);
+        FormatNode(tree, names, s.RefTo, current, indent, /*isLast=*/true, /*initialMarker=*/true, spec);
         return;
     }
 
-    size_t count = 0;
+    std::size_t count = 0;
     for (auto j : tree.Indices(i)) {
-        FormatNode(tree, variableNames, j, current, indent, ++count == s.Arity, /*initialMarker=*/true, decimalPrecision);
+        FormatNode(tree, names, j, current, indent, ++count == s.Arity, /*initialMarker=*/true, spec);
     }
 }
 
-auto TreeFormatter::Format(Tree const& tree, Dataset const& dataset, int decimalPrecision) -> std::string
+} // namespace
+
+auto FormatTreeDiagram(Tree const& tree, NameView const& names, ValueSpec spec) -> std::string
 {
-    if (tree.Nodes().empty()) { return std::string{}; }
-
-    Operon::Map<Operon::Hash, std::string> variableNames;
-    for (auto const& var : dataset.GetVariables()) {
-        variableNames.insert({ var.Hash, var.Name });
-    }
-
     std::string result;
-    FormatNode(tree, variableNames, tree.Length() - 1, result, "", /*isLast=*/true, /*initialMarker=*/false, decimalPrecision);
+    FormatNode(tree, names, tree.Length() - 1, result, "", /*isLast=*/true, /*initialMarker=*/false, spec);
     return result;
 }
 
-auto TreeFormatter::Format(Tree const& tree, Operon::Map<Operon::Hash, std::string> const& variableNames, int decimalPrecision) -> std::string
-{
-    if (tree.Nodes().empty()) { return std::string{}; }
-
-    std::string result;
-    FormatNode(tree, variableNames, tree.Length() - 1, result, "", /*isLast=*/true, /*initialMarker=*/false, decimalPrecision);
-    return result;
-}
-
-} // namespace Operon
+} // namespace Operon::Fmt::Detail

--- a/source/operators/shape_constrained_evaluator.cpp
+++ b/source/operators/shape_constrained_evaluator.cpp
@@ -782,7 +782,7 @@ auto ShapeConstrainedEvaluator::Prepare(Operon::Span<Individual const> pop) cons
         std::ignore = Feasible(pop[i].Genotype); // populates the ordinary cache as a side effect
 
         if (dump) {
-            auto const infix = Operon::InfixFormatter::Format(pop[i].Genotype, *GetProblem()->GetDataset(), std::numeric_limits<Operon::Scalar>::max_digits10);
+            auto const infix = fmt::format("{:infix:roundtrip}", Operon::Fmt::WithNames{pop[i].Genotype, *GetProblem()->GetDataset()});
             // Constraints are checked against the SCALED model (Scale*f+Offset),
             // not the raw subtree -- TransformBound applies this same fit to the
             // bound rather than baking it into the tree (see MeasureConstraints).

--- a/test/source/implementation/dispatch_table.cpp
+++ b/test/source/implementation/dispatch_table.cpp
@@ -17,6 +17,7 @@
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/parser/infix.hpp"
 #include "operon/formatter/formatter.hpp"
+#include <fmt/format.h>
 
 namespace Operon::Test {
 
@@ -433,17 +434,17 @@ TEST_CASE("RegisterFunction - FunctionInfo convenience wrapper", "[interpreter]"
         dynNode.Length = 1;
 
         Operon::Tree const tree({ varNode, dynNode });
-        auto formatted = InfixFormatter::Format(tree, ds);
+        auto formatted = fmt::format("{:infix}", Operon::Fmt::WithNames{tree, ds});
         CHECK(formatted.find("cube") != std::string::npos);
     }
 
     SECTION("PostfixFormatter and DotFormatter use registered built-in names") {
         auto builtInTree = InfixParser::Parse("sin(x)");
 
-        auto postfix = PostfixFormatter::Format(builtInTree, ds);
+        auto postfix = fmt::format("{:postfix}", Operon::Fmt::WithNames{builtInTree, ds});
         CHECK(postfix == "((1.00 * x) sin) ");
 
-        auto dot = DotFormatter::Format(builtInTree, ds);
+        auto dot = fmt::format("{:dot}", Operon::Fmt::WithNames{builtInTree, ds});
         CHECK(dot.find("[label=\"sin\"]") != std::string::npos);
         CHECK(dot.find("0 -> 1") != std::string::npos);
     }
@@ -481,7 +482,7 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
             dyn,
         });
 
-        auto formatted = InfixFormatter::Format(tree, ds);
+        auto formatted = fmt::format("{:infix}", Operon::Fmt::WithNames{tree, ds});
         CHECK(formatted.find("sum3(") != std::string::npos);
         CHECK(formatted.find("21") != std::string::npos);
         CHECK(formatted.find("34") != std::string::npos);
@@ -511,7 +512,7 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
         Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
 
         std::string formatted;
-        CHECK_NOTHROW(formatted = TreeFormatter::Format(tree, ds));
+        CHECK_NOTHROW(formatted = fmt::format("{:tree}", Operon::Fmt::WithNames{tree, ds}));
         CHECK(formatted.find("2.50") != std::string::npos);
         CHECK(formatted.find("cube") != std::string::npos);
     }
@@ -531,7 +532,7 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
         dyn.Value = 2.5;
         Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
 
-        auto dot = DotFormatter::Format(tree, ds);
+        auto dot = fmt::format("{:dot}", Operon::Fmt::WithNames{tree, ds});
         CHECK(dot.find("2.50") != std::string::npos);
         CHECK(dot.find("cube") != std::string::npos);
     }
@@ -551,7 +552,7 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
         dyn.Value = 2.5;
         Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
 
-        auto postfix = PostfixFormatter::Format(tree, ds);
+        auto postfix = fmt::format("{:postfix}", Operon::Fmt::WithNames{tree, ds});
         CHECK(postfix == "(1.00 cube 2.50 *) ");
     }
 
@@ -574,7 +575,7 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
         Operon::Tree const tree({ Operon::Node::Constant(1.0), dyn });
 
         std::string formatted;
-        CHECK_NOTHROW(formatted = PostfixFormatter::Format(tree, ds));
+        CHECK_NOTHROW(formatted = fmt::format("{:postfix}", Operon::Fmt::WithNames{tree, ds}));
         CHECK(formatted.find("f{brace}") != std::string::npos);
     }
 
@@ -583,9 +584,9 @@ TEST_CASE("Formatter bugfixes: registered n-ary calls, weighted function nodes, 
         std::string treeOut;
         std::string postfixOut;
         std::string dotOut;
-        CHECK_NOTHROW(treeOut = TreeFormatter::Format(empty, ds));
-        CHECK_NOTHROW(postfixOut = PostfixFormatter::Format(empty, ds));
-        CHECK_NOTHROW(dotOut = DotFormatter::Format(empty, ds));
+        CHECK_NOTHROW(treeOut = fmt::format("{:tree}", Operon::Fmt::WithNames{empty, ds}));
+        CHECK_NOTHROW(postfixOut = fmt::format("{:postfix}", Operon::Fmt::WithNames{empty, ds}));
+        CHECK_NOTHROW(dotOut = fmt::format("{:dot}", Operon::Fmt::WithNames{empty, ds}));
         CHECK(treeOut.empty());
         CHECK(postfixOut.empty());
         CHECK(dotOut.find("digraph") != std::string::npos);

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -8,6 +8,7 @@
 #include "../operon_test.hpp"
 #include "operon/interpreter/interpreter.hpp"
 #include "operon/formatter/formatter.hpp"
+#include <fmt/format.h>
 #include "operon/core/pset.hpp"
 #include "operon/operators/creator.hpp"
 #include "operon/parser/infix.hpp"
@@ -38,7 +39,7 @@ TEST_CASE("Parser roundtrip correctness", "[parser]")
     Operon::Vector<Operon::Tree> parsedTrees;
     parsedTrees.reserve(nTrees);
     std::transform(trees.begin(), trees.end(), std::back_inserter(parsedTrees), [&](const auto& tree) -> auto {
-        return InfixParser::Parse(InfixFormatter::Format(tree, ds, 50), ds);
+        return InfixParser::Parse(fmt::format("{:infix:50}", Operon::Fmt::WithNames{tree, ds}), ds);
     });
 
     Range range{0, 1};
@@ -98,7 +99,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         t.UpdateNodes();
 
         Dataset const ds("./data/Poly-10.csv", true);
-        auto s1 = InfixFormatter::Format(t, ds, 5);
+        auto s1 = fmt::format("{:infix:5}", Operon::Fmt::WithNames{t, ds});
         auto t2 = InfixParser::Parse(s1);
 
         // Roundtrip: same number of nodes
@@ -147,7 +148,7 @@ TEST_CASE("Formatter output", "[parser]")
 
         for (int i = 0; i < 100; ++i) {
             auto tree = btc(rng, 20, 1, 10);
-            auto s = InfixFormatter::Format(tree, ds, 5);
+            auto s = fmt::format("{:infix:5}", Operon::Fmt::WithNames{tree, ds});
             CHECK(validateString(s));
         }
     }
@@ -177,7 +178,7 @@ TEST_CASE("Formatter output", "[parser]")
         Operon::Tree tree({nx, ny, mul, refX, add});
         tree.UpdateNodes();
 
-        auto const s = InfixFormatter::Format(tree, names, 3);
+        auto const s = fmt::format("{:infix:3}", Operon::Fmt::WithNames{tree, names});
         CHECK(s.find('y') != std::string::npos); // from x*y
         // Formatted string must reference x twice (once from x*y, once from
         // ref(x)) -- a formatter that follows i-1 instead of RefTo would
@@ -220,7 +221,7 @@ TEST_CASE("Formatter output", "[parser]")
         };
 
         SECTION("PostfixFormatter replays the referenced subtree's tokens") {
-            auto const s = PostfixFormatter::Format(tree, names, 2);
+            auto const s = fmt::format("{:postfix:2}", Operon::Fmt::WithNames{tree, names});
             // x*y contributes one "x", ref(x) must replay x's token again --
             // a formatter following i-1 instead of RefTo would instead
             // duplicate the "y" (or mul) token and never emit a second x.
@@ -229,18 +230,45 @@ TEST_CASE("Formatter output", "[parser]")
         }
 
         SECTION("TreeFormatter nests the referenced subtree under the Ref leaf") {
-            auto const s = TreeFormatter::Format(tree, names, 2);
+            auto const s = fmt::format("{:tree:2}", Operon::Fmt::WithNames{tree, names});
             CHECK(countOccurrences(s, "x D:") == 2);
         }
 
         SECTION("DotFormatter points edges at the shared node, not a duplicate/dangling Ref box") {
-            auto const s = DotFormatter::Format(tree, names, 2);
-            CHECK_NOTHROW(DotFormatter::Format(tree, names, 2));
+            auto const s = fmt::format("{:dot:2}", Operon::Fmt::WithNames{tree, names});
+            CHECK_NOTHROW(fmt::format("{:dot:2}", Operon::Fmt::WithNames{tree, names}));
             CHECK(s.find("3 [label=") == std::string::npos); // no box for the Ref node itself
             CHECK(s.find("0 -> 4") != std::string::npos); // nx -> add, resolved through the Ref
             CHECK(s.find("3 ->") == std::string::npos);
             CHECK(s.find("-> 3") == std::string::npos);
         }
+    }
+
+    SECTION("Bare Tree (no WithNames) falls back to deterministic X_<hash> variable labels") {
+        Operon::Dataset const ds2({"x", "y"}, {{2.0F}, {3.0F}});
+        auto const hx = ds2.GetVariable("x").value().Hash;
+
+        Operon::Node nx(NodeType::Variable);
+        nx.HashValue = hx;
+        nx.Value = 1;
+        Operon::Tree tree({nx});
+        tree.UpdateNodes();
+
+        // fmt::formatter<Operon::Tree> (no Dataset/map supplied) must not
+        // throw -- a Tree does not itself own variable names, so this is
+        // diagnostic-only fallback labeling, not an error condition.
+        std::string bare;
+        CHECK_NOTHROW(bare = fmt::format("{}", tree));
+        CHECK(bare.find(fmt::format("X_{:016x}", hx)) != std::string::npos);
+
+        // Deterministic: the same hash gets the same fallback label on a
+        // second, independent format call.
+        CHECK(fmt::format("{}", tree) == bare);
+
+        // Every mode accepts the bare-Tree form.
+        CHECK_NOTHROW(fmt::format("{:postfix}", tree));
+        CHECK_NOTHROW(fmt::format("{:tree}", tree));
+        CHECK_NOTHROW(fmt::format("{:dot}", tree));
     }
 }
 

--- a/test/source/performance/infix_parser.cpp
+++ b/test/source/performance/infix_parser.cpp
@@ -8,6 +8,7 @@
 
 #include "operon/core/pset.hpp"
 #include "operon/formatter/formatter.hpp"
+#include <fmt/format.h>
 #include "operon/operators/creator.hpp"
 #include "operon/parser/infix.hpp"
 
@@ -38,7 +39,7 @@ TEST_CASE("Parser throughput", "[performance]")
     for (auto i = 0; i < nTrees; ++i) {
         auto tree = creator(rng, dist(rng), 0, 10);
         totalNodes += tree.Length();
-        strings.push_back(InfixFormatter::Format(tree, ds, 20));
+        strings.push_back(fmt::format("{:infix:20}", Operon::Fmt::WithNames{tree, ds}));
     }
 
     size_t idx{0};


### PR DESCRIPTION
## Summary
- replace formatter classes with `fmt::formatter<Tree>` and `Fmt::WithNames` wrappers with infix, postfix, tree, dot, precision, and round-trip specs
- keep rendering backends compiled, centralize variable-name lookup and numeric rendering, and migrate every formatter caller
- correctly render shared `Ref` subtrees, weighted functions, bare trees, and escaped DOT labels

## Verification
- `nix develop -c cmake --build build --parallel 16`
- `nix develop -c ./build/test/operon_test '[parser]'` — 138 assertions in 4 test cases\n- `nix develop -c ./build/example/custom_primitives data/Poly-10.csv`\n\n## Note\nThe repository-wide `format-check` target remains red before this branch: it reports many existing files. The changed C++ files were not reformatted as unrelated cleanup.