### PR TITLE
Map references during subtree shuffles

### DIFF
--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -93,6 +93,53 @@ struct SubtreeSpan {
     return copy;
 }
 
+struct SourceSegment {
+    std::size_t First;
+    std::size_t Size;
+};
+
+[[nodiscard]] inline auto RewriteSegments(Operon::Span<Node const> source, Operon::Span<SourceSegment const> segments) -> Operon::Vector<Node>
+{
+    Operon::Vector<std::size_t> destinations(source.size(), source.size());
+    std::size_t size {};
+    for (auto const segment : segments) {
+        EXPECT(segment.First <= source.size());
+        EXPECT(segment.Size <= source.size() - segment.First);
+        size += segment.Size;
+    }
+    if (size != source.size()) {
+        throw std::invalid_argument("source segments do not cover the tree");
+    }
+
+    Operon::Vector<Node> rewritten;
+    rewritten.reserve(size);
+    for (auto const segment : segments) {
+        for (std::size_t old = segment.First; old < segment.First + segment.Size; ++old) {
+            if (destinations[old] != source.size()) {
+                throw std::invalid_argument("source segment appears more than once");
+            }
+            destinations[old] = rewritten.size();
+            rewritten.push_back(source[old]);
+        }
+    }
+
+    for (std::size_t i = 0; i < rewritten.size(); ++i) {
+        auto& node = rewritten[i];
+        if (!node.IsRef()) {
+            continue;
+        }
+        if (node.RefTo >= destinations.size() || destinations[node.RefTo] == source.size()) {
+            throw std::invalid_argument("rewritten tree omits a Ref target");
+        }
+        auto const target = destinations[node.RefTo];
+        if (target >= i) {
+            throw std::invalid_argument("rewritten Ref target is not backward");
+        }
+        node.RefTo = static_cast<uint16_t>(target);
+    }
+    return rewritten;
+}
+
 } // namespace Operon::detail
 
 #endif

--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <optional>
 #include <stdexcept>
 
 #include "operon/core/contracts.hpp"
@@ -93,12 +94,25 @@ struct SubtreeSpan {
     return copy;
 }
 
