### PR TITLE
Add tree validation oracle

### DIFF
--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -7,9 +7,11 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <vector>
 #include <numeric>
+#include <optional>
+#include <string>
 #include <type_traits>
+#include <vector>
 
 #include "contracts.hpp"
 #include "subtree.hpp"
@@ -51,6 +53,15 @@ public:
     }
 
     auto UpdateNodes() -> Tree&;
+
+    // Validates the postfix tree representation without using Subtree traversal.
+    // A non-empty tree has one root at the final node; every Function consumes
+    // exactly Arity contiguous completed child subtrees. Terminals (including
+    // Ref) have zero arity, and RefTo points to an earlier node. Length, Depth,
+    // Parent, and Level must equal the metadata derived from that structure.
+    // Empty trees are valid. This opt-in diagnostic API is intentionally not
+    // called by evaluation or search paths.
+    [[nodiscard]] auto Validate() const -> std::optional<std::string>;
     auto Sort() -> Tree&;
     auto Reduce() -> Tree&;
     auto Simplify() -> Tree&;

--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -8,16 +8,34 @@
 #include <algorithm>
 #include <cstdint>
 #include <numeric>
-#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
+
+#include <tl/expected.hpp>
 
 #include "contracts.hpp"
 #include "subtree.hpp"
 #include "operon/operon_export.hpp"
 
 namespace Operon {
+enum class TreeValidationError : std::uint8_t {
+    InvalidNodeType,
+    RefNotBackward,
+    FunctionArityZero,
+    TerminalArityNonZero,
+    MissingChildren,
+    ChildSubtreesNotContiguous,
+    ChildSubtreesNotAdjacent,
+    MultipleRoots,
+    RootDoesNotCoverTree,
+    DerivedMetadataOverflow,
+    LengthMismatch,
+    DepthMismatch,
+    ParentMismatch,
+    LevelMismatch,
+};
+
 class OPERON_EXPORT Tree { // NOLINT
 public:
     Tree() = default;
@@ -59,9 +77,10 @@ public:
     // exactly Arity contiguous completed child subtrees. Terminals (including
     // Ref) have zero arity, and RefTo points to an earlier node. Length, Depth,
     // Parent, and Level must equal the metadata derived from that structure.
-    // Empty trees are valid. This opt-in diagnostic API is intentionally not
-    // called by evaluation or search paths.
-    [[nodiscard]] auto Validate() const -> std::optional<std::string>;
+    // Empty trees are valid. This opt-in API is intentionally not called by
+    // evaluation or search paths. Its error value identifies the first failed
+    // invariant without allocating a diagnostic string.
+    [[nodiscard]] auto Validate() const -> tl::expected<void, TreeValidationError>;
     auto Sort() -> Tree&;
     auto Reduce() -> Tree&;
     auto Simplify() -> Tree&;

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -2,16 +2,18 @@
 // SPDX-FileCopyrightText: Copyright 2019-2025 Heal Research
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
-#include <cstddef>
-#include <cstdint>
 #include <algorithm>
 #include <cmath>
-#include <numeric>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iterator>
+#include <limits>
+#include <numeric>
 #include <optional>
-#include <vector>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "operon/core/tree.hpp"
 #include "operon/hash/hash.hpp"
@@ -49,6 +51,105 @@ auto Tree::UpdateNodes() -> Tree&
     }
 
     return *this;
+}
+
+auto Tree::Validate() const -> std::optional<std::string>
+{
+    if (nodes_.empty()) { return std::nullopt; }
+
+    struct CompletedSubtree {
+        size_t First;
+        size_t Root;
+        size_t Depth;
+    };
+
+    std::vector<CompletedSubtree> stack;
+    stack.reserve(nodes_.size());
+    std::vector<size_t> parents(nodes_.size());
+    std::vector<size_t> lengths(nodes_.size());
+    std::vector<size_t> depths(nodes_.size());
+
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+        auto const& node = nodes_[i];
+        if (node.IsRef() && node.RefTo >= i) {
+            return "node " + std::to_string(i) + ": RefTo must point to an earlier node";
+        }
+
+        if (node.IsFunction() == node.IsLeaf()) {
+            return "node " + std::to_string(i) + ": "
+                + (node.IsFunction() ? "Function must have positive arity" : "terminal must have zero arity");
+        }
+        if (node.IsLeaf()) {
+            depths[i] = 1;
+            stack.push_back({i, i, 1});
+            continue;
+        }
+
+        auto const arity = static_cast<size_t>(node.Arity);
+        if (stack.size() < arity) {
+            return "node " + std::to_string(i) + ": arity " + std::to_string(arity)
+                + " requires that many completed child subtrees, but only " + std::to_string(stack.size()) + " are available";
+        }
+
+        auto const firstChild = stack.size() - arity;
+        auto const first      = stack[firstChild].First;
+        if (firstChild > 0 && stack[firstChild - 1].Root + 1 != first) {
+            return "node " + std::to_string(i) + ": child subtrees do not form a contiguous postfix partition";
+        }
+        if (stack.back().Root + 1 != i) {
+            return "node " + std::to_string(i) + ": child subtrees do not end immediately before their parent";
+        }
+
+        size_t depth{1};
+        for (auto j = firstChild; j < stack.size(); ++j) {
+            parents[stack[j].Root] = i;
+            depth = std::max(depth, stack[j].Depth + 1);
+        }
+        stack.erase(stack.begin() + static_cast<std::ptrdiff_t>(firstChild), stack.end());
+        stack.push_back({first, i, depth});
+        lengths[i] = i - first;
+        depths[i]  = depth;
+    }
+
+    if (stack.size() != 1) {
+        return "tree has " + std::to_string(stack.size()) + " roots; postfix input must contain exactly one root";
+    }
+    if (stack.front().First != 0 || stack.front().Root != nodes_.size() - 1) {
+        return "root does not cover every node in the postfix sequence";
+    }
+
+    std::vector<size_t> levels(nodes_.size());
+    levels.back() = 1;
+    for (size_t i = nodes_.size() - 1; i > 0; --i) {
+        levels[i - 1] = levels[parents[i - 1]] + 1;
+    }
+
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+        auto const& node = nodes_[i];
+        if (lengths[i] > std::numeric_limits<uint16_t>::max()
+            || depths[i] > std::numeric_limits<uint16_t>::max()
+            || parents[i] > std::numeric_limits<uint16_t>::max()
+            || levels[i] > std::numeric_limits<uint16_t>::max()) {
+            return "node " + std::to_string(i) + ": derived metadata exceeds uint16_t storage";
+        }
+        if (node.Length != lengths[i]) {
+            return "node " + std::to_string(i) + ": Length is " + std::to_string(node.Length)
+                + ", expected " + std::to_string(lengths[i]);
+        }
+        if (node.Depth != depths[i]) {
+            return "node " + std::to_string(i) + ": Depth is " + std::to_string(node.Depth)
+                + ", expected " + std::to_string(depths[i]);
+        }
+        if (node.Parent != parents[i]) {
+            return "node " + std::to_string(i) + ": Parent is " + std::to_string(node.Parent)
+                + ", expected " + std::to_string(parents[i]);
+        }
+        if (node.Level != levels[i]) {
+            return "node " + std::to_string(i) + ": Level is " + std::to_string(node.Level)
+                + ", expected " + std::to_string(levels[i]);
+        }
+    }
+    return std::nullopt;
 }
 
 auto Tree::Reduce() -> Tree&

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -53,9 +53,9 @@ auto Tree::UpdateNodes() -> Tree&
     return *this;
 }
 
