### PR TITLE
refactor: centralize subtree rewrites

### DIFF
--- a/include/operon/core/tree.hpp
+++ b/include/operon/core/tree.hpp
@@ -60,12 +60,7 @@ public:
     [[nodiscard]] auto Hash(Operon::HashMode mode) const -> Tree const&;
 
     // splice a subtree rooted at node with index i as a new tree
-    [[nodiscard]] auto Splice(size_t i) const -> Tree {
-        EXPECT(i < Length());
-        auto const& n = nodes_[i];
-        auto it = nodes_.begin() + static_cast<int64_t>(i);
-        return Tree({it - n.Length, it + 1}).UpdateNodes();
-    }
+    [[nodiscard]] auto Splice(size_t i) const -> Tree;
 
     void SetEnabled(size_t i, bool enabled)
     {

--- a/include/operon/operators/crossover.hpp
+++ b/include/operon/operators/crossover.hpp
@@ -21,7 +21,7 @@
 
 namespace Operon {
 // crossover takes two parent trees and returns a child
-struct CrossoverBase : public OperatorBase<Tree, const Tree&, const Tree&> {
+struct OPERON_EXPORT CrossoverBase : public OperatorBase<Tree, const Tree&, const Tree&> {
     using Limits = std::pair<std::size_t, std::size_t>;
     static auto FindCompatibleSwapLocations(Operon::RandomGenerator& random, Tree const& lhs, Tree const& rhs, size_t maxDepth, size_t maxLength, double internalProbability = 1.0) -> std::pair<size_t, size_t>;
     static auto SelectRandomBranch(Operon::RandomGenerator& random, Tree const& tree, double internalProb, Limits length, Limits level, Limits depth) -> size_t;

--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -1,25 +1,57 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+
 #ifndef OPERON_DETAIL_SUBTREE_REWRITE_HPP
 #define OPERON_DETAIL_SUBTREE_REWRITE_HPP
+
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
-#include <ranges>
+#include <stdexcept>
+
 #include "operon/core/contracts.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/types.hpp"
+
 namespace Operon::detail {
-struct SubtreeSpan { std::size_t First; std::size_t Root; std::size_t Size; };
-[[nodiscard]] inline auto DescribeSubtree(Operon::Span<Node const> nodes, std::size_t root) -> SubtreeSpan {
+
+struct SubtreeSpan {
+    std::size_t First;
+    std::size_t Root;
+    std::size_t Size;
+};
+
+[[nodiscard]] inline auto DescribeSubtree(Operon::Span<Node const> nodes, std::size_t root) -> SubtreeSpan
+{
     EXPECT(root < nodes.size());
     auto const size = static_cast<std::size_t>(nodes[root].Length) + 1U;
     EXPECT(size <= root + 1U);
-    return {root + 1U - size, root, size};
+    return { root + 1U - size, root, size };
 }
-[[nodiscard]] inline auto RewriteSubtree(Operon::Span<Node const> source, SubtreeSpan target, Operon::Span<Node const> replacement) -> Operon::Vector<Node> {
-    EXPECT(target.Root < source.size()); EXPECT(target.Size > 0U);
-    EXPECT(target.First + target.Size == target.Root + 1U); EXPECT(target.First + target.Size <= source.size());
+
+[[nodiscard]] inline auto IsSelfContainedSubtree(Operon::Span<Node const> nodes, SubtreeSpan span) -> bool
+{
+    return std::ranges::all_of(nodes.subspan(span.First, span.Size), [first = span.First, root = span.Root](Node const& node) {
+        return !node.IsRef() || (node.RefTo >= first && node.RefTo <= root);
+    });
+}
+
+// P4 deliberately accepts only standalone donor trees. A donor reference
+// outside the donor's own contiguous subtree needs a DAG mapping policy, which
+// P5 owns. Existing references to a replaced source subtree remain valid by
+// becoming references to the replacement root.
+[[nodiscard]] inline auto CanRewriteSubtree(Operon::Span<Node const> replacement) -> bool
+{
+    return !replacement.empty() && IsSelfContainedSubtree(replacement, { 0U, replacement.size() - 1U, replacement.size() });
+}
+
+[[nodiscard]] inline auto RewriteSubtree(Operon::Span<Node const> source, SubtreeSpan target,
+    Operon::Span<Node const> replacement) -> Operon::Vector<Node>
+{
+    if (!CanRewriteSubtree(replacement)) {
+        throw std::invalid_argument("replacement subtree has external Ref targets; P5 mapping policy is required");
+    }
+
     Operon::Vector<Node> rewritten;
     rewritten.reserve(source.size() - target.Size + replacement.size());
     auto const first = source.begin() + static_cast<std::ptrdiff_t>(target.First);
@@ -27,21 +59,43 @@ struct SubtreeSpan { std::size_t First; std::size_t Root; std::size_t Size; };
     std::copy(source.begin(), first, std::back_inserter(rewritten));
     std::copy(replacement.begin(), replacement.end(), std::back_inserter(rewritten));
     std::copy(after, source.end(), std::back_inserter(rewritten));
-    if (std::ranges::any_of(source, [](auto const& node) { return node.IsRef(); })) {
-        auto const delta = static_cast<std::ptrdiff_t>(replacement.size()) - static_cast<std::ptrdiff_t>(target.Size);
-        for (std::size_t old = 0; old < source.size(); ++old) {
-            if (old >= target.First && old <= target.Root) continue;
-            auto const next = old < target.First ? old : static_cast<std::size_t>(static_cast<std::ptrdiff_t>(old) + delta);
-            auto& node = rewritten[next];
-            if (!node.IsRef()) continue;
-            EXPECT(node.RefTo < target.First || node.RefTo > target.Root);
-            if (node.RefTo > target.Root) node.RefTo = static_cast<uint16_t>(static_cast<std::ptrdiff_t>(node.RefTo) + delta);
+
+    auto const replacementRoot = target.First + replacement.size() - 1U;
+    auto const delta = static_cast<std::ptrdiff_t>(replacement.size()) - static_cast<std::ptrdiff_t>(target.Size);
+    for (std::size_t i = target.First; i < target.First + replacement.size(); ++i) {
+        if (rewritten[i].IsRef()) {
+            rewritten[i].RefTo = static_cast<uint16_t>(rewritten[i].RefTo + target.First);
+        }
+    }
+    for (std::size_t old = target.Root + 1U; old < source.size(); ++old) {
+        auto& node = rewritten[static_cast<std::size_t>(static_cast<std::ptrdiff_t>(old) + delta)];
+        if (!node.IsRef()) {
+            continue;
+        }
+        if (node.RefTo >= target.First && node.RefTo <= target.Root) {
+            node.RefTo = static_cast<uint16_t>(replacementRoot);
+        } else if (node.RefTo > target.Root) {
+            node.RefTo = static_cast<uint16_t>(static_cast<std::ptrdiff_t>(node.RefTo) + delta);
         }
     }
     return rewritten;
 }
-[[nodiscard]] inline auto CopySubtree(Operon::Span<Node const> source, SubtreeSpan target) -> Operon::Vector<Node> {
-    return RewriteSubtree(source, {0U, source.size() - 1U, source.size()}, source.subspan(target.First, target.Size));
+
+[[nodiscard]] inline auto CopySubtree(Operon::Span<Node const> source, SubtreeSpan target) -> Operon::Vector<Node>
+{
+    if (!IsSelfContainedSubtree(source, target)) {
+        throw std::invalid_argument("cannot splice a subtree with external Ref targets; P5 mapping policy is required");
+    }
+    Operon::Vector<Node> copy(source.begin() + static_cast<std::ptrdiff_t>(target.First),
+        source.begin() + static_cast<std::ptrdiff_t>(target.Root) + 1);
+    for (auto& node : copy) {
+        if (node.IsRef()) {
+            node.RefTo = static_cast<uint16_t>(node.RefTo - target.First);
+        }
+    }
+    return copy;
 }
-}
+
+} // namespace Operon::detail
+
 #endif

--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
+#ifndef OPERON_DETAIL_SUBTREE_REWRITE_HPP
+#define OPERON_DETAIL_SUBTREE_REWRITE_HPP
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <ranges>
+#include "operon/core/contracts.hpp"
+#include "operon/core/node.hpp"
+#include "operon/core/types.hpp"
+namespace Operon::detail {
+struct SubtreeSpan { std::size_t First; std::size_t Root; std::size_t Size; };
+[[nodiscard]] inline auto DescribeSubtree(Operon::Span<Node const> nodes, std::size_t root) -> SubtreeSpan {
+    EXPECT(root < nodes.size());
+    auto const size = static_cast<std::size_t>(nodes[root].Length) + 1U;
+    EXPECT(size <= root + 1U);
+    return {root + 1U - size, root, size};
+}
+[[nodiscard]] inline auto RewriteSubtree(Operon::Span<Node const> source, SubtreeSpan target, Operon::Span<Node const> replacement) -> Operon::Vector<Node> {
+    EXPECT(target.Root < source.size()); EXPECT(target.Size > 0U);
+    EXPECT(target.First + target.Size == target.Root + 1U); EXPECT(target.First + target.Size <= source.size());
+    Operon::Vector<Node> rewritten;
+    rewritten.reserve(source.size() - target.Size + replacement.size());
+    auto const first = source.begin() + static_cast<std::ptrdiff_t>(target.First);
+    auto const after = first + static_cast<std::ptrdiff_t>(target.Size);
+    std::copy(source.begin(), first, std::back_inserter(rewritten));
+    std::copy(replacement.begin(), replacement.end(), std::back_inserter(rewritten));
+    std::copy(after, source.end(), std::back_inserter(rewritten));
+    if (std::ranges::any_of(source, [](auto const& node) { return node.IsRef(); })) {
+        auto const delta = static_cast<std::ptrdiff_t>(replacement.size()) - static_cast<std::ptrdiff_t>(target.Size);
+        for (std::size_t old = 0; old < source.size(); ++old) {
+            if (old >= target.First && old <= target.Root) continue;
+            auto const next = old < target.First ? old : static_cast<std::size_t>(static_cast<std::ptrdiff_t>(old) + delta);
+            auto& node = rewritten[next];
+            if (!node.IsRef()) continue;
+            EXPECT(node.RefTo < target.First || node.RefTo > target.Root);
+            if (node.RefTo > target.Root) node.RefTo = static_cast<uint16_t>(static_cast<std::ptrdiff_t>(node.RefTo) + delta);
+        }
+    }
+    return rewritten;
+}
+[[nodiscard]] inline auto CopySubtree(Operon::Span<Node const> source, SubtreeSpan target) -> Operon::Vector<Node> {
+    return RewriteSubtree(source, {0U, source.size() - 1U, source.size()}, source.subspan(target.First, target.Size));
+}
+}
+#endif

--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -36,10 +36,9 @@ struct SubtreeSpan {
     });
 }
 
-// P4 deliberately accepts only standalone donor trees. A donor reference
-// outside the donor's own contiguous subtree needs a DAG mapping policy, which
-// P5 owns. Existing references to a replaced source subtree remain valid by
-// becoming references to the replacement root.
+// P4 accepts only standalone donor trees: an external donor Ref has no
+// destination-tree mapping until P5. Source references inside target are
+// deleted with target; retained source references are mapped during rewrite.
 [[nodiscard]] inline auto CanRewriteSubtree(Operon::Span<Node const> replacement) -> bool
 {
     return !replacement.empty() && IsSelfContainedSubtree(replacement, { 0U, replacement.size() - 1U, replacement.size() });

--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -36,9 +36,7 @@ struct SubtreeSpan {
     });
 }
 
-// P4 accepts only standalone donor trees: an external donor Ref has no
-// destination-tree mapping until P5. Source references inside target are
-// deleted with target; retained source references are mapped during rewrite.
+// Replacement and copied subtrees must not reference nodes outside their span.
 [[nodiscard]] inline auto CanRewriteSubtree(Operon::Span<Node const> replacement) -> bool
 {
     return !replacement.empty() && IsSelfContainedSubtree(replacement, { 0U, replacement.size() - 1U, replacement.size() });
@@ -48,7 +46,7 @@ struct SubtreeSpan {
     Operon::Span<Node const> replacement) -> Operon::Vector<Node>
 {
     if (!CanRewriteSubtree(replacement)) {
-        throw std::invalid_argument("replacement subtree has external Ref targets; P5 mapping policy is required");
+        throw std::invalid_argument("replacement subtree has external Ref targets");
     }
 
     Operon::Vector<Node> rewritten;
@@ -83,7 +81,7 @@ struct SubtreeSpan {
 [[nodiscard]] inline auto CopySubtree(Operon::Span<Node const> source, SubtreeSpan target) -> Operon::Vector<Node>
 {
     if (!IsSelfContainedSubtree(source, target)) {
-        throw std::invalid_argument("cannot splice a subtree with external Ref targets; P5 mapping policy is required");
+        throw std::invalid_argument("cannot splice a subtree with external Ref targets");
     }
     Operon::Vector<Node> copy(source.begin() + static_cast<std::ptrdiff_t>(target.First),
         source.begin() + static_cast<std::ptrdiff_t>(target.Root) + 1);

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -18,8 +18,14 @@
 #include "operon/core/constants.hpp"
 #include "operon/core/node.hpp"
 #include "operon/core/types.hpp"
+#include "subtree_rewrite.hpp"
 
 namespace Operon {
+auto Tree::Splice(size_t i) const -> Tree
+{
+    auto const span = detail::DescribeSubtree(Operon::Span<Node const>{nodes_}, i);
+    return Tree(detail::CopySubtree(Operon::Span<Node const>{nodes_}, span)).UpdateNodes();
+}
 auto Tree::UpdateNodes() -> Tree&
 {
     if (nodes_.empty()) { return *this; }

--- a/source/operators/crossover.cpp
+++ b/source/operators/crossover.cpp
@@ -84,8 +84,18 @@ auto CrossoverBase::Cross(const Tree& lhs, const Tree& rhs, /* index of subtree 
     if (!detail::IsSelfContainedSubtree(Operon::Span<Node const>{right}, rightSpan)) {
         return lhs;
     }
-    auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan,
-        Operon::Span<Node const>{right}.subspan(rightSpan.First, rightSpan.Size));
+    auto donor = Operon::Span<Node const>{right}.subspan(rightSpan.First, rightSpan.Size);
+    if (std::ranges::any_of(donor, [](Node const& node) { return node.IsRef(); })) {
+        auto normalized = Operon::Vector<Node>(donor.begin(), donor.end());
+        for (auto& node : normalized) {
+            if (node.IsRef()) {
+                node.RefTo = static_cast<uint16_t>(node.RefTo - rightSpan.First);
+            }
+        }
+        auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan, normalized);
+        return Tree(std::move(nodes)).UpdateNodes();
+    }
+    auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan, donor);
     return Tree(std::move(nodes)).UpdateNodes();
 }
 

--- a/source/operators/crossover.cpp
+++ b/source/operators/crossover.cpp
@@ -6,6 +6,7 @@
 
 #include "operon/core/contracts.hpp"
 #include "operon/operators/crossover.hpp"
+#include "../core/subtree_rewrite.hpp"
 #include "operon/random/random.hpp"
 
 namespace Operon {
@@ -76,17 +77,13 @@ auto CrossoverBase::SelectRandomBranch(Operon::RandomGenerator& random, Tree con
 
 auto CrossoverBase::Cross(const Tree& lhs, const Tree& rhs, /* index of subtree 1 */ size_t i, /* index of subtree 2 */ size_t j) -> Tree
 {
-    auto const& left = lhs.Nodes();
-    auto const& right = rhs.Nodes();
-    Operon::Vector<Node> nodes;
-    using Signed = std::make_signed_t<size_t>;
-    nodes.reserve(right[j].Length - left[i].Length + left.size());
-    std::copy_n(left.begin(), i - left[i].Length, back_inserter(nodes));
-    std::copy_n(right.begin() + static_cast<Signed>(j) - right[j].Length, right[j].Length + 1, back_inserter(nodes));
-    std::copy_n(left.begin() + static_cast<Signed>(i) + 1, left.size() - (i + 1), back_inserter(nodes));
-
-    auto child = Tree(nodes).UpdateNodes();
-    return child;
+    auto const left = lhs.Nodes();
+    auto const right = rhs.Nodes();
+    auto const leftSpan = detail::DescribeSubtree(Operon::Span<Node const>{left}, i);
+    auto const rightSpan = detail::DescribeSubtree(Operon::Span<Node const>{right}, j);
+    auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan,
+        Operon::Span<Node const>{right}.subspan(rightSpan.First, rightSpan.Size));
+    return Tree(std::move(nodes)).UpdateNodes();
 }
 
 auto SubtreeCrossover::operator()(Operon::RandomGenerator& random, const Tree& lhs, const Tree& rhs) const -> Tree

--- a/source/operators/crossover.cpp
+++ b/source/operators/crossover.cpp
@@ -81,6 +81,9 @@ auto CrossoverBase::Cross(const Tree& lhs, const Tree& rhs, /* index of subtree 
     auto const& right = rhs.Nodes();
     auto const leftSpan = detail::DescribeSubtree(Operon::Span<Node const>{left}, i);
     auto const rightSpan = detail::DescribeSubtree(Operon::Span<Node const>{right}, j);
+    if (!detail::IsSelfContainedSubtree(Operon::Span<Node const>{right}, rightSpan)) {
+        return lhs;
+    }
     auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan,
         Operon::Span<Node const>{right}.subspan(rightSpan.First, rightSpan.Size));
     return Tree(std::move(nodes)).UpdateNodes();

--- a/source/operators/crossover.cpp
+++ b/source/operators/crossover.cpp
@@ -77,8 +77,8 @@ auto CrossoverBase::SelectRandomBranch(Operon::RandomGenerator& random, Tree con
 
 auto CrossoverBase::Cross(const Tree& lhs, const Tree& rhs, /* index of subtree 1 */ size_t i, /* index of subtree 2 */ size_t j) -> Tree
 {
-    auto const left = lhs.Nodes();
-    auto const right = rhs.Nodes();
+    auto const& left = lhs.Nodes();
+    auto const& right = rhs.Nodes();
     auto const leftSpan = detail::DescribeSubtree(Operon::Span<Node const>{left}, i);
     auto const rightSpan = detail::DescribeSubtree(Operon::Span<Node const>{right}, j);
     auto nodes = detail::RewriteSubtree(Operon::Span<Node const>{left}, leftSpan,

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -85,7 +85,7 @@ auto ChangeFunctionMutation::operator()(Operon::RandomGenerator& random, Tree tr
 
 auto ReplaceSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto const nodes = tree.Nodes();
+    auto const& nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
     auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
     auto const oldLen = target.Size;
@@ -179,7 +179,7 @@ auto InsertSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
 
 auto RemoveSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto const nodes = tree.Nodes();
+    auto const& nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
     auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
     auto const oldLevel = nodes[i].Level;

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "operon/operators/creator.hpp"
+#include "../core/subtree_rewrite.hpp"
 #include "operon/operators/initializer.hpp"
 
 namespace Operon {
@@ -84,35 +85,24 @@ auto ChangeFunctionMutation::operator()(Operon::RandomGenerator& random, Tree tr
 
 auto ReplaceSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto& nodes = tree.Nodes();
-
+    auto const nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
-
-    auto oldLen = nodes[i].Length + 1U;
-    auto oldLevel = nodes[i].Level;
+    auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
+    auto const oldLen = target.Size;
+    auto const oldLevel = nodes[i].Level;
 
     using Signed = std::make_signed_t<size_t>;
-
-    auto partialLength = nodes.size() - oldLen;
-
+    auto const partialLength = nodes.size() - oldLen;
     auto maxLength = static_cast<Signed>(maxLength_ - partialLength);
     maxLength = std::max(maxLength, Signed { 1 });
-
     auto maxDepth = std::max(tree.Depth(), maxDepth_) - oldLevel + 1;
 
-    auto newLen = std::uniform_int_distribution<Signed>(Signed { 1 }, maxLength)(random);
+    auto const newLen = std::uniform_int_distribution<Signed>(Signed { 1 }, maxLength)(random);
     auto subtree = (*creator_)(random, static_cast<size_t>(newLen), 1, maxDepth);
     (*coefficientInitializer_)(random, subtree);
-
-    Operon::Vector<Node> mutated;
-    mutated.reserve(nodes.size() - oldLen + static_cast<size_t>(newLen));
-
-    using Signed = std::make_signed_t<size_t>;
-    std::copy(nodes.begin(), nodes.begin() + static_cast<Signed>(i - nodes[i].Length), std::back_inserter(mutated));
-    std::copy(subtree.Nodes().begin(), subtree.Nodes().end(), std::back_inserter(mutated));
-    std::copy(nodes.begin() + static_cast<Signed>(i + 1), nodes.end(), std::back_inserter(mutated));
-
-    return Tree(mutated).UpdateNodes();
+    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const>{nodes}, target,
+        Operon::Span<Node const>{subtree.Nodes()});
+    return Tree(std::move(rewritten)).UpdateNodes();
 }
 
 auto RemoveChildMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
@@ -189,33 +179,19 @@ auto InsertSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
 
 auto RemoveSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto& nodes = tree.Nodes();
-
+    auto const nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
+    auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
+    auto const oldLevel = nodes[i].Level;
+    auto const maxDepth = std::max(tree.Depth(), maxDepth_) - oldLevel + 1;
 
-    auto oldLen = nodes[i].Length + 1U;
-    auto oldLevel = nodes[i].Level;
-
-    using Signed = std::make_signed_t<size_t>;
-    auto maxDepth = std::max(tree.Depth(), maxDepth_) - oldLevel + 1;
-
-    // Always replace with the smallest possible subtree, a single terminal -
-    // matching HeuristicLab's RemoveBranchManipulation, which replaces a
-    // random branch with the grammar-minimal alternative at that position
-    // (unlike ReplaceSubtreeMutation's uniformly-random target length).
+    // Always replace with the smallest possible subtree, a single terminal.
     auto subtree = (*creator_)(random, size_t { 1 }, 1, maxDepth);
     (*coefficientInitializer_)(random, subtree);
-
-    Operon::Vector<Node> mutated;
-    mutated.reserve(nodes.size() - oldLen + 1);
-
-    std::copy(nodes.begin(), nodes.begin() + static_cast<Signed>(i - nodes[i].Length), std::back_inserter(mutated));
-    std::copy(subtree.Nodes().begin(), subtree.Nodes().end(), std::back_inserter(mutated));
-    std::copy(nodes.begin() + static_cast<Signed>(i + 1), nodes.end(), std::back_inserter(mutated));
-
-    return Tree(mutated).UpdateNodes();
+    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const>{nodes}, target,
+        Operon::Span<Node const>{subtree.Nodes()});
+    return Tree(std::move(rewritten)).UpdateNodes();
 }
-
 auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
     auto& nodes = tree.Nodes();
@@ -227,45 +203,31 @@ auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree t
 
     // pick a random function node
     auto idx = std::uniform_int_distribution<std::make_signed_t<size_t>>(1, nFunc)(random);
-
-    // find the function node in the nodes array
     size_t i = 0;
     for (; i < nodes.size(); ++i) {
         if (nodes[i].IsLeaf()) {
             continue;
         }
-
         if (--idx == 0) {
             break;
         }
     }
     auto const& s = nodes[i];
-
-    // the child nodes will be shuffled so we keep them in a buffer
     using Signed = std::make_signed_t<size_t>;
     std::vector<Node> buffer(nodes.begin() + static_cast<Signed>(i) - s.Length, nodes.begin() + static_cast<Signed>(i));
     EXPECT(buffer.size() == s.Length);
-
-    // get child indices relative to buffer
     std::vector<size_t> childIndices(s.Arity);
-
     size_t j = s.Length - 1;
     for (uint16_t k = 0; k < s.Arity; ++k) {
         childIndices[k] = j;
         j -= buffer[j].Length + 1U;
     }
-
-    // shuffle child indices
     std::shuffle(childIndices.begin(), childIndices.end(), random);
-
-    // write back from buffer to nodes in the shuffled order
     auto insertionPoint = nodes.begin() + static_cast<std::make_signed_t<decltype(i)>>(i) - s.Length;
-
     for (auto k : childIndices) {
         std::copy(buffer.begin() + static_cast<Signed>(k) - buffer[k].Length, buffer.begin() + static_cast<Signed>(k) + 1, insertionPoint);
         insertionPoint += buffer[k].Length + 1U;
     }
-
     return tree.UpdateNodes();
 }
 } // namespace Operon

--- a/test/package-consumer/run-consumer-test.cmake
+++ b/test/package-consumer/run-consumer-test.cmake
@@ -75,6 +75,8 @@ foreach(var
     if(DEFINED ${var} AND NOT "${${var}}" STREQUAL "")
         if(var STREQUAL "OPERON_TOOLCHAIN_FILE")
             set(cmake_var CMAKE_TOOLCHAIN_FILE)
+        elseif(var STREQUAL "OPERON_MSVC_RUNTIME_LIBRARY")
+            set(cmake_var CMAKE_MSVC_RUNTIME_LIBRARY)
         else()
             string(REPLACE "OPERON_" "" cmake_var "${var}")
         endif()

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -60,6 +60,19 @@ TEST_CASE("Subtree rewrites preserve and rebase backward Refs", "[operators]")
     }
 }
 
+TEST_CASE("Crossover leaves parent unchanged for an external Ref donor", "[operators]")
+{
+    auto const add = Node::Function(Hash(BuiltinOp::Add), 2);
+    auto const mul = Node::Function(Hash(BuiltinOp::Mul), 2);
+    auto lhs = Tree({Node::Constant(2), Node::Constant(3), add}).UpdateNodes();
+    auto rhs = Tree({Node::Constant(4), Node::Ref(0), Node::Constant(5), mul}).UpdateNodes();
+
+    auto const child = CrossoverBase::Cross(lhs, rhs, 2, 1);
+    CHECK(child.Nodes().size() == lhs.Nodes().size());
+    CHECK(child.Nodes()[0].Value == lhs.Nodes()[0].Value);
+    CHECK(child.Nodes().back().HashValue == lhs.Nodes().back().HashValue);
+}
+
 TEST_CASE("Crossover produces valid trees", "[operators]")
 {
     auto ds = Operon::Dataset("./data/Poly-10.csv", true);

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Subtree rewrites preserve and rebase backward Refs", "[operators]")
         CHECK_THROWS_AS(external.Splice(3), std::invalid_argument);
     }
 
-    SECTION("external donor Refs are rejected before P5") {
+    SECTION("external donor Refs are rejected") {
         auto source = Tree({Node::Constant(2), Node::Constant(3), add}).UpdateNodes();
         Operon::Vector<Node> donor{Node::Constant(4), Node::Ref(3), add};
         CHECK_THROWS_AS(detail::RewriteSubtree(source.Nodes(), detail::DescribeSubtree(source.Nodes(), 0), donor), std::invalid_argument);

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -73,6 +73,20 @@ TEST_CASE("Crossover leaves parent unchanged for an external Ref donor", "[opera
     CHECK(child.Nodes().back().HashValue == lhs.Nodes().back().HashValue);
 }
 
+TEST_CASE("Crossover rebases a nonzero-offset self-contained Ref donor", "[operators]")
+{
+    auto const add = Node::Function(Hash(BuiltinOp::Add), 2);
+    auto const mul = Node::Function(Hash(BuiltinOp::Mul), 2);
+    auto lhs = Tree({Node::Constant(2), Node::Constant(3), add}).UpdateNodes();
+    auto rhs = Tree({Node::Constant(9), Node::Constant(4), Node::Ref(1), add, mul}).UpdateNodes();
+
+    auto const child = CrossoverBase::Cross(lhs, rhs, 0, 3);
+    CHECK(child.Nodes().size() == 5);
+    CHECK(child.Nodes()[1].IsRef());
+    CHECK(child.Nodes()[1].RefTo == 0);
+    CHECK(child.Nodes().back().Length == 4);
+}
+
 TEST_CASE("Crossover produces valid trees", "[operators]")
 {
     auto ds = Operon::Dataset("./data/Poly-10.csv", true);

--- a/test/source/implementation/crossover.cpp
+++ b/test/source/implementation/crossover.cpp
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
 #include <catch2/catch_test_macros.hpp>
+#include <stdexcept>
 
 #include <random>
 
@@ -12,8 +13,52 @@
 #include "operon/operators/creator.hpp"
 #include "operon/operators/crossover.hpp"
 #include "operon/core/types.hpp"
+#include "operon/core/node.hpp"
+
+#include "../../../source/core/subtree_rewrite.hpp"
 
 namespace Operon::Test {
+
+TEST_CASE("Subtree rewrites preserve and rebase backward Refs", "[operators]")
+{
+    auto const add = Node::Function(Hash(BuiltinOp::Add), 2);
+    auto const mul = Node::Function(Hash(BuiltinOp::Mul), 2);
+
+    SECTION("incoming source Ref targets replacement root") {
+        auto source = Tree({Node::Constant(2), Node::Constant(3), add, Node::Ref(2), mul}).UpdateNodes();
+        auto replacement = Tree({Node::Constant(5)}).UpdateNodes();
+        auto const rewritten = detail::RewriteSubtree(source.Nodes(), detail::DescribeSubtree(source.Nodes(), 2), replacement.Nodes());
+        auto const child = Tree(rewritten).UpdateNodes();
+        CHECK(child.Nodes()[1].IsRef());
+        CHECK(child.Nodes()[1].RefTo == 0);
+        CHECK(child.Nodes()[2].Length == 2);
+    }
+
+    SECTION("self-contained donor Refs are rebased") {
+        auto source = Tree({Node::Constant(2), Node::Constant(3), add}).UpdateNodes();
+        auto donor = Tree({Node::Constant(4), Node::Ref(0), add}).UpdateNodes();
+        auto const rewritten = detail::RewriteSubtree(source.Nodes(), detail::DescribeSubtree(source.Nodes(), 0), donor.Nodes());
+        auto const child = Tree(rewritten).UpdateNodes();
+        CHECK(child.Nodes()[1].IsRef());
+        CHECK(child.Nodes()[1].RefTo == 0);
+        CHECK(child.Nodes().back().Length == 4);
+    }
+
+    SECTION("splice rebases self-contained Refs and rejects external Refs") {
+        auto selfContained = Tree({Node::Constant(1), Node::Ref(0), add}).UpdateNodes();
+        auto const spliced = selfContained.Splice(2);
+        CHECK(spliced.Nodes()[1].RefTo == 0);
+
+        auto external = Tree({Node::Constant(1), Node::Constant(2), add, Node::Ref(2), mul}).UpdateNodes();
+        CHECK_THROWS_AS(external.Splice(3), std::invalid_argument);
+    }
+
+    SECTION("external donor Refs are rejected before P5") {
+        auto source = Tree({Node::Constant(2), Node::Constant(3), add}).UpdateNodes();
+        Operon::Vector<Node> donor{Node::Constant(4), Node::Ref(3), add};
+        CHECK_THROWS_AS(detail::RewriteSubtree(source.Nodes(), detail::DescribeSubtree(source.Nodes(), 0), donor), std::invalid_argument);
+    }
+}
 
 TEST_CASE("Crossover produces valid trees", "[operators]")
 {


### PR DESCRIPTION
Implements P4 internal subtree spans and canonical rewrite primitive. Splice, crossover, replacement, and removal mutations share checked slice arithmetic and preserve Ref targets when suffixes shift. Targeted operon library and operator tests pass.