-struct SourceSegment {
+struct PermutationSegment {
     std::size_t First;
     std::size_t Size;
 };
 
-[[nodiscard]] inline auto RewriteSegments(Operon::Span<Node const> source, Operon::Span<SourceSegment const> segments) -> Operon::Vector<Node>
+[[nodiscard]] inline auto HasValidPostfixStructure(Operon::Span<Node const> nodes) -> bool
+{
+    std::size_t completed {};
+    for (auto const& node : nodes) {
+        if (node.Arity > completed) {
+            return false;
+        }
+        completed -= node.Arity;
+        ++completed;
+    }
+    return completed == 1;
+}
+
+[[nodiscard]] inline auto PermuteSegments(Operon::Span<Node const> source, Operon::Span<PermutationSegment const> segments) -> std::optional<Operon::Vector<Node>>
 {
     Operon::Vector<std::size_t> destinations(source.size(), source.size());
     std::size_t size {};
@@ -108,7 +122,7 @@ struct SourceSegment {
         size += segment.Size;
     }
     if (size != source.size()) {
-        throw std::invalid_argument("source segments do not cover the tree");
+        return std::nullopt;
     }
 
     Operon::Vector<Node> rewritten;
@@ -116,11 +130,14 @@ struct SourceSegment {
     for (auto const segment : segments) {
         for (std::size_t old = segment.First; old < segment.First + segment.Size; ++old) {
             if (destinations[old] != source.size()) {
-                throw std::invalid_argument("source segment appears more than once");
+                return std::nullopt;
             }
             destinations[old] = rewritten.size();
             rewritten.push_back(source[old]);
         }
+    }
+    if (!HasValidPostfixStructure(rewritten)) {
+        return std::nullopt;
     }
 
     for (std::size_t i = 0; i < rewritten.size(); ++i) {
@@ -128,18 +145,14 @@ struct SourceSegment {
         if (!node.IsRef()) {
             continue;
         }
-        if (node.RefTo >= destinations.size() || destinations[node.RefTo] == source.size()) {
-            throw std::invalid_argument("rewritten tree omits a Ref target");
-        }
         auto const target = destinations[node.RefTo];
         if (target >= i) {
-            throw std::invalid_argument("rewritten Ref target is not backward");
+            return std::nullopt;
         }
         node.RefTo = static_cast<uint16_t>(target);
     }
     return rewritten;
 }
-
 } // namespace Operon::detail
 
 #endif

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -9,10 +9,11 @@
 #include <iterator>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 #include <type_traits>
 
-#include "operon/operators/creator.hpp"
 #include "../core/subtree_rewrite.hpp"
+#include "operon/operators/creator.hpp"
 #include "operon/operators/initializer.hpp"
 
 namespace Operon {
@@ -87,7 +88,7 @@ auto ReplaceSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tr
 {
     auto const& nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
-    auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
+    auto const target = detail::DescribeSubtree(Operon::Span<Node const> { nodes }, i);
     auto const oldLen = target.Size;
     auto const oldLevel = nodes[i].Level;
 
@@ -100,8 +101,8 @@ auto ReplaceSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tr
     auto const newLen = std::uniform_int_distribution<Signed>(Signed { 1 }, maxLength)(random);
     auto subtree = (*creator_)(random, static_cast<size_t>(newLen), 1, maxDepth);
     (*coefficientInitializer_)(random, subtree);
-    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const>{nodes}, target,
-        Operon::Span<Node const>{subtree.Nodes()});
+    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const> { nodes }, target,
+        Operon::Span<Node const> { subtree.Nodes() });
     return Tree(std::move(rewritten)).UpdateNodes();
 }
 
@@ -181,53 +182,62 @@ auto RemoveSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
 {
     auto const& nodes = tree.Nodes();
     auto i = std::uniform_int_distribution<size_t>(0, nodes.size() - 1)(random);
-    auto const target = detail::DescribeSubtree(Operon::Span<Node const>{nodes}, i);
+    auto const target = detail::DescribeSubtree(Operon::Span<Node const> { nodes }, i);
     auto const oldLevel = nodes[i].Level;
     auto const maxDepth = std::max(tree.Depth(), maxDepth_) - oldLevel + 1;
 
     // Always replace with the smallest possible subtree, a single terminal.
     auto subtree = (*creator_)(random, size_t { 1 }, 1, maxDepth);
     (*coefficientInitializer_)(random, subtree);
-    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const>{nodes}, target,
-        Operon::Span<Node const>{subtree.Nodes()});
+    auto rewritten = detail::RewriteSubtree(Operon::Span<Node const> { nodes }, target,
+        Operon::Span<Node const> { subtree.Nodes() });
     return Tree(std::move(rewritten)).UpdateNodes();
 }
 auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto& nodes = tree.Nodes();
-    auto nFunc = std::count_if(nodes.begin(), nodes.end(), [](const auto& node) -> auto { return !node.IsLeaf(); });
+    auto const& nodes = tree.Nodes();
+    auto const nFunc = std::count_if(nodes.begin(), nodes.end(), [](auto const& node) -> auto { return !node.IsLeaf(); });
 
     if (nFunc == 0) {
         return tree;
     }
 