-auto Tree::Validate() const -> std::optional<std::string>
+auto Tree::Validate() const -> tl::expected<void, TreeValidationError>
 {
-    if (nodes_.empty()) { return std::nullopt; }
+    if (nodes_.empty()) { return {}; }
 
     struct CompletedSubtree {
         size_t First;
@@ -78,16 +78,16 @@ auto Tree::Validate() const -> std::optional<std::string>
         case NodeType::Function:
             break;
         default:
-            return "node " + std::to_string(i) + ": invalid NodeType "
-                + std::to_string(static_cast<unsigned int>(node.Type));
+            return tl::make_unexpected(TreeValidationError::InvalidNodeType);
         }
         if (node.IsRef() && node.RefTo >= i) {
-            return "node " + std::to_string(i) + ": RefTo must point to an earlier node";
+            return tl::make_unexpected(TreeValidationError::RefNotBackward);
         }
 
         if (node.IsFunction() == node.IsLeaf()) {
-            return "node " + std::to_string(i) + ": "
-                + (node.IsFunction() ? "Function must have positive arity" : "terminal must have zero arity");
+            return tl::make_unexpected(node.IsFunction()
+                ? TreeValidationError::FunctionArityZero
+                : TreeValidationError::TerminalArityNonZero);
         }
         if (node.IsLeaf()) {
             depths[i] = 1;
@@ -97,17 +97,16 @@ auto Tree::Validate() const -> std::optional<std::string>
 
         auto const arity = static_cast<size_t>(node.Arity);
         if (stack.size() < arity) {
-            return "node " + std::to_string(i) + ": arity " + std::to_string(arity)
-                + " requires that many completed child subtrees, but only " + std::to_string(stack.size()) + " are available";
+            return tl::make_unexpected(TreeValidationError::MissingChildren);
         }
 
         auto const firstChild = stack.size() - arity;
         auto const first      = stack[firstChild].First;
         if (firstChild > 0 && stack[firstChild - 1].Root + 1 != first) {
-            return "node " + std::to_string(i) + ": child subtrees do not form a contiguous postfix partition";
+            return tl::make_unexpected(TreeValidationError::ChildSubtreesNotContiguous);
         }
         if (stack.back().Root + 1 != i) {
-            return "node " + std::to_string(i) + ": child subtrees do not end immediately before their parent";
+            return tl::make_unexpected(TreeValidationError::ChildSubtreesNotAdjacent);
         }
 
         size_t depth{1};
@@ -122,10 +121,10 @@ auto Tree::Validate() const -> std::optional<std::string>
     }
 
     if (stack.size() != 1) {
-        return "tree has " + std::to_string(stack.size()) + " roots; postfix input must contain exactly one root";
+        return tl::make_unexpected(TreeValidationError::MultipleRoots);
     }
     if (stack.front().First != 0 || stack.front().Root != nodes_.size() - 1) {
-        return "root does not cover every node in the postfix sequence";
+        return tl::make_unexpected(TreeValidationError::RootDoesNotCoverTree);
     }
 
     std::vector<size_t> levels(nodes_.size());
@@ -140,26 +139,22 @@ auto Tree::Validate() const -> std::optional<std::string>
             || depths[i] > std::numeric_limits<uint16_t>::max()
             || parents[i] > std::numeric_limits<uint16_t>::max()
             || levels[i] > std::numeric_limits<uint16_t>::max()) {
-            return "node " + std::to_string(i) + ": derived metadata exceeds uint16_t storage";
+            return tl::make_unexpected(TreeValidationError::DerivedMetadataOverflow);
         }
         if (node.Length != lengths[i]) {
-            return "node " + std::to_string(i) + ": Length is " + std::to_string(node.Length)
-                + ", expected " + std::to_string(lengths[i]);
+            return tl::make_unexpected(TreeValidationError::LengthMismatch);
         }
         if (node.Depth != depths[i]) {
-            return "node " + std::to_string(i) + ": Depth is " + std::to_string(node.Depth)
-                + ", expected " + std::to_string(depths[i]);
+            return tl::make_unexpected(TreeValidationError::DepthMismatch);
         }
         if (node.Parent != parents[i]) {
-            return "node " + std::to_string(i) + ": Parent is " + std::to_string(node.Parent)
-                + ", expected " + std::to_string(parents[i]);
+            return tl::make_unexpected(TreeValidationError::ParentMismatch);
         }
         if (node.Level != levels[i]) {
-            return "node " + std::to_string(i) + ": Level is " + std::to_string(node.Level)
-                + ", expected " + std::to_string(levels[i]);
+            return tl::make_unexpected(TreeValidationError::LevelMismatch);
         }
     }
