### PR TITLE
refactor: use optional for dataset variable lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ target_link_libraries(operon_operon PUBLIC
     vstat::vstat
     std::mdspan
     pappus::pappus # required by IntervalEvaluator/AffineEvaluator
-    tl::expected # Dataset::GetVariable returns tl::expected in the public dataset.hpp header
+    tl::expected # required by public Tree::Validate/FitOutcome APIs
 )
 
 target_link_libraries(operon_operon PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ target_link_libraries(operon_operon PUBLIC
     vstat::vstat
     std::mdspan
     pappus::pappus # required by IntervalEvaluator/AffineEvaluator
-    tl::expected # required by public Tree::Validate/FitOutcome APIs
+    tl::expected # Dataset::GetVariable returns tl::expected in the public dataset.hpp header
 )
 
 target_link_libraries(operon_operon PRIVATE

--- a/include/operon/core/dataset.hpp
+++ b/include/operon/core/dataset.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include <gsl/pointers>
-#include <tl/expected.hpp>
 
 #include "operon/operon_export.hpp"
 #include "contracts.hpp"
@@ -21,9 +20,6 @@
 
 namespace Operon {
 
-enum class DatasetError : std::uint8_t {
-    VariableNotFound = 0,
-};
 
 class OPERON_EXPORT Dataset {
 public:
@@ -110,8 +106,8 @@ public:
     [[nodiscard]] auto GetPaddedValues(std::string const& name) const noexcept -> Scalar const*;
     [[nodiscard]] auto GetPaddedValues(Variable const& var) const noexcept -> Scalar const* { return GetPaddedValues(var.Hash); }
 
-    [[nodiscard]] auto GetVariable(std::string const& name) const noexcept -> tl::expected<Variable, DatasetError>;
-    [[nodiscard]] auto GetVariable(Operon::Hash hash) const noexcept -> tl::expected<Variable, DatasetError>;
+    [[nodiscard]] auto GetVariable(std::string const& name) const noexcept -> std::optional<Variable>;
+    [[nodiscard]] auto GetVariable(Operon::Hash hash) const noexcept -> std::optional<Variable>;
     [[nodiscard]] auto GetVariables() const noexcept -> std::vector<Operon::Variable>;
 
     // Zero-copy variable-name lookup: a view into this Dataset's own

--- a/source/core/dataset.cpp
+++ b/source/core/dataset.cpp
@@ -296,16 +296,16 @@ auto Dataset::GetValues(int64_t index) const noexcept -> Span<Scalar const>
     return ColSpan(static_cast<int>(index)); // NOLINT(cppcoreguidelines-narrowing-conversions)
 }
 
-auto Dataset::GetVariable(std::string const& name) const noexcept -> tl::expected<Variable, DatasetError>
+auto Dataset::GetVariable(std::string const& name) const noexcept -> std::optional<Variable>
 {
     return GetVariable(Hasher {}(name));
 }
 
-auto Dataset::GetVariable(Operon::Hash hash) const noexcept -> tl::expected<Variable, DatasetError>
+auto Dataset::GetVariable(Operon::Hash hash) const noexcept -> std::optional<Variable>
 {
     auto it = variables_.find(hash);
     if (it == variables_.end()) {
-        return tl::make_unexpected(DatasetError::VariableNotFound);
+        return std::nullopt;
     }
     return it->second;
 }

--- a/test/source/implementation/details.cpp
+++ b/test/source/implementation/details.cpp
@@ -244,6 +244,10 @@ TEST_CASE("Dataset loading and access", "[core]")
         auto result = ds.GetVariable("Y");
         CHECK(result.has_value());
     }
+
+    SECTION("Missing variable lookup") {
+        CHECK_FALSE(ds.GetVariable("does-not-exist"));
+    }
 }
 
 TEST_CASE("PrimitiveSet configuration", "[core]")


### PR DESCRIPTION
## Summary
- represent an absent dataset variable as `std::optional` rather than a one-value `tl::expected` error type
- remove the redundant `DatasetError` type and dependency
- cover a missing variable lookup

## Verification
- `nix develop -c cmake --build build-package-components --target operon_test -j4`
- `build-package-components/test/operon_test "Dataset loading and access"`