-    // pick a random function node
-    auto idx = std::uniform_int_distribution<std::make_signed_t<size_t>>(1, nFunc)(random);
-    size_t i = 0;
-    for (; i < nodes.size(); ++i) {
-        if (nodes[i].IsLeaf()) {
-            continue;
+    auto const selected = std::uniform_int_distribution<std::make_signed_t<size_t>>(1, nFunc)(random);
+    auto const root = [&] {
+        auto remaining = selected;
+        for (std::size_t i = 0; i < nodes.size(); ++i) {
+            if (!nodes[i].IsLeaf() && --remaining == 0) {
+                return i;
+            }
         }
-        if (--idx == 0) {
-            break;
-        }
+        UNREACHABLE();
+    }();
+
+    auto const span = detail::DescribeSubtree(Operon::Span<Node const> { nodes }, root);
+    Operon::Vector<detail::SubtreeSpan> children;
+    children.reserve(nodes[root].Arity);
+    for (auto const child : tree.Indices(root)) {
+        children.push_back(detail::DescribeSubtree(Operon::Span<Node const> { nodes }, child));
     }
-    auto const& s = nodes[i];
-    using Signed = std::make_signed_t<size_t>;
-    std::vector<Node> buffer(nodes.begin() + static_cast<Signed>(i) - s.Length, nodes.begin() + static_cast<Signed>(i));
-    EXPECT(buffer.size() == s.Length);
-    std::vector<size_t> childIndices(s.Arity);
-    size_t j = s.Length - 1;
-    for (uint16_t k = 0; k < s.Arity; ++k) {
-        childIndices[k] = j;
-        j -= buffer[j].Length + 1U;
+    std::shuffle(children.begin(), children.end(), random);
+
+    Operon::Vector<detail::SourceSegment> segments;
+    segments.reserve(children.size() + 3);
+    if (span.First != 0) {
+        segments.push_back({ 0, span.First });
     }
-    std::shuffle(childIndices.begin(), childIndices.end(), random);
-    auto insertionPoint = nodes.begin() + static_cast<std::make_signed_t<decltype(i)>>(i) - s.Length;
-    for (auto k : childIndices) {
-        std::copy(buffer.begin() + static_cast<Signed>(k) - buffer[k].Length, buffer.begin() + static_cast<Signed>(k) + 1, insertionPoint);
-        insertionPoint += buffer[k].Length + 1U;
+    for (auto const child : children) {
+        segments.push_back({ child.First, child.Size });
     }
-    return tree.UpdateNodes();
+    segments.push_back({ root, 1 });
+    if (root + 1 < nodes.size()) {
+        segments.push_back({ root + 1, nodes.size() - root - 1 });
+    }
+
+    try {
+        return Tree(detail::RewriteSegments(Operon::Span<Node const> { nodes }, segments)).UpdateNodes();
+    } catch (std::invalid_argument const&) {
+        return tree;
+    }
 }
 } // namespace Operon

--- a/source/operators/mutation.cpp
+++ b/source/operators/mutation.cpp
@@ -9,7 +9,6 @@
 #include <iterator>
 #include <numeric>
 #include <random>
-#include <stdexcept>
 #include <type_traits>
 
 #include "../core/subtree_rewrite.hpp"
@@ -195,9 +194,8 @@ auto RemoveSubtreeMutation::operator()(Operon::RandomGenerator& random, Tree tre
 }
 auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree tree) const -> Tree
 {
-    auto const& nodes = tree.Nodes();
-    auto const nFunc = std::count_if(nodes.begin(), nodes.end(), [](auto const& node) -> auto { return !node.IsLeaf(); });
-
+    auto& nodes = tree.Nodes();
+    auto const nFunc = std::count_if(nodes.begin(), nodes.end(), [](Node const& node) { return !node.IsLeaf(); });
     if (nFunc == 0) {
         return tree;
     }
@@ -220,8 +218,28 @@ auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree t
         children.push_back(detail::DescribeSubtree(Operon::Span<Node const> { nodes }, child));
     }
     std::shuffle(children.begin(), children.end(), random);
+    if (children.size() < 2) {
+        return tree;
+    }
 
-    Operon::Vector<detail::SourceSegment> segments;
+    auto original = tree.Indices(root).begin();
+    auto const unchanged = std::ranges::all_of(children, [&](detail::SubtreeSpan const& child) { return child.Root == *original++; });
+    if (unchanged) {
+        return tree;
+    }
+
+    if (!std::ranges::any_of(nodes, [](Node const& node) { return node.IsRef(); })) {
+        Operon::Vector<Node> buffer(nodes.begin() + static_cast<std::ptrdiff_t>(span.First), nodes.begin() + static_cast<std::ptrdiff_t>(root));
+        auto destination = nodes.begin() + static_cast<std::ptrdiff_t>(span.First);
+        for (auto const child : children) {
+            auto const first = child.First - span.First;
+            std::copy_n(buffer.begin() + static_cast<std::ptrdiff_t>(first), child.Size, destination);
+            destination += static_cast<std::ptrdiff_t>(child.Size);
+        }
+        return tree.UpdateNodes();
+    }
+
+    Operon::Vector<detail::PermutationSegment> segments;
     segments.reserve(children.size() + 3);
     if (span.First != 0) {
         segments.push_back({ 0, span.First });
@@ -234,10 +252,7 @@ auto ShuffleSubtreesMutation::operator()(Operon::RandomGenerator& random, Tree t
         segments.push_back({ root + 1, nodes.size() - root - 1 });
     }
 
-    try {
-        return Tree(detail::RewriteSegments(Operon::Span<Node const> { nodes }, segments)).UpdateNodes();
-    } catch (std::invalid_argument const&) {
-        return tree;
-    }
+    auto rewritten = detail::PermuteSegments(Operon::Span<Node const> { nodes }, segments);
+    return rewritten ? Tree(std::move(*rewritten)).UpdateNodes() : tree;
 }
 } // namespace Operon

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -27,17 +27,26 @@ TEST_CASE("Mapped subtree segments preserve Ref safety", "[operators]")
 {
     auto nodes = Operon::Vector<Node> { Node::Constant(1), Node::Constant(2), Add(), Node::Ref(2), Add() };
 
-    auto const unchangedSegments = Operon::Vector<detail::SourceSegment> { { 0, 3 }, { 3, 1 }, { 4, 1 } };
-    auto const unchanged = detail::RewriteSegments(nodes, unchangedSegments);
-    REQUIRE(unchanged[3].IsRef());
-    CHECK(unchanged[3].RefTo == 2);
-    CHECK(Tree(unchanged).UpdateNodes().Validate());
+    auto const unchangedSegments = Operon::Vector<detail::PermutationSegment> { { 0, 3 }, { 3, 1 }, { 4, 1 } };
+    auto const unchanged = detail::PermuteSegments(nodes, unchangedSegments);
+    REQUIRE(unchanged);
+    CHECK((*unchanged)[3].IsRef());
+    CHECK((*unchanged)[3].RefTo == 2);
+    CHECK(Tree(*unchanged).UpdateNodes().Validate());
 
-    auto const reorderedSegments = Operon::Vector<detail::SourceSegment> { { 3, 1 }, { 0, 3 }, { 4, 1 } };
-    CHECK_THROWS_AS(detail::RewriteSegments(nodes, reorderedSegments), std::invalid_argument);
+    auto const selfContained = Operon::Vector<Node> { Node::Constant(1), Node::Ref(0), Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2), Node::Constant(2), Add() };
+    auto const reorderedSegments = Operon::Vector<detail::PermutationSegment> { { 3, 1 }, { 0, 3 }, { 4, 1 } };
+    auto const reordered = detail::PermuteSegments(selfContained, reorderedSegments);
+    REQUIRE(reordered);
+    CHECK((*reordered)[2].IsRef());
+    CHECK((*reordered)[2].RefTo == 1);
+    CHECK(Tree(*reordered).UpdateNodes().Validate());
 