-    return std::nullopt;
+    return {};
 }
 
 auto Tree::Reduce() -> Tree&

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -71,6 +71,16 @@ auto Tree::Validate() const -> std::optional<std::string>
 
     for (size_t i = 0; i < nodes_.size(); ++i) {
         auto const& node = nodes_[i];
+        switch (node.Type) {
+        case NodeType::Constant:
+        case NodeType::Variable:
+        case NodeType::Ref:
+        case NodeType::Function:
+            break;
+        default:
+            return "node " + std::to_string(i) + ": invalid NodeType "
+                + std::to_string(static_cast<unsigned int>(node.Type));
+        }
         if (node.IsRef() && node.RefTo >= i) {
             return "node " + std::to_string(i) + ": RefTo must point to an earlier node";
         }

--- a/test/package-consumer/run-consumer-test.cmake
+++ b/test/package-consumer/run-consumer-test.cmake
@@ -75,6 +75,8 @@ foreach(var
     if(DEFINED ${var} AND NOT "${${var}}" STREQUAL "")
         if(var STREQUAL "OPERON_TOOLCHAIN_FILE")
             set(cmake_var CMAKE_TOOLCHAIN_FILE)
+        elseif(var STREQUAL "OPERON_MSVC_RUNTIME_LIBRARY")
+            set(cmake_var CMAKE_MSVC_RUNTIME_LIBRARY)
         else()
             string(REPLACE "OPERON_" "" cmake_var "${var}")
         endif()

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Crossover produces valid trees", "[operators]")
         auto child = cx(rng, p1, p2);
 
         CHECK(child.Length() > 0);
-        CHECK_FALSE(child.Validate().has_value());
+        CHECK(child.Validate());
     }
 
     SECTION("Child size is within bounds") {
@@ -61,7 +61,7 @@ TEST_CASE("Crossover produces valid trees", "[operators]")
             auto p2 = dist(rng);
             auto child = cx(rng, trees[p1], trees[p2]);
             CHECK(child.Length() <= maxLength);
-            CHECK_FALSE(child.Validate().has_value());
+            CHECK(child.Validate());
         }
     }
 }

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -41,6 +41,7 @@ TEST_CASE("Crossover produces valid trees", "[operators]")
         auto child = cx(rng, p1, p2);
 
         CHECK(child.Length() > 0);
