### PR TITLE
test(build): verify installed package consumer

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,3 +94,38 @@ endif()
 
 add_test(NAME operon_test COMMAND operon_test "~[performance]" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 windows_set_path(operon_test operon::operon)
+
+# ---- Installed-package-consumer contract (package-consumer) ----
+# Exercises the install -> relocate -> find_package(operon CONFIG) -> build
+# -> run path a real external consumer takes, using the package this build
+# just produced. Every step below runs at `ctest` time, not at configure
+# time: only the actual build tree produced by *this* invocation is a valid
+# thing to install from.
+#
+# Only meaningful when operon is being built directly (PROJECT_IS_TOP_LEVEL
+# is FALSE here precisely when test/ has been add_subdirectory()'d from the
+# main operon build -- see cmake/project-is-top-level.cmake). When test/ is
+# instead configured standalone against some pre-existing operon
+# installation, there is no operon build tree in this invocation to install
+# from, so the fixture is skipped.
+if(NOT PROJECT_IS_TOP_LEVEL)
+    set(operon_package_consumer_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/package-consumer")
+    set(operon_package_consumer_work_dir "${CMAKE_BINARY_DIR}/package-consumer")
+
+    add_test(
+        NAME package_consumer
+        COMMAND "${CMAKE_COMMAND}"
+                "-DCMAKE_COMMAND=${CMAKE_COMMAND}"
+                "-DOPERON_MAIN_BUILD_DIR=${CMAKE_BINARY_DIR}"
+                "-DOPERON_CONFIGURATION=$<CONFIG>"
+                "-DOPERON_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+                "-DOPERON_VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}"
+                "-DOPERON_VCPKG_INSTALLED_DIR=${VCPKG_INSTALLED_DIR}"
+                "-DOPERON_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}"
+                "-DOPERON_STAGE_DIR=${operon_package_consumer_work_dir}/stage"
+                "-DOPERON_RELOCATED_PREFIX=${operon_package_consumer_work_dir}/relocated-prefix"
+                "-DOPERON_CONSUMER_SOURCE_DIR=${operon_package_consumer_source_dir}"
+                "-DOPERON_CONSUMER_BUILD_DIR=${operon_package_consumer_work_dir}/build"
+                -P "${operon_package_consumer_source_dir}/run-consumer-test.cmake"
+    )
+endif()

--- a/test/package-consumer/CMakeLists.txt
+++ b/test/package-consumer/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+# SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+#
+# Standalone consumer project. NEVER add_subdirectory()'d into the main
+# operon build -- run-consumer-test.cmake configures/builds/runs it as an
+# entirely separate `cmake` invocation, against an installed and relocated
+# `operon` package, to prove the installed package's find_package/target
+# contract holds outside the operon source and build trees.
+cmake_minimum_required(VERSION 3.25)
+
+project(operon_package_consumer LANGUAGES CXX)
+
+find_package(operon CONFIG REQUIRED)
+
+add_executable(package_consumer source/main.cpp)
+target_link_libraries(package_consumer PRIVATE operon::operon)
+target_compile_features(package_consumer PRIVATE cxx_std_23)
+
+enable_testing()
+add_test(NAME package_consumer COMMAND package_consumer)

--- a/test/package-consumer/run-consumer-test.cmake
+++ b/test/package-consumer/run-consumer-test.cmake
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+# SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+#
+# CTest driver (`cmake -P`) for the installed-package-consumer contract.
+#
+# Runs, in order, the four steps an out-of-tree consumer of operon actually
+# performs: install the package this build just produced into a staging
+# prefix, relocate that prefix to an unrelated path (proving nothing in the
+# installed tree hard-codes the staging location), configure the standalone
+# consumer project against ONLY the relocated prefix via CMAKE_PREFIX_PATH,
+# then build and run it. Any step failing aborts immediately with the
+# offending command's captured output.
+cmake_minimum_required(VERSION 3.25)
+
+foreach(var
+    CMAKE_COMMAND
+    OPERON_MAIN_BUILD_DIR
+    OPERON_STAGE_DIR
+    OPERON_RELOCATED_PREFIX
+    OPERON_CONSUMER_SOURCE_DIR
+    OPERON_CONSUMER_BUILD_DIR
+)
+    if(NOT DEFINED ${var} OR "${${var}}" STREQUAL "")
+        message(FATAL_ERROR "run-consumer-test.cmake: ${var} must be passed via -D")
+    endif()
+endforeach()
+
+function(run_step description)
+    execute_process(
+        COMMAND ${ARGN}
+        RESULT_VARIABLE step_result
+        OUTPUT_VARIABLE step_output
+        ERROR_VARIABLE step_error
+    )
+    if(NOT step_result EQUAL 0)
+        message(FATAL_ERROR
+            "package-consumer: ${description} failed (exit ${step_result})\n"
+            "--- stdout ---\n${step_output}\n"
+            "--- stderr ---\n${step_error}"
+        )
+    endif()
+    message(STATUS "package-consumer: ${description} OK")
+endfunction()
+
+# Start from a clean slate: re-running ctest must not observe stale state
+# from a previous run (a previously relocated prefix, a previous consumer
+# build cache pointing at now-invalid paths, ...).
+file(REMOVE_RECURSE "${OPERON_STAGE_DIR}")
+file(REMOVE_RECURSE "${OPERON_RELOCATED_PREFIX}")
+file(REMOVE_RECURSE "${OPERON_CONSUMER_BUILD_DIR}")
+
+# A multi-config parent build must install and exercise the same configuration
+# CTest selected. Single-config generators expand $<CONFIG> to an empty string,
+# for which omitting --config preserves CMake's normal behavior. CMake uses
+# --config for installation/building; CTest spells the equivalent option -C.
+set(operon_cmake_config_args)
+set(operon_ctest_config_args)
+if(DEFINED OPERON_CONFIGURATION AND NOT "${OPERON_CONFIGURATION}" STREQUAL "")
+    list(APPEND operon_cmake_config_args --config "${OPERON_CONFIGURATION}")
+    list(APPEND operon_ctest_config_args -C "${OPERON_CONFIGURATION}")
+endif()
+
+# Preserve the parent's dependency-discovery and runtime ABI context when it
+# uses vcpkg. The relocated prefix remains the only package-specific search
+# location; these settings merely let operonConfig.cmake resolve its declared
+# third-party dependencies on Windows.
+set(operon_consumer_config_args)
+foreach(var
+    OPERON_TOOLCHAIN_FILE
+    OPERON_VCPKG_TARGET_TRIPLET
+    OPERON_VCPKG_INSTALLED_DIR
+    OPERON_MSVC_RUNTIME_LIBRARY
+)
+    if(DEFINED ${var} AND NOT "${${var}}" STREQUAL "")
+        if(var STREQUAL "OPERON_TOOLCHAIN_FILE")
+            set(cmake_var CMAKE_TOOLCHAIN_FILE)
+        else()
+            string(REPLACE "OPERON_" "" cmake_var "${var}")
+        endif()
+        list(APPEND operon_consumer_config_args "-D${cmake_var}=${${var}}")
+    endif()
+endforeach()
+
+# 1. Install only the library package components. CI builds operon_test, not
+# the optional CLI executables, whose independent install component would
+# otherwise make this contract test fail before reaching the consumer.
+run_step("install runtime"
+    "${CMAKE_COMMAND}" --install "${OPERON_MAIN_BUILD_DIR}" ${operon_cmake_config_args} --component operon_Runtime --prefix "${OPERON_STAGE_DIR}"
+)
+run_step("install development"
+    "${CMAKE_COMMAND}" --install "${OPERON_MAIN_BUILD_DIR}" ${operon_cmake_config_args} --component operon_Development --prefix "${OPERON_STAGE_DIR}"
+)
+
+# 2. Relocate the staged prefix. A consumer never sees OPERON_STAGE_DIR;
+# only the moved-to path is handed to the fixture below. If any exported
+# file baked an absolute path back to the staging (or, worse, the operon
+# source/build tree) location, this rename makes that surface as a
+# find_package or link failure instead of silently passing.
+file(RENAME "${OPERON_STAGE_DIR}" "${OPERON_RELOCATED_PREFIX}")
+
+# 3. Configure the fixture with the relocated prefix as its only package
+# location. Forwarded vcpkg settings preserve the parent toolchain's
+# dependency discovery and MSVC runtime ABI without exposing its build tree.
+run_step("configure"
+    "${CMAKE_COMMAND}"
+        -S "${OPERON_CONSUMER_SOURCE_DIR}"
+        -B "${OPERON_CONSUMER_BUILD_DIR}"
+        "-DCMAKE_PREFIX_PATH=${OPERON_RELOCATED_PREFIX}"
+        ${operon_consumer_config_args}
+)
+
+# 4. Build it in the selected configuration, when applicable.
+run_step("build"
+    "${CMAKE_COMMAND}" --build "${OPERON_CONSUMER_BUILD_DIR}" ${operon_cmake_config_args}
+)
+
+# 5. Run it via CTest. `-C`, rather than CMake's `--config`, selects a
+# multi-config CTest configuration.
+run_step("run"
+    "${CMAKE_COMMAND}" -E env --unset=CTEST_OUTPUT_ON_FAILURE
+    ctest --test-dir "${OPERON_CONSUMER_BUILD_DIR}" ${operon_ctest_config_args} --output-on-failure
+)

--- a/test/package-consumer/source/main.cpp
+++ b/test/package-consumer/source/main.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+//
+// Package-consumer contract fixture (see test/package-consumer/CMakeLists.txt).
+// Intentionally standalone: it must compile and link using ONLY the public
+// headers and operon::operon target as they appear after `find_package(operon
+// CONFIG REQUIRED)` against an *installed, relocated* package -- it never
+// sees the operon source or build tree directly.
+
+#include <cstdlib>
+#include <iostream>
+
+#include <operon/core/node.hpp>
+#include <operon/core/tree.hpp>
+#include <operon/core/version.hpp>
+
+auto main() -> int {
+    // A one-node tree is enough to prove that the installed public headers
+    // are self-sufficient (no missing transitive includes) and that
+    // liboperon's implementation is actually reachable through the
+    // operon::operon imported target (UpdateNodes() is defined in
+    // source/core/tree.cpp, not header-only).
+    auto node = Operon::Node::Constant(2.0);
+    Operon::Tree tree({node});
+    tree.UpdateNodes();
+
+    if (tree.Length() != 1) {
+        std::cerr << "package-consumer: unexpected tree length " << tree.Length() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "package-consumer: " << Operon::Version();
+    std::cout << "package-consumer: OK\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- add a CTest fixture that installs, relocates, discovers, builds, and runs an Operon package consumer
- exercise static/shared package components without requiring optional CLI binaries
- preserve multi-config selection and Windows vcpkg/MSVC runtime context

## Verification
```
nix develop -c cmake -S . -B build-package-components -Doperon_DEVELOPER_MODE=ON -DBUILD_EXAMPLES=OFF -DUSE_ASMJIT=OFF
nix develop -c cmake --build build-package-components --target operon_operon -j16
nix develop -c ctest --test-dir build-package-components -C Release -R "^package_consumer$" --output-on-failure
```
`1/1 package_consumer` passed.