-    auto const incompleteSegments = Operon::Vector<detail::SourceSegment> { { 0, 3 }, { 4, 1 } };
-    CHECK_THROWS_AS(detail::RewriteSegments(nodes, incompleteSegments), std::invalid_argument);
+    auto const incompleteSegments = Operon::Vector<detail::PermutationSegment> { { 0, 3 }, { 4, 1 } };
+    CHECK_FALSE(detail::PermuteSegments(nodes, incompleteSegments));
+
+    auto const malformedSegments = Operon::Vector<detail::PermutationSegment> { { 0, 1 }, { 2, 1 }, { 1, 1 } };
+    CHECK_FALSE(detail::PermuteSegments(Operon::Vector<Node> { Node::Constant(1), Node::Constant(2), Add() }, malformedSegments));
 }
 
 TEST_CASE("ShuffleSubtreesMutation preserves Ref validity", "[operators]")

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -6,6 +6,7 @@
 
 #include "../operon_test.hpp"
 
+#include "../../../source/core/subtree_rewrite.hpp"
 #include "operon/core/dataset.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/core/variable.hpp"
@@ -15,13 +16,51 @@
 
 namespace Operon::Test {
 
+namespace {
+    auto Add() -> Node
+    {
+        return Node::Function(static_cast<Hash>(BuiltinOp::Add), 2);
+    }
+} // namespace
+
+TEST_CASE("Mapped subtree segments preserve Ref safety", "[operators]")
+{
+    auto nodes = Operon::Vector<Node> { Node::Constant(1), Node::Constant(2), Add(), Node::Ref(2), Add() };
+
+    auto const unchangedSegments = Operon::Vector<detail::SourceSegment> { { 0, 3 }, { 3, 1 }, { 4, 1 } };
+    auto const unchanged = detail::RewriteSegments(nodes, unchangedSegments);
+    REQUIRE(unchanged[3].IsRef());
+    CHECK(unchanged[3].RefTo == 2);
+    CHECK(Tree(unchanged).UpdateNodes().Validate());
+
+    auto const reorderedSegments = Operon::Vector<detail::SourceSegment> { { 3, 1 }, { 0, 3 }, { 4, 1 } };
+    CHECK_THROWS_AS(detail::RewriteSegments(nodes, reorderedSegments), std::invalid_argument);
+
+    auto const incompleteSegments = Operon::Vector<detail::SourceSegment> { { 0, 3 }, { 4, 1 } };
+    CHECK_THROWS_AS(detail::RewriteSegments(nodes, incompleteSegments), std::invalid_argument);
+}
+
+TEST_CASE("ShuffleSubtreesMutation preserves Ref validity", "[operators]")
+{
+    auto const add = Add();
+    auto const mul = Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2);
+    auto const tree = Tree({ Node::Constant(1), Node::Constant(2), add, Node::Ref(2), mul }).UpdateNodes();
+    auto random = Operon::RandomGenerator(1234);
+    auto const mutation = ShuffleSubtreesMutation {};
+
+    for (auto i = 0; i < 100; ++i) {
+        auto const child = mutation(random, tree);
+        CHECK(child.Validate());
+    }
+}
+
 TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
 {
     auto ds = Dataset("./data/Poly-10.csv", true);
     auto inputs = ds.VariableHashes();
     std::erase(inputs, ds.GetVariable("Y").value().Hash);
-    auto const maxDepth{1000};
-    auto const maxLength{100};
+    auto const maxDepth { 1000 };
+    auto const maxLength { 100 };
 
     PrimitiveSet grammar;
     grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
@@ -30,7 +69,7 @@ TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Sub>().HashValue, 1);
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Div>().HashValue, 1);
 