+        CHECK_FALSE(child.Validate().has_value());
     }
 
     SECTION("Child size is within bounds") {
@@ -60,6 +61,7 @@ TEST_CASE("Crossover produces valid trees", "[operators]")
             auto p2 = dist(rng);
             auto child = cx(rng, trees[p1], trees[p2]);
             CHECK(child.Length() <= maxLength);
+            CHECK_FALSE(child.Validate().has_value());
         }
     }
 }

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -104,6 +104,15 @@ TEST_CASE("Tree validation reports postfix invariants", "[core][tree-validation]
         REQUIRE(error);
         CHECK(error->find("terminal") != std::string::npos);
     }
+    SECTION("node type must be known") {
+        auto node = Node::Constant(1);
+        node.Type = static_cast<NodeType>(255);
+        Tree tree({node});
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("NodeType") != std::string::npos);
+    }
+
 
     SECTION("Ref points backward") {
         Tree tree({Node::Ref(0)});
@@ -115,9 +124,27 @@ TEST_CASE("Tree validation reports postfix invariants", "[core][tree-validation]
     SECTION("derived metadata matches the postfix structure") {
         auto tree = valid();
         tree[2].Length = 0;
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("Length") != std::string::npos);
+        auto const lengthError = tree.Validate();
+        REQUIRE(lengthError);
+        CHECK(lengthError->find("Length") != std::string::npos);
+
+        tree = valid();
+        tree[2].Depth = 0;
+        auto const depthError = tree.Validate();
+        REQUIRE(depthError);
+        CHECK(depthError->find("Depth") != std::string::npos);
+
+        tree = valid();
+        tree[1].Parent = 0;
+        auto const parentError = tree.Validate();
+        REQUIRE(parentError);
+        CHECK(parentError->find("Parent") != std::string::npos);
+
+        tree = valid();
+        tree[1].Level = 0;
+        auto const levelError = tree.Validate();
+        REQUIRE(levelError);
+        CHECK(levelError->find("Level") != std::string::npos);
     }
 }
 

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -78,73 +78,73 @@ TEST_CASE("Tree validation reports postfix invariants", "[core][tree-validation]
     };
 
     SECTION("ordinary and empty trees are valid") {
-        CHECK_FALSE(Tree{}.Validate().has_value());
-        CHECK_FALSE(valid().Validate().has_value());
+        CHECK(Tree{}.Validate());
+        CHECK(valid().Validate());
     }
 
     SECTION("function arity cannot consume missing children") {
         Tree tree({Util::MakeOp<BuiltinOp::Add>()});
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("requires") != std::string::npos);
+        auto const result = tree.Validate();
+        REQUIRE_FALSE(result);
+        CHECK(result.error() == TreeValidationError::MissingChildren);
     }
 
     SECTION("postfix input has exactly one root") {
         Tree tree({Node::Constant(1), Node::Constant(2)});
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("roots") != std::string::npos);
+        auto const result = tree.Validate();
+        REQUIRE_FALSE(result);
+        CHECK(result.error() == TreeValidationError::MultipleRoots);
     }
 
     SECTION("terminals have zero arity") {
         auto leaf = Node::Constant(1);
         leaf.Arity = 1;
         Tree tree({leaf});
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("terminal") != std::string::npos);
+        auto const result = tree.Validate();
+        REQUIRE_FALSE(result);
+        CHECK(result.error() == TreeValidationError::TerminalArityNonZero);
     }
+
     SECTION("node type must be known") {
         auto node = Node::Constant(1);
         node.Type = static_cast<NodeType>(255);
         Tree tree({node});
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("NodeType") != std::string::npos);
+        auto const result = tree.Validate();
+        REQUIRE_FALSE(result);
+        CHECK(result.error() == TreeValidationError::InvalidNodeType);
     }
