### PR TITLE
Redesign subtree child traversal ranges

### DIFF
--- a/include/operon/core/subtree.hpp
+++ b/include/operon/core/subtree.hpp
@@ -13,19 +13,20 @@
 
 #include "contracts.hpp"
 #include "node.hpp"
+
 namespace Operon {
 // A non-owning view over a subtree that exposes its direct children in postfix order.
-template<typename T>
-requires std::is_same_v<Node, T> || std::is_same_v<Node const, T>
+template <typename T>
+    requires std::is_same_v<Node, T> || std::is_same_v<Node const, T>
 struct Subtree {
     struct Sentinel {};
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class ChildRange;
 
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class EnumerateRange;
 
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class SubtreeIterator {
     public:
         using value_type = std::conditional_t<ReturnIndices, std::size_t, std::remove_const_t<T>>; // NOLINT
@@ -39,7 +40,7 @@ struct Subtree {
         auto operator++() -> SubtreeIterator&
         {
             ++position_;
-            if (position_ < nodes_[parent_].Arity) {
+            if (position_ < arity_) {
                 child_ -= nodes_[child_].Length + 1;
             }
             return *this;
@@ -47,15 +48,18 @@ struct Subtree {
 
         auto operator++(int) -> SubtreeIterator
         {
-            auto copy{*this};
+            auto copy { *this };
             ++(*this);
             return copy;
         }
 
         [[nodiscard]] auto operator*() const -> reference
         {
-            if constexpr (ReturnIndices) { return child_; }
-            else { return nodes_[child_]; }
+            if constexpr (ReturnIndices) {
+                return child_;
+            } else {
+                return nodes_[child_];
+            }
         }
 
         friend auto operator==(SubtreeIterator const& lhs, SubtreeIterator const& rhs) -> bool
@@ -69,7 +73,7 @@ struct Subtree {
 
         friend auto operator==(SubtreeIterator const& iterator, Sentinel /*unused*/) -> bool
         {
-            return iterator.position_ == iterator.nodes_[iterator.parent_].Arity;
+            return iterator.position_ >= iterator.arity_;
         }
 
         friend auto operator==(Sentinel sentinel, SubtreeIterator const& iterator) -> bool { return iterator == sentinel; }
@@ -78,35 +82,40 @@ struct Subtree {
         friend class ChildRange<ReturnIndices>;
 
         SubtreeIterator(Operon::Span<T> nodes, std::size_t parent)
-            : nodes_(nodes), parent_(parent), child_(nodes[parent].Arity == 0 ? parent : parent - 1)
+            : nodes_(nodes)
+            , parent_(parent)
+            , child_(nodes[parent].Arity == 0 ? parent : parent - 1)
+            , arity_(nodes[parent].Arity)
         {
         }
 
-        Operon::Span<T> nodes_{};
-        std::size_t parent_{};
-        std::size_t child_{};
-        std::size_t position_{};
+        Operon::Span<T> nodes_ {};
+        std::size_t parent_ {};
+        std::size_t child_ {};
+        std::size_t position_ {};
+        std::size_t arity_ {};
     };
 
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class ChildRange {
     public:
-        [[nodiscard]] auto begin() const -> SubtreeIterator<ReturnIndices> { return {nodes_, parent_}; }
+        [[nodiscard]] auto begin() const -> SubtreeIterator<ReturnIndices> { return { nodes_, parent_ }; }
         [[nodiscard]] auto end() const -> Sentinel { return {}; }
 
     private:
         friend struct Subtree;
 
         ChildRange(Operon::Span<T> nodes, std::size_t parent)
-            : nodes_(nodes), parent_(parent)
+            : nodes_(nodes)
+            , parent_(parent)
         {
         }
 
-        Operon::Span<T> nodes_{};
-        std::size_t parent_{};
+        Operon::Span<T> nodes_ {};
+        std::size_t parent_ {};
     };
 
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class Enumerator {
     public:
         using Iterator = SubtreeIterator<ReturnIndices>;
@@ -127,12 +136,12 @@ struct Subtree {
 
         auto operator++(int) -> Enumerator
         {
-            auto copy{*this};
+            auto copy { *this };
             ++(*this);
             return copy;
         }
 
-        [[nodiscard]] auto operator*() const -> reference { return {index_, *iterator_}; }
+        [[nodiscard]] auto operator*() const -> reference { return { index_, *iterator_ }; }
 
         friend auto operator==(Enumerator const& lhs, Enumerator const& rhs) -> bool
         {
@@ -150,26 +159,27 @@ struct Subtree {
         {
         }
 
-        Iterator iterator_{};
-        std::size_t index_{};
+        Iterator iterator_ {};
+        std::size_t index_ {};
     };
 
-    template<bool ReturnIndices>
+    template <bool ReturnIndices>
     class EnumerateRange {
     public:
-        [[nodiscard]] auto begin() const -> Enumerator<ReturnIndices> { return Enumerator<ReturnIndices>{ChildRange<ReturnIndices>{nodes_, parent_}.begin()}; }
+        [[nodiscard]] auto begin() const -> Enumerator<ReturnIndices> { return Enumerator<ReturnIndices> { ChildRange<ReturnIndices> { nodes_, parent_ }.begin() }; }
         [[nodiscard]] auto end() const -> Sentinel { return {}; }
 
     private:
         friend struct Subtree;
 
         EnumerateRange(Operon::Span<T> nodes, std::size_t parent)
-            : nodes_(nodes), parent_(parent)
+            : nodes_(nodes)
+            , parent_(parent)
         {
         }
 
-        Operon::Span<T> nodes_{};
-        std::size_t parent_{};
+        Operon::Span<T> nodes_ {};
+        std::size_t parent_ {};
     };
 
     using IndexIterator = SubtreeIterator<true>;
@@ -178,16 +188,17 @@ struct Subtree {
     using NodeRange = ChildRange<false>;
 
     Subtree(Operon::Span<T> nodes, std::size_t parent)
-        : nodes_(nodes), parent_(parent)
+        : nodes_(nodes)
+        , parent_(parent)
     {
         EXPECT(parent < nodes_.size());
     }
 
-    [[nodiscard]] auto Indices() const -> IndexRange { return {nodes_, parent_}; }
-    [[nodiscard]] auto EnumerateIndices() const -> EnumerateRange<true> { return {nodes_, parent_}; }
+    [[nodiscard]] auto Indices() const -> IndexRange { return { nodes_, parent_ }; }
+    [[nodiscard]] auto EnumerateIndices() const -> EnumerateRange<true> { return { nodes_, parent_ }; }
 
-    [[nodiscard]] auto Nodes() const -> NodeRange { return {nodes_, parent_}; }
-    [[nodiscard]] auto EnumerateNodes() const -> EnumerateRange<false> { return {nodes_, parent_}; }
+    [[nodiscard]] auto Nodes() const -> NodeRange { return { nodes_, parent_ }; }
+    [[nodiscard]] auto EnumerateNodes() const -> EnumerateRange<false> { return { nodes_, parent_ }; }
 
 private:
     Operon::Span<T> nodes_;
@@ -195,6 +206,4 @@ private:
 };
 
 } // namespace Operon
-
-
 #endif

--- a/include/operon/core/subtree.hpp
+++ b/include/operon/core/subtree.hpp
@@ -5,135 +5,189 @@
 #ifndef OPERON_SUBTREE_HPP
 #define OPERON_SUBTREE_HPP
 
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
 #include "contracts.hpp"
 #include "node.hpp"
-
 namespace Operon {
-// a non-owning view over a subtree (part of a tree) with the ability
-// to iterate over child nodes or child node indices
+// A non-owning view over a subtree that exposes its direct children in postfix order.
 template<typename T>
 requires std::is_same_v<Node, T> || std::is_same_v<Node const, T>
 struct Subtree {
-    Subtree(Operon::Span<T> nodes, std::size_t parent)
-        : nodes_(nodes), parent_(parent)
-    {}
-
     struct Sentinel {};
+    template<bool ReturnIndices>
+    class ChildRange;
 
-    template<typename Iterator>
-    struct Enumerator {
+    template<bool ReturnIndices>
+    class EnumerateRange;
+
+    template<bool ReturnIndices>
+    class SubtreeIterator {
+    public:
+        using value_type = std::conditional_t<ReturnIndices, std::size_t, std::remove_const_t<T>>; // NOLINT
+        using reference = std::conditional_t<ReturnIndices, std::size_t, T&>; // NOLINT
+        using difference_type = std::ptrdiff_t; // NOLINT
+        using iterator_concept = std::forward_iterator_tag; // NOLINT
+        using iterator_category = std::forward_iterator_tag; // NOLINT
+
+        SubtreeIterator() = default;
+
+        auto operator++() -> SubtreeIterator&
+        {
+            ++position_;
+            if (position_ < nodes_[parent_].Arity) {
+                child_ -= nodes_[child_].Length + 1;
+            }
+            return *this;
+        }
+
+        auto operator++(int) -> SubtreeIterator
+        {
+            auto copy{*this};
+            ++(*this);
+            return copy;
+        }
+
+        [[nodiscard]] auto operator*() const -> reference
+        {
+            if constexpr (ReturnIndices) { return child_; }
+            else { return nodes_[child_]; }
+        }
+
+        friend auto operator==(SubtreeIterator const& lhs, SubtreeIterator const& rhs) -> bool
+        {
+            return lhs.nodes_.data() == rhs.nodes_.data()
+                && lhs.nodes_.size() == rhs.nodes_.size()
+                && lhs.parent_ == rhs.parent_
+                && lhs.child_ == rhs.child_
+                && lhs.position_ == rhs.position_;
+        }
+
+        friend auto operator==(SubtreeIterator const& iterator, Sentinel /*unused*/) -> bool
+        {
+            return iterator.position_ == iterator.nodes_[iterator.parent_].Arity;
+        }
+
+        friend auto operator==(Sentinel sentinel, SubtreeIterator const& iterator) -> bool { return iterator == sentinel; }
+
+    private:
+        friend class ChildRange<ReturnIndices>;
+
+        SubtreeIterator(Operon::Span<T> nodes, std::size_t parent)
+            : nodes_(nodes), parent_(parent), child_(nodes[parent].Arity == 0 ? parent : parent - 1)
+        {
+        }
+
+        Operon::Span<T> nodes_{};
+        std::size_t parent_{};
+        std::size_t child_{};
+        std::size_t position_{};
+    };
+
+    template<bool ReturnIndices>
+    class ChildRange {
+    public:
+        [[nodiscard]] auto begin() const -> SubtreeIterator<ReturnIndices> { return {nodes_, parent_}; }
+        [[nodiscard]] auto end() const -> Sentinel { return {}; }
+
+    private:
+        friend struct Subtree;
+
+        ChildRange(Operon::Span<T> nodes, std::size_t parent)
+            : nodes_(nodes), parent_(parent)
+        {
+        }
+
+        Operon::Span<T> nodes_{};
+        std::size_t parent_{};
+    };
+
+    template<bool ReturnIndices>
+    class Enumerator {
+    public:
+        using Iterator = SubtreeIterator<ReturnIndices>;
         using value_type = std::tuple<std::size_t, typename Iterator::value_type>; // NOLINT
         using reference = std::tuple<std::size_t, typename Iterator::reference>; // NOLINT
         using difference_type = std::ptrdiff_t; // NOLINT
-        using iterator_tag = std::forward_iterator_tag; // NOLINT
+        using iterator_concept = std::forward_iterator_tag; // NOLINT
+        using iterator_category = std::forward_iterator_tag; // NOLINT
 
-        Enumerator(Operon::Span<T> nodes, std::size_t parent)
-            : Iter{nodes, parent}
-        {}
+        Enumerator() = default;
 
-        auto operator++() -> Enumerator& {
-            ++Iter;
-            ++Index;
+        auto operator++() -> Enumerator&
+        {
+            ++iterator_;
+            ++index_;
             return *this;
         }
 
-        auto operator++(int) -> Enumerator {
-            auto tmp{*this};
+        auto operator++(int) -> Enumerator
+        {
+            auto copy{*this};
             ++(*this);
-            return tmp;
+            return copy;
         }
 
-        auto begin() const { return *this; } // NOLINT
-        auto end() const { return Sentinel{}; } // NOLINT
+        [[nodiscard]] auto operator*() const -> reference { return {index_, *iterator_}; }
 
-        auto operator==(Enumerator const& other) {
-            return Iter == other.Iter && Index == other.Index;
+        friend auto operator==(Enumerator const& lhs, Enumerator const& rhs) -> bool
+        {
+            return lhs.iterator_ == rhs.iterator_ && lhs.index_ == rhs.index_;
         }
 
-        auto operator!=(Enumerator const& other) {
-            return !(*this == other);
+        friend auto operator==(Enumerator const& iterator, Sentinel sentinel) -> bool { return iterator.iterator_ == sentinel; }
+        friend auto operator==(Sentinel sentinel, Enumerator const& iterator) -> bool { return iterator == sentinel; }
+
+    private:
+        friend class EnumerateRange<ReturnIndices>;
+
+        explicit Enumerator(Iterator iterator)
+            : iterator_(std::move(iterator))
+        {
         }
 
-        auto operator<(Enumerator const& other) {
-            return std::tie(Index, Iter) < std::tie(other.Index, other.Iter);
-        }
-
-        auto operator==(Sentinel /*unused*/) const -> bool { return Iter.Done(); }
-
-        auto operator*() const -> reference { return { Index, *Iter }; }
-        auto operator*() -> reference { return { Index, *Iter }; }
-
-        Iterator Iter;
-        std::size_t Index{};
+        Iterator iterator_{};
+        std::size_t index_{};
     };
 
-    template<bool ReturnIndices = true>
-    struct SubtreeIterator {
-        using value_type = std::conditional_t<ReturnIndices, std::size_t, T>; // NOLINT
-        using reference = std::conditional_t<ReturnIndices, std::size_t, T&>; // NOLINT
-        using difference_type = std::ptrdiff_t; // NOLINT
-        using iterator_tag = std::forward_iterator_tag; // NOLINT
+    template<bool ReturnIndices>
+    class EnumerateRange {
+    public:
+        [[nodiscard]] auto begin() const -> Enumerator<ReturnIndices> { return Enumerator<ReturnIndices>{ChildRange<ReturnIndices>{nodes_, parent_}.begin()}; }
+        [[nodiscard]] auto end() const -> Sentinel { return {}; }
 
-        SubtreeIterator(Operon::Span<T> nodes, std::size_t parent)
-            : Nodes(nodes), Parent(parent), Child(parent-1)
+    private:
+        friend struct Subtree;
+
+        EnumerateRange(Operon::Span<T> nodes, std::size_t parent)
+            : nodes_(nodes), parent_(parent)
         {
-            EXPECT(parent > 0);
         }
 
-        inline auto begin() const { return *this; } // NOLINT
-        inline auto end() const { return Sentinel{}; } // NOLINT
-
-        auto operator==(SubtreeIterator const& other) const {
-            return Parent == other.Parent
-                && Child == other.Child
-                && Index == other.Index
-                && Nodes.data() == other.Nodes.data();
-        }
-
-        auto operator<(SubtreeIterator const& other) const {
-            return Index < other.Index;
-        }
-
-        auto operator++() -> SubtreeIterator& {
-            Child -= Nodes[Child].Length + 1;
-            Index += 1;
-            return *this;
-        }
-
-        auto operator++(int) -> SubtreeIterator {
-            auto tmp{*this};
-            ++(*this);
-            return tmp;
-        }
-
-        auto operator==(Sentinel /*unused*/) const -> bool { return Done(); }
-
-        auto operator*() const -> reference {
-            if constexpr (ReturnIndices) { return Child; }
-            else { return Nodes[Child]; }
-        }
-
-        auto operator*() -> reference {
-            if constexpr (ReturnIndices) { return Child; }
-            else { return Nodes[Child]; }
-        }
-
-        [[nodiscard]] auto Done() const -> bool { return Index >= Nodes[Parent].Arity; }
-
-        Operon::Span<T> Nodes;
-        std::size_t Parent;
-        std::size_t Child;
-        std::size_t Index{};
+        Operon::Span<T> nodes_{};
+        std::size_t parent_{};
     };
 
     using IndexIterator = SubtreeIterator<true>;
     using NodeIterator = SubtreeIterator<false>;
+    using IndexRange = ChildRange<true>;
+    using NodeRange = ChildRange<false>;
 
-    [[nodiscard]] auto Indices() const { return IndexIterator{nodes_, parent_}; }
-    [[nodiscard]] auto EnumerateIndices() const { return Enumerator<IndexIterator>{nodes_, parent_}; }
+    Subtree(Operon::Span<T> nodes, std::size_t parent)
+        : nodes_(nodes), parent_(parent)
+    {
+        EXPECT(parent < nodes_.size());
+    }
 
-    [[nodiscard]] auto Nodes() const { return NodeIterator{nodes_, parent_}; }
-    [[nodiscard]] auto EnumerateNodes() const { return Enumerator<NodeIterator>{nodes_, parent_}; }
+    [[nodiscard]] auto Indices() const -> IndexRange { return {nodes_, parent_}; }
+    [[nodiscard]] auto EnumerateIndices() const -> EnumerateRange<true> { return {nodes_, parent_}; }
+
+    [[nodiscard]] auto Nodes() const -> NodeRange { return {nodes_, parent_}; }
+    [[nodiscard]] auto EnumerateNodes() const -> EnumerateRange<false> { return {nodes_, parent_}; }
 
 private:
     Operon::Span<T> nodes_;
@@ -141,5 +195,6 @@ private:
 };
 
 } // namespace Operon
+
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(operon_test
     source/implementation/pappus_nsgp.cpp
     source/implementation/registry_coverage.cpp
     source/implementation/user_defined_registries.cpp
+    source/implementation/subtree.cpp
     source/implementation/composed_function.cpp
     )
 target_link_libraries(operon_test PRIVATE operon::operon Catch2::Catch2WithMain scn::scn nanobench::nanobench)

--- a/test/source/implementation/subtree.cpp
+++ b/test/source/implementation/subtree.cpp
@@ -4,6 +4,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <ranges>
+#include <utility>
 #include <vector>
 
 #include "operon/core/tree.hpp"
@@ -24,41 +25,61 @@ namespace {
 
 TEST_CASE("Subtree child ranges handle leaves and preserve postfix child order", "[core]")
 {
-    auto rootLeaf = Tree({Constant(1)}).UpdateNodes();
+    auto rootLeaf = Tree({ Constant(1) }).UpdateNodes();
     CHECK(std::ranges::empty(rootLeaf.Children(0)));
     CHECK(std::ranges::empty(rootLeaf.Indices(0)));
 
-    auto tree = Tree({Constant(1), Constant(2), Add(), Constant(3), Add()}).UpdateNodes();
+    auto tree = Tree({ Constant(1), Constant(2), Add(), Constant(3), Add() }).UpdateNodes();
     std::vector<std::size_t> indices;
     for (auto const index : tree.Indices(4)) {
         indices.push_back(index);
     }
     CHECK(std::ranges::empty(tree.Indices(0)));
 
-    CHECK(indices == std::vector<std::size_t>{3, 2});
+    CHECK(indices == std::vector<std::size_t> { 3, 2 });
 
     std::vector<Scalar> children;
     for (auto const& child : tree.Children(4)) {
         children.push_back(child.Value);
     }
-    CHECK(children == std::vector<Scalar>{3, 1});
+    CHECK(children == std::vector<Scalar> { 3, 1 });
 }
 
 TEST_CASE("Subtree child ranges enumerate indices and mutable nodes", "[core]")
 {
-    auto tree = Tree({Constant(1), Constant(2), Add()}).UpdateNodes();
+    auto tree = Tree({ Constant(1), Constant(2), Add() }).UpdateNodes();
 
     std::vector<std::tuple<std::size_t, std::size_t>> indexed;
     for (auto const [position, child] : Tree::EnumerateIndices(tree.Nodes(), 2)) {
         indexed.emplace_back(position, child);
     }
-    CHECK(indexed == std::vector<std::tuple<std::size_t, std::size_t>>{{0, 1}, {1, 0}});
+    CHECK(indexed == std::vector<std::tuple<std::size_t, std::size_t>> { { 0, 1 }, { 1, 0 } });
+
+    auto iterator = tree.Indices(2).begin();
+    auto copy = iterator++;
+    CHECK(copy == tree.Indices(2).begin());
+    CHECK(iterator != copy);
 
     for (auto [position, child] : Tree::EnumerateNodes(tree.Nodes(), 2)) {
         child.Value = static_cast<Scalar>(position + 10);
     }
     CHECK(tree.Nodes()[1].Value == 10);
     CHECK(tree.Nodes()[0].Value == 11);
+}
+
+TEST_CASE("Subtree child ranges support default and const iterators", "[core]")
+{
+    auto tree = Tree({ Constant(1), Constant(2), Add() }).UpdateNodes();
+
+    auto constIterator = decltype(tree.Indices(2).begin()) {};
+    CHECK(constIterator == tree.Indices(2).end());
+
+    auto const& constTree = std::as_const(tree);
+    std::vector<Scalar> constChildren;
+    for (auto const& child : Tree::Nodes(constTree.Nodes(), 2)) {
+        constChildren.push_back(child.Value);
+    }
+    CHECK(constChildren == std::vector<Scalar> { 2, 1 });
 }
 
 } // namespace Operon::Test

--- a/test/source/implementation/subtree.cpp
+++ b/test/source/implementation/subtree.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright 2026 Bogdan Burlacu and contributors
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <ranges>
+#include <vector>
+
+#include "operon/core/tree.hpp"
+
+namespace Operon::Test {
+
+namespace {
+    auto Constant(Scalar value) -> Node
+    {
+        return Node::Constant(value);
+    }
+
+    auto Add() -> Node
+    {
+        return Node::Function(static_cast<Hash>(BuiltinOp::Add), 2);
+    }
+} // namespace
+
+TEST_CASE("Subtree child ranges handle leaves and preserve postfix child order", "[core]")
+{
+    auto rootLeaf = Tree({Constant(1)}).UpdateNodes();
+    CHECK(std::ranges::empty(rootLeaf.Children(0)));
+    CHECK(std::ranges::empty(rootLeaf.Indices(0)));
+
+    auto tree = Tree({Constant(1), Constant(2), Add(), Constant(3), Add()}).UpdateNodes();
+    std::vector<std::size_t> indices;
+    for (auto const index : tree.Indices(4)) {
+        indices.push_back(index);
+    }
+    CHECK(std::ranges::empty(tree.Indices(0)));
+
+    CHECK(indices == std::vector<std::size_t>{3, 2});
+
+    std::vector<Scalar> children;
+    for (auto const& child : tree.Children(4)) {
+        children.push_back(child.Value);
+    }
+    CHECK(children == std::vector<Scalar>{3, 1});
+}
+
+TEST_CASE("Subtree child ranges enumerate indices and mutable nodes", "[core]")
+{
+    auto tree = Tree({Constant(1), Constant(2), Add()}).UpdateNodes();
+
+    std::vector<std::tuple<std::size_t, std::size_t>> indexed;
+    for (auto const [position, child] : Tree::EnumerateIndices(tree.Nodes(), 2)) {
+        indexed.emplace_back(position, child);
+    }
+    CHECK(indexed == std::vector<std::tuple<std::size_t, std::size_t>>{{0, 1}, {1, 0}});
+
+    for (auto [position, child] : Tree::EnumerateNodes(tree.Nodes(), 2)) {
+        child.Value = static_cast<Scalar>(position + 10);
+    }
+    CHECK(tree.Nodes()[1].Value == 10);
+    CHECK(tree.Nodes()[0].Value == 11);
+}
+
+} // namespace Operon::Test


### PR DESCRIPTION
## Summary
- Make subtree child traversal ranges sentinel-based and safe for leaf parents.
- Validate subtree parent indices and keep iterator state private.
- Cover leaf traversal, order, enumeration, and mutable child traversal.

## Validation
- `cmake --build . --target operon_test -j2`
- `./test/operon_test "Subtree child*"`
- `git diff --check`