-    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    BalancedTreeCreator btc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
 
     Operon::RandomGenerator random(1234);
@@ -39,7 +78,7 @@ TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")
 
     auto tree = btc(random, targetLen, 1, maxDepth);
 
-    InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, 2 * targetLen, maxDepth);
+    InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &btc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, 2 * targetLen, maxDepth);
     auto child = mut(random, tree);
 
     CHECK(child.Length() > 0);
@@ -52,8 +91,8 @@ TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-mini
     auto ds = Dataset("./data/Poly-10.csv", true);
     auto inputs = ds.VariableHashes();
     std::erase(inputs, ds.GetVariable("Y").value().Hash);
-    auto const maxDepth{1000};
-    auto const maxLength{100};
+    auto const maxDepth { 1000 };
+    auto const maxLength { 100 };
 
     PrimitiveSet grammar;
     grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
@@ -62,15 +101,15 @@ TEST_CASE("RemoveSubtreeMutation replaces a random subtree with the grammar-mini
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Sub>().HashValue, 1);
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Div>().HashValue, 1);
 
-    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    BalancedTreeCreator btc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
 
     Operon::RandomGenerator random(1234);
-    auto const targetLen = size_t{30};
+    auto const targetLen = size_t { 30 };
     auto tree = btc(random, targetLen, 1, maxDepth);
     auto const originalLength = tree.Length();
 
-    RemoveSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxDepth);
+    RemoveSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &btc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, maxDepth);
 
     // Every replacement subtree is a single terminal (the smallest possible),
     // so the result can only shrink or stay the same length - never grow -
@@ -88,8 +127,8 @@ TEST_CASE("RemoveSubtreeMutation on a single-node tree does not crash", "[operat
     auto ds = Dataset("./data/Poly-10.csv", true);
     auto inputs = ds.VariableHashes();
     std::erase(inputs, ds.GetVariable("Y").value().Hash);
-    auto const maxDepth{1000};
-    auto const maxLength{100};
+    auto const maxDepth { 1000 };
+    auto const maxLength { 100 };
 
     PrimitiveSet grammar;
     grammar.SetConfig(PrimitiveSet::Arithmetic | BuiltinOp::Log | BuiltinOp::Exp);
@@ -98,14 +137,14 @@ TEST_CASE("RemoveSubtreeMutation on a single-node tree does not crash", "[operat
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Sub>().HashValue, 1);
     grammar.SetFrequency(Util::MakeOp<BuiltinOp::Div>().HashValue, 1);
 
-    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    BalancedTreeCreator btc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
 
     Operon::RandomGenerator random(4321);
     auto tree = btc(random, /*targetLen=*/1, 1, maxDepth);
     REQUIRE(tree.Length() == 1);
 
-    RemoveSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxDepth);
+    RemoveSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &btc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, maxDepth);
     auto child = mut(random, tree);
     CHECK(child.Length() == 1);
 }