-
 
     SECTION("Ref points backward") {
         Tree tree({Node::Ref(0)});
-        auto const error = tree.Validate();
-        REQUIRE(error);
-        CHECK(error->find("RefTo") != std::string::npos);
+        auto const result = tree.Validate();
+        REQUIRE_FALSE(result);
+        CHECK(result.error() == TreeValidationError::RefNotBackward);
     }
 
     SECTION("derived metadata matches the postfix structure") {
         auto tree = valid();
         tree[2].Length = 0;
-        auto const lengthError = tree.Validate();
-        REQUIRE(lengthError);
-        CHECK(lengthError->find("Length") != std::string::npos);
+        auto const lengthResult = tree.Validate();
+        REQUIRE_FALSE(lengthResult);
+        CHECK(lengthResult.error() == TreeValidationError::LengthMismatch);
 
         tree = valid();
         tree[2].Depth = 0;
-        auto const depthError = tree.Validate();
-        REQUIRE(depthError);
-        CHECK(depthError->find("Depth") != std::string::npos);
+        auto const depthResult = tree.Validate();
+        REQUIRE_FALSE(depthResult);
+        CHECK(depthResult.error() == TreeValidationError::DepthMismatch);
 
         tree = valid();
         tree[1].Parent = 0;
-        auto const parentError = tree.Validate();
-        REQUIRE(parentError);
-        CHECK(parentError->find("Parent") != std::string::npos);
+        auto const parentResult = tree.Validate();
+        REQUIRE_FALSE(parentResult);
+        CHECK(parentResult.error() == TreeValidationError::ParentMismatch);
 
         tree = valid();
         tree[1].Level = 0;
-        auto const levelError = tree.Validate();
-        REQUIRE(levelError);
-        CHECK(levelError->find("Level") != std::string::npos);
+        auto const levelResult = tree.Validate();
+        REQUIRE_FALSE(levelResult);
+        CHECK(levelResult.error() == TreeValidationError::LevelMismatch);
     }
 }
 
@@ -158,7 +158,7 @@ TEST_CASE("Tree::UpdateNodes is idempotent under validation", "[core][tree-valid
     auto const once = tree.Nodes();
 
     tree.UpdateNodes();
-    REQUIRE_FALSE(tree.Validate().has_value());
+    REQUIRE(tree.Validate());
     REQUIRE(tree.Length() == once.size());
     for (size_t i = 0; i < tree.Length(); ++i) {
         CHECK(tree[i].Length == once[i].Length);
@@ -272,7 +272,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("constant folding: Add(2, 3) -> Const(5)") {
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(5.0));
@@ -281,7 +281,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("constant folding: Mul(2, 3) -> Const(6)") {
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(6.0));
@@ -291,7 +291,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         // [Const(2), Const(3), Mul, Const(4), Add]
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>(), Const(4), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(10.0));
@@ -300,7 +300,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("identity: x + 0 -> x") {
         Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
     }
@@ -481,7 +481,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         // Var+Const(5).
         Operon::Vector<Node> ns{ Var(), Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         REQUIRE(tree.Length() == 3);
         CHECK(tree[0].IsVariable());
         REQUIRE(tree[1].IsConstant());

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -67,6 +67,80 @@ TEST_CASE("Tree construction and access", "[core]")
     }
 }
 
+TEST_CASE("Tree validation reports postfix invariants", "[core][tree-validation]")
+{
+    auto const valid = []() {
+        Node x(NodeType::Variable);
+        x.HashValue = x.CalculatedHashValue = 1;
+        Node y(NodeType::Variable);
+        y.HashValue = y.CalculatedHashValue = 2;
+        return Tree({x, y, Util::MakeOp<BuiltinOp::Add>(), Node::Ref(2), Util::MakeOp<BuiltinOp::Mul>()}).UpdateNodes();
+    };
+
+    SECTION("ordinary and empty trees are valid") {
+        CHECK_FALSE(Tree{}.Validate().has_value());
+        CHECK_FALSE(valid().Validate().has_value());
+    }
+
+    SECTION("function arity cannot consume missing children") {
+        Tree tree({Util::MakeOp<BuiltinOp::Add>()});
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("requires") != std::string::npos);
+    }
+
+    SECTION("postfix input has exactly one root") {
+        Tree tree({Node::Constant(1), Node::Constant(2)});
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("roots") != std::string::npos);
+    }
+
+    SECTION("terminals have zero arity") {
+        auto leaf = Node::Constant(1);
+        leaf.Arity = 1;
+        Tree tree({leaf});
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("terminal") != std::string::npos);
+    }
+
+    SECTION("Ref points backward") {
+        Tree tree({Node::Ref(0)});
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("RefTo") != std::string::npos);
+    }
+
+    SECTION("derived metadata matches the postfix structure") {
+        auto tree = valid();
+        tree[2].Length = 0;
+        auto const error = tree.Validate();
+        REQUIRE(error);
+        CHECK(error->find("Length") != std::string::npos);
+    }
+}
+
+TEST_CASE("Tree::UpdateNodes is idempotent under validation", "[core][tree-validation]")
+{
+    Node x(NodeType::Variable);
+    x.HashValue = x.CalculatedHashValue = 1;
+    Node y(NodeType::Variable);
+    y.HashValue = y.CalculatedHashValue = 2;
+    auto tree = Tree({x, y, Util::MakeOp<BuiltinOp::Add>(), Node::Ref(2), Util::MakeOp<BuiltinOp::Mul>()}).UpdateNodes();
+    auto const once = tree.Nodes();
+
+    tree.UpdateNodes();
+    REQUIRE_FALSE(tree.Validate().has_value());
+    REQUIRE(tree.Length() == once.size());
+    for (size_t i = 0; i < tree.Length(); ++i) {
+        CHECK(tree[i].Length == once[i].Length);
+        CHECK(tree[i].Depth == once[i].Depth);
+        CHECK(tree[i].Parent == once[i].Parent);
+        CHECK(tree[i].Level == once[i].Level);
+    }
+}
+
 TEST_CASE("Tree coefficients", "[core]")
 {
     Node c1(NodeType::Constant); c1.Value = 3.14F; c1.Optimize = true;
@@ -171,6 +245,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("constant folding: Add(2, 3) -> Const(5)") {
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        CHECK_FALSE(tree.Validate().has_value());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(5.0));
@@ -179,6 +254,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("constant folding: Mul(2, 3) -> Const(6)") {
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        CHECK_FALSE(tree.Validate().has_value());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(6.0));
@@ -188,6 +264,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         // [Const(2), Const(3), Mul, Const(4), Add]
         Operon::Vector<Node> ns{ Const(2), Const(3), Util::MakeOp<BuiltinOp::Mul>(), Const(4), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        CHECK_FALSE(tree.Validate().has_value());
         REQUIRE(tree.Length() == 1);
         REQUIRE(tree[0].IsConstant());
         CHECK(tree[0].Value == Catch::Approx(10.0));
@@ -196,6 +273,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
     SECTION("identity: x + 0 -> x") {
         Operon::Vector<Node> ns{ Const(0), Var(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        CHECK_FALSE(tree.Validate().has_value());
         REQUIRE(tree.Length() == 1);
         CHECK(tree[0].IsVariable());
     }
@@ -376,6 +454,7 @@ TEST_CASE("Tree::Simplify", "[core][simplify]")
         // Var+Const(5).
         Operon::Vector<Node> ns{ Var(), Const(2), Const(3), Util::MakeOp<BuiltinOp::Add>(), Util::MakeOp<BuiltinOp::Add>() };
         auto tree = Tree(std::move(ns)).UpdateNodes().Simplify();
+        CHECK_FALSE(tree.Validate().has_value());
         REQUIRE(tree.Length() == 3);
         CHECK(tree[0].IsVariable());
         REQUIRE(tree[1].IsConstant());

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -39,7 +39,9 @@ TEST_CASE("Parser roundtrip correctness", "[parser]")
     Operon::Vector<Operon::Tree> parsedTrees;
     parsedTrees.reserve(nTrees);
     std::transform(trees.begin(), trees.end(), std::back_inserter(parsedTrees), [&](const auto& tree) -> auto {
-        return InfixParser::Parse(fmt::format("{:infix:50}", Operon::Fmt::WithNames{tree, ds}), ds);
+        auto parsed = InfixParser::Parse(fmt::format("{:infix:50}", Operon::Fmt::WithNames{tree, ds}), ds);
+        CHECK_FALSE(parsed.Validate().has_value());
+        return parsed;
     });
 
     Range range{0, 1};
@@ -86,6 +88,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         const auto* str = "sin((sqrt(abs(square(sin(((-0.00191) * X6))))) - sqrt(abs(((-0.96224) / (-0.40567))))))";
         auto tree = Operon::InfixParser::Parse(str);
         CHECK(tree.Length() > 0);
+        CHECK_FALSE(tree.Validate().has_value());
     }
 
     SECTION("Arithmetic with constants") {
@@ -110,6 +113,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         std::string const expr{"aq(3, 5)"};
         auto tree = InfixParser::Parse(expr);
         CHECK(tree.Length() > 0);
+        CHECK_FALSE(tree.Validate().has_value());
     }
 
     SECTION("Multiple additions") {
@@ -122,6 +126,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         std::vector<Operon::Scalar> const v{0};
         Operon::Dataset const ds({x}, {v});
         auto result = Interpreter<Operon::Scalar, DTable>::Evaluate(tree, ds, Range(0, 1));
+        CHECK_FALSE(tree.Validate().has_value());
         CHECK(result[0] == Catch::Approx(10.0F));
     }
 }

--- a/test/source/implementation/infix_parser.cpp
+++ b/test/source/implementation/infix_parser.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Parser roundtrip correctness", "[parser]")
     parsedTrees.reserve(nTrees);
     std::transform(trees.begin(), trees.end(), std::back_inserter(parsedTrees), [&](const auto& tree) -> auto {
         auto parsed = InfixParser::Parse(fmt::format("{:infix:50}", Operon::Fmt::WithNames{tree, ds}), ds);
-        CHECK_FALSE(parsed.Validate().has_value());
+        CHECK(parsed.Validate());
         return parsed;
     });
 
@@ -88,7 +88,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         const auto* str = "sin((sqrt(abs(square(sin(((-0.00191) * X6))))) - sqrt(abs(((-0.96224) / (-0.40567))))))";
         auto tree = Operon::InfixParser::Parse(str);
         CHECK(tree.Length() > 0);
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
     }
 
     SECTION("Arithmetic with constants") {
@@ -113,7 +113,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         std::string const expr{"aq(3, 5)"};
         auto tree = InfixParser::Parse(expr);
         CHECK(tree.Length() > 0);
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
     }
 
     SECTION("Multiple additions") {
@@ -126,7 +126,7 @@ TEST_CASE("Parse specific expressions", "[parser]")
         std::vector<Operon::Scalar> const v{0};
         Operon::Dataset const ds({x}, {v});
         auto result = Interpreter<Operon::Scalar, DTable>::Evaluate(tree, ds, Range(0, 1));
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
         CHECK(result[0] == Catch::Approx(10.0F));
     }
 }

--- a/test/source/implementation/initialization.cpp
+++ b/test/source/implementation/initialization.cpp
@@ -117,6 +117,7 @@ TEST_CASE("GROW creator", "[operators]") // NOLINT(readability-function-cognitiv
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
             CHECK(tree.Length() <= maxLength + 10); // allow some slack for tree construction
+            CHECK_FALSE(tree.Validate().has_value());
         }
     }
 
@@ -156,6 +157,7 @@ TEST_CASE("BTC creator", "[operators]")
         auto trees = GenerateTrees(random, btc, lengths, maxDepth);
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
+            CHECK_FALSE(tree.Validate().has_value());
         }
     }
 
@@ -197,6 +199,7 @@ TEST_CASE("PTC2 creator", "[operators]")
         auto trees = GenerateTrees(random, ptc, lengths, maxDepth);
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
+            CHECK_FALSE(tree.Validate().has_value());
         }
     }
 }
@@ -222,6 +225,7 @@ TEST_CASE("PTC2 creator respects maxDepth", "[operators]")
                 auto const tree = ptc(random, targetLen, 1, maxDepth);
                 CHECK(tree.Length() <= targetLen);
                 CHECK(tree.Depth() <= maxDepth);
+                CHECK_FALSE(tree.Validate().has_value());
             }
         }
     }

--- a/test/source/implementation/initialization.cpp
+++ b/test/source/implementation/initialization.cpp
@@ -117,7 +117,7 @@ TEST_CASE("GROW creator", "[operators]") // NOLINT(readability-function-cognitiv
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
             CHECK(tree.Length() <= maxLength + 10); // allow some slack for tree construction
-            CHECK_FALSE(tree.Validate().has_value());
+            CHECK(tree.Validate());
         }
     }
 
@@ -157,7 +157,7 @@ TEST_CASE("BTC creator", "[operators]")
         auto trees = GenerateTrees(random, btc, lengths, maxDepth);
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
-            CHECK_FALSE(tree.Validate().has_value());
+            CHECK(tree.Validate());
         }
     }
 
@@ -199,7 +199,7 @@ TEST_CASE("PTC2 creator", "[operators]")
         auto trees = GenerateTrees(random, ptc, lengths, maxDepth);
         for (auto const& tree : trees) {
             CHECK(tree.Length() > 0);
-            CHECK_FALSE(tree.Validate().has_value());
+            CHECK(tree.Validate());
         }
     }
 }
@@ -225,7 +225,7 @@ TEST_CASE("PTC2 creator respects maxDepth", "[operators]")
                 auto const tree = ptc(random, targetLen, 1, maxDepth);
                 CHECK(tree.Length() <= targetLen);
                 CHECK(tree.Depth() <= maxDepth);
-                CHECK_FALSE(tree.Validate().has_value());
+                CHECK(tree.Validate());
             }
         }
     }

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -44,6 +44,7 @@ TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
 
     CHECK(child.Length() > 0);
     CHECK(child.Length() <= 2 * targetLen);
+    CHECK_FALSE(child.Validate().has_value());
 }
 
 TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-minimal terminal", "[operators]")
@@ -78,6 +79,7 @@ TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-mini
         auto child = mut(random, tree);
         CHECK(child.Length() > 0);
         CHECK(child.Length() <= originalLength);
+        CHECK_FALSE(child.Validate().has_value());
     }
 }
 
@@ -130,6 +132,7 @@ TEST_CASE("Mutation tree stays within bounds", "[operators]")
         auto child = mut(random, tree);
         CHECK(child.Length() > 0);
         CHECK(child.Length() <= static_cast<size_t>(maxLength));
+        CHECK_FALSE(child.Validate().has_value());
     }
 }
 
@@ -161,6 +164,7 @@ TEST_CASE("ReplaceSubtreeMutation via PTC2 respects maxDepth", "[operators]")
     for (int i = 0; i < 5000; ++i) {
         tree = mut(random, std::move(tree));
         CHECK(tree.Depth() <= maxDepth);
+        CHECK_FALSE(tree.Validate().has_value());
     }
 }
 

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -44,7 +44,7 @@ TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
 
     CHECK(child.Length() > 0);
     CHECK(child.Length() <= 2 * targetLen);
-    CHECK_FALSE(child.Validate().has_value());
+    CHECK(child.Validate());
 }
 
 TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-minimal terminal", "[operators]")
@@ -79,7 +79,7 @@ TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-mini
         auto child = mut(random, tree);
         CHECK(child.Length() > 0);
         CHECK(child.Length() <= originalLength);
-        CHECK_FALSE(child.Validate().has_value());
+        CHECK(child.Validate());
     }
 }
 
@@ -132,7 +132,7 @@ TEST_CASE("Mutation tree stays within bounds", "[operators]")
         auto child = mut(random, tree);
         CHECK(child.Length() > 0);
         CHECK(child.Length() <= static_cast<size_t>(maxLength));
-        CHECK_FALSE(child.Validate().has_value());
+        CHECK(child.Validate());
     }
 }
 
@@ -164,7 +164,7 @@ TEST_CASE("ReplaceSubtreeMutation via PTC2 respects maxDepth", "[operators]")
     for (int i = 0; i < 5000; ++i) {
         tree = mut(random, std::move(tree));
         CHECK(tree.Depth() <= maxDepth);
-        CHECK_FALSE(tree.Validate().has_value());
+        CHECK(tree.Validate());
     }
 }
 

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Tree JSON round-trip", "[serialization]")
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::TreeFromJson(json);
         REQUIRE(restored);
-        CHECK_FALSE(restored->Validate().has_value());
+        CHECK(restored->Validate());
         CHECK(TreesEqual(original, *restored));
     }
 }
@@ -102,7 +102,7 @@ TEST_CASE("Individual JSON round-trip", "[serialization]")
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::IndividualFromJson(json);
         REQUIRE(restored);
-        CHECK_FALSE(restored->Genotype.Validate().has_value());
+        CHECK(restored->Genotype.Validate());
         CHECK(IndividualsEqual(original, *restored));
     }
 }
@@ -133,7 +133,7 @@ TEST_CASE("Tree BEVE round-trip", "[serialization]")
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::TreeFromBeve(beve);
         REQUIRE(restored);
-        CHECK_FALSE(restored->Validate().has_value());
+        CHECK(restored->Validate());
         CHECK(TreesEqual(original, *restored));
     }
 }
@@ -146,7 +146,7 @@ TEST_CASE("Individual BEVE round-trip", "[serialization]")
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::IndividualFromBeve(beve);
         REQUIRE(restored);
-        CHECK_FALSE(restored->Genotype.Validate().has_value());
+        CHECK(restored->Genotype.Validate());
         CHECK(IndividualsEqual(original, *restored));
     }
 }

--- a/test/source/implementation/serialization.cpp
+++ b/test/source/implementation/serialization.cpp
@@ -89,6 +89,7 @@ TEST_CASE("Tree JSON round-trip", "[serialization]")
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::TreeFromJson(json);
         REQUIRE(restored);
+        CHECK_FALSE(restored->Validate().has_value());
         CHECK(TreesEqual(original, *restored));
     }
 }
@@ -101,6 +102,7 @@ TEST_CASE("Individual JSON round-trip", "[serialization]")
         auto json     = Operon::Serialization::ToJson(original);
         auto restored = Operon::Serialization::IndividualFromJson(json);
         REQUIRE(restored);
+        CHECK_FALSE(restored->Genotype.Validate().has_value());
         CHECK(IndividualsEqual(original, *restored));
     }
 }
@@ -131,6 +133,7 @@ TEST_CASE("Tree BEVE round-trip", "[serialization]")
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::TreeFromBeve(beve);
         REQUIRE(restored);
+        CHECK_FALSE(restored->Validate().has_value());
         CHECK(TreesEqual(original, *restored));
     }
 }
@@ -143,6 +146,7 @@ TEST_CASE("Individual BEVE round-trip", "[serialization]")
         auto beve     = Operon::Serialization::ToBeve(original);
         auto restored = Operon::Serialization::IndividualFromBeve(beve);
         REQUIRE(restored);
+        CHECK_FALSE(restored->Genotype.Validate().has_value());
         CHECK(IndividualsEqual(original, *restored));
     }
 }


### PR DESCRIPTION
## Summary
- Add opt-in Tree::Validate() with safe postfix diagnostics for structure, backward references, and derived metadata.
- Keep validation outside evaluation and search paths.
- Cover malformed inputs, UpdateNodes idempotence, and representative creator, mutation, crossover, parser, simplifier, and deserialization paths.

## Verification
- nix develop -c cmake --build build-package-components --target operon_test -j2
- nix develop -c ./build-package-components/test/operon_test "[tree-validation],[operators],[parser],[simplify],[serialization]" (153108 assertions in 42 test cases)