@@ -115,20 +154,20 @@ TEST_CASE("Mutation tree stays within bounds", "[operators]")
     auto ds = Dataset("./data/Poly-10.csv", true);
     auto inputs = ds.VariableHashes();
     std::erase(inputs, ds.GetVariable("Y").value().Hash);
-    auto const maxDepth{1000};
-    auto const maxLength{50};
+    auto const maxDepth { 1000 };
+    auto const maxLength { 50 };
 
     PrimitiveSet grammar;
     grammar.SetConfig(PrimitiveSet::Arithmetic);
 
-    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    BalancedTreeCreator btc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
 
     Operon::RandomGenerator random(1234);
 
     for (int i = 0; i < 100; ++i) {
         auto tree = btc(random, 10, 1, maxDepth);
-        InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxLength, maxDepth);
+        InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &btc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, maxLength, maxDepth);
         auto child = mut(random, tree);
         CHECK(child.Length() > 0);
         CHECK(child.Length() <= static_cast<size_t>(maxLength));
@@ -150,9 +189,9 @@ TEST_CASE("ReplaceSubtreeMutation via PTC2 respects maxDepth", "[operators]")
     // PTC2 is the creator whose depth enforcement is being exercised here: the
     // mutation hands it a per-call depth budget and relies on the creator to
     // honor it when growing the replacement subtree.
-    ProbabilisticTreeCreator const ptc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    ProbabilisticTreeCreator const ptc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
-    ReplaceSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&ptc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxDepth, maxLength);
+    ReplaceSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &ptc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, maxDepth, maxLength);
 
     Operon::RandomGenerator random(42);
 
@@ -173,13 +212,13 @@ TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators u
     auto ds = Dataset("./data/Poly-10.csv", true);
     auto inputs = ds.VariableHashes();
     std::erase(inputs, ds.GetVariable("Y").value().Hash);
-    auto const maxDepth{1000};
-    auto const maxLength{50};
+    auto const maxDepth { 1000 };
+    auto const maxLength { 50 };
 
     PrimitiveSet grammar;
     grammar.SetConfig(PrimitiveSet::Arithmetic);
 
-    BalancedTreeCreator btc{&grammar, inputs, /* bias= */ 0.0, maxLength};
+    BalancedTreeCreator btc { &grammar, inputs, /* bias= */ 0.0, maxLength };
     UniformCoefficientInitializer cfi;
 
     auto const variableHash = ds.GetVariable("X1").value().Hash;
@@ -191,7 +230,7 @@ TEST_CASE("InsertSubtreeMutation leaves trees without eligible n-ary operators u
     Tree const tree({ variable, sin });
 
     Operon::RandomGenerator random(1234);
-    InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*>{&btc}, gsl::not_null<Operon::CoefficientInitializerBase const*>{&cfi}, maxLength, maxDepth);
+    InsertSubtreeMutation const mut(gsl::not_null<Operon::CreatorBase const*> { &btc }, gsl::not_null<Operon::CoefficientInitializerBase const*> { &cfi }, maxLength, maxDepth);
     auto child = mut(random, tree);
 
     CHECK(child.Length() == tree.Length());


### PR DESCRIPTION
## Summary
- Add a complete source-segment rewrite primitive that remaps retained `Ref` targets.
- Migrate `ShuffleSubtreesMutation` to that primitive.
- Leave a shuffle unchanged when its permutation would omit a reference target or make a reference non-backward.

## Verification
- `cmake --build build-package-components --target operon_test -j4`
- `build-package-components/test/operon_test "[operators]"` — 52,604 assertions across 26 cases
- `nix develop -c clang-tidy test/source/implementation/mutation.cpp -p build-package-components --warnings-as-errors='*'`
- `nix develop -c clang-format --style=file --dry-run --Werror source/core/subtree_rewrite.hpp source/operators/mutation.cpp test/source/implementation/mutation.cpp`
- `git diff --check`