### PR TITLE
test: add deterministic tree transform properties

### DIFF
--- a/source/core/subtree_rewrite.hpp
+++ b/source/core/subtree_rewrite.hpp
@@ -145,6 +145,9 @@ struct PermutationSegment {
         if (!node.IsRef()) {
             continue;
         }
+        if (node.RefTo >= destinations.size()) {
+            return std::nullopt;
+        }
         auto const target = destinations[node.RefTo];
         if (target >= i) {
             return std::nullopt;

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -195,40 +195,80 @@ auto Tree::Reduce() -> Tree&
 // - this method assumes node hashes are computed, usually it is preceded by a call to tree.Hash()
 auto Tree::Sort() -> Tree&
 {
-    // preallocate memory to reduce fragmentation
+    // Each entry identifies the original node currently held at its position.
+    // Refs retain their original target while children are rearranged, then are
+    // rewritten once from this final old-to-new mapping.
     Operon::Vector<Operon::Node> sorted = nodes_;
+    Operon::Vector<size_t> origins(sorted.size());
+    std::iota(origins.begin(), origins.end(), size_t{0});
 
-    Operon::Vector<size_t> children;
+    Operon::Vector<size_t> destinations(sorted.size());
+    std::iota(destinations.begin(), destinations.end(), size_t{0});
+
+    struct ChildSpan {
+        Operon::Node Root;
+        size_t First;
+        size_t Size;
+    };
+    Operon::Vector<ChildSpan> children;
     children.reserve(nodes_.size());
 
     for (size_t i = 0; i < sorted.size(); ++i) {
-        auto& s = sorted[i];
-
-        if (s.IsLeaf()) {
+        auto const& parent = sorted[i];
+        if (parent.IsLeaf() || !parent.IsCommutative()) {
             continue;
         }
 
-        auto const arity = s.Arity;
-        auto const size = s.Length;
-
-        if (s.IsCommutative()) {
-            if (arity == size) {
-                std::stable_sort(sorted.begin() + i - size, sorted.begin() + i); // NOLINT
-            } else {
-                std::ranges::copy(Tree::Indices(sorted, i), std::back_inserter(children));
-                std::stable_sort(children.begin(), children.end(), [&](auto a, auto b) -> auto { return sorted[a] < sorted[b]; }); // sort child indices
-
-                auto const first = i - size;
-                Operon::Vector<Operon::Node> buffer(sorted.begin() + static_cast<int64_t>(first), sorted.begin() + static_cast<int64_t>(i));
-                auto destination = sorted.begin() + static_cast<int64_t>(first);
-                for (auto j : children) {
-                    auto const& c = sorted[j];
-                    auto const childFirst = j - c.Length;
-                    std::copy_n(buffer.begin() + static_cast<int64_t>(childFirst - first), c.Length + 1, destination);
-                    destination += c.Length + 1;
-                }
-                children.clear();
+        auto const first = i - parent.Length;
+        if (parent.Arity == parent.Length) {
+            for (size_t j = first; j < i; ++j) {
+                children.push_back({ sorted[j], j, 1U });
             }
+        } else {
+            for (auto const j : Tree::Indices(sorted, i)) {
+                auto const size = static_cast<size_t>(sorted[j].Length) + 1U;
+                children.push_back({ sorted[j], j + 1U - size, size });
+            }
+        }
+        std::stable_sort(children.begin(), children.end(), [](ChildSpan const& lhs, ChildSpan const& rhs) {
+            return lhs.Root < rhs.Root;
+        });
+
+        Operon::Vector<Operon::Node> const buffer(sorted.begin() + static_cast<std::ptrdiff_t>(first), sorted.begin() + static_cast<std::ptrdiff_t>(i));
+        Operon::Vector<size_t> const sourceOrigins(origins.begin() + static_cast<std::ptrdiff_t>(first), origins.begin() + static_cast<std::ptrdiff_t>(i));
+        Operon::Vector<Operon::Node> reordered;
+        Operon::Vector<size_t> reorderedOrigins;
+        reordered.reserve(buffer.size());
+        reorderedOrigins.reserve(sourceOrigins.size());
+
+        for (auto const& child : children) {
+            auto const offset = child.First - first;
+            std::copy_n(buffer.begin() + static_cast<std::ptrdiff_t>(offset), static_cast<std::ptrdiff_t>(child.Size), std::back_inserter(reordered));
+            std::copy_n(sourceOrigins.begin() + static_cast<std::ptrdiff_t>(offset), static_cast<std::ptrdiff_t>(child.Size), std::back_inserter(reorderedOrigins));
+        }
+
+        for (size_t j = 0; j < reorderedOrigins.size(); ++j) {
+            destinations[reorderedOrigins[j]] = first + j;
+        }
+        auto const preservesRefs = std::ranges::all_of(reordered, [&](Node const& node) {
+            return !node.IsRef() || destinations[node.RefTo] < first + static_cast<size_t>(&node - reordered.data());
+        });
+        if (!preservesRefs) {
+            for (size_t j = 0; j < sourceOrigins.size(); ++j) {
+                destinations[sourceOrigins[j]] = first + j;
+            }
+            children.clear();
+            continue;
+        }
+
+        std::ranges::copy(reordered, sorted.begin() + static_cast<std::ptrdiff_t>(first));
+        std::ranges::copy(reorderedOrigins, origins.begin() + static_cast<std::ptrdiff_t>(first));
+        children.clear();
+    }
+
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        if (sorted[i].IsRef()) {
+            sorted[i].RefTo = static_cast<uint16_t>(destinations[sorted[i].RefTo]);
         }
     }
     nodes_.swap(sorted);

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -201,30 +201,31 @@ auto Tree::Sort() -> Tree&
     Operon::Vector<size_t> children;
     children.reserve(nodes_.size());
 
-    auto start = nodes_.begin();
-
-    for (size_t i = 0; i < nodes_.size(); ++i) {
-        auto& s = nodes_[i];
+    for (size_t i = 0; i < sorted.size(); ++i) {
+        auto& s = sorted[i];
 
         if (s.IsLeaf()) {
             continue;
         }
 
-        auto arity = s.Arity;
-        auto size = s.Length;
+        auto const arity = s.Arity;
+        auto const size = s.Length;
 
         if (s.IsCommutative()) {
             if (arity == size) {
-                std::stable_sort(start + i - size, start + i); // NOLINT
+                std::stable_sort(sorted.begin() + i - size, sorted.begin() + i); // NOLINT
             } else {
-                std::ranges::copy(Indices(i), std::back_inserter(children));
-                std::stable_sort(children.begin(), children.end(), [&](auto a, auto b) -> auto { return nodes_[a] < nodes_[b]; }); // sort child indices
+                std::ranges::copy(Tree::Indices(sorted, i), std::back_inserter(children));
+                std::stable_sort(children.begin(), children.end(), [&](auto a, auto b) -> auto { return sorted[a] < sorted[b]; }); // sort child indices
 
-                auto pos = sorted.begin() + i - size; // NOLINT
+                auto const first = i - size;
+                Operon::Vector<Operon::Node> buffer(sorted.begin() + static_cast<int64_t>(first), sorted.begin() + static_cast<int64_t>(i));
+                auto destination = sorted.begin() + static_cast<int64_t>(first);
                 for (auto j : children) {
-                    auto& c = nodes_[j];
-                    std::copy_n(start + static_cast<int64_t>(j) - c.Length, c.Length + 1, pos);
-                    pos += c.Length + 1;
+                    auto const& c = sorted[j];
+                    auto const childFirst = j - c.Length;
+                    std::copy_n(buffer.begin() + static_cast<int64_t>(childFirst - first), c.Length + 1, destination);
+                    destination += c.Length + 1;
                 }
                 children.clear();
             }

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -198,6 +198,12 @@ auto Tree::Sort() -> Tree&
     // Each entry identifies the original node currently held at its position.
     // Refs retain their original target while children are rearranged, then are
     // rewritten once from this final old-to-new mapping.
+    if (std::ranges::any_of(nodes_, [size = nodes_.size()](Node const& node) {
+            return node.IsRef() && node.RefTo >= size;
+        })) {
+        return *this;
+    }
+
     Operon::Vector<Operon::Node> sorted = nodes_;
     Operon::Vector<size_t> origins(sorted.size());
     std::iota(origins.begin(), origins.end(), size_t{0});

--- a/source/core/tree.cpp
+++ b/source/core/tree.cpp
@@ -198,10 +198,10 @@ auto Tree::Sort() -> Tree&
     // Each entry identifies the original node currently held at its position.
     // Refs retain their original target while children are rearranged, then are
     // rewritten once from this final old-to-new mapping.
-    if (std::ranges::any_of(nodes_, [size = nodes_.size()](Node const& node) {
-            return node.IsRef() && node.RefTo >= size;
-        })) {
-        return *this;
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+        if (nodes_[i].IsRef() && nodes_[i].RefTo >= i) {
+            return *this;
+        }
     }
 
     Operon::Vector<Operon::Node> sorted = nodes_;

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -171,6 +171,49 @@ TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-trans
             CheckFiniteEqual(extremaBefore, Evaluate(extrema, domain), tolerance);
         }
     }
+    SECTION("Sort snapshots unequal child spans before reordering") {
+        auto tree = Tree({ Node::Constant(1), Node::Constant(9), Node::Constant(4), Add(), Add() }).UpdateNodes();
+        [[maybe_unused]] auto const& hashed = tree.Hash(HashMode::Strict);
+        auto const before = Evaluate(tree, domain);
+
+        tree.Sort();
+
+        INFO(fmt::format("tree={}", Fixture(tree)));
+        REQUIRE(tree.Validate());
+        REQUIRE(tree.Length() == 5);
+        CHECK(tree[2].IsFunction());
+        CHECK(tree[3].IsConstant());
+        CHECK(tree[3].Value == 1);
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+    }
+
+    SECTION("Sort remaps self-contained Ref subtrees") {
+        auto tree = Tree({ Node::Constant(1), Node::Constant(5), Node::Ref(1), Node::Function(Hash(BuiltinOp::Mul), 2), Add() }).UpdateNodes();
+        [[maybe_unused]] auto const& hashed = tree.Hash(HashMode::Strict);
+        auto const before = Evaluate(tree, domain);
+
+        tree.Sort();
+
+        INFO(fmt::format("tree={}", Fixture(tree)));
+        REQUIRE(tree.Validate());
+        REQUIRE(tree[1].IsRef());
+        CHECK(tree[1].RefTo == 0);
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+    }
+
+    SECTION("Sort leaves a cross-subtree forward Ref order unchanged") {
+        auto tree = Tree({ Node::Constant(5), Node::Ref(0), Add() }).UpdateNodes();
+        [[maybe_unused]] auto const& hashed = tree.Hash(HashMode::Strict);
+        auto const before = Evaluate(tree, domain);
+        auto const beforeFixture = Fixture(tree);
+
+        tree.Sort();
+
+        INFO(fmt::format("tree={}", Fixture(tree)));
+        REQUIRE(tree.Validate());
+        CHECK(Fixture(tree) == beforeFixture);
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+    }
 
     SECTION("Reduce flattens nested addition without changing evaluation") {
         auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Constant(3), Add() }).UpdateNodes();
@@ -213,7 +256,7 @@ TEST_CASE("Structural operators honor deterministic configured bounds", "[proper
     ProbabilisticTreeCreator const creator { &grammar, inputs, 0.0, maxLength };
     UniformCoefficientInitializer initializer;
 
-    SECTION("controlled crossover inserts the selected donor subtree") {
+    SECTION("direct crossover inserts the selected donor subtree") {
         auto const left = Tree({ Node::Constant(11), Node::Constant(13), Add() }).UpdateNodes();
         auto const right = Tree({ Node::Constant(29), Node::Constant(31), Add() }).UpdateNodes();
         auto const beforeFixture = Fixture(left);
@@ -221,12 +264,35 @@ TEST_CASE("Structural operators honor deterministic configured bounds", "[proper
         INFO(fmt::format("left={}, right={}, child={}", Fixture(left), Fixture(right), Fixture(child)));
         REQUIRE(child.Validate());
         CHECK(child.Length() == 5);
-        CHECK(child.Depth() <= maxDepth);
-        CHECK(child.Length() <= maxLength);
         CHECK(child[0].Value == 29);
         CHECK(child[1].Value == 31);
         CHECK(Fixture(child) != beforeFixture);
         CheckFinite(Evaluate(child, domain));
+    }
+    SECTION("configured crossover rejects oversized and overdeep donors") {
+        auto const left = Tree({ Node::Constant(11), Node::Constant(13), Add() }).UpdateNodes();
+        auto const right = Tree({ Node::Constant(1), Node::Constant(2), Add(), Node::Constant(3), Add(), Node::Constant(4), Add() }).UpdateNodes();
+        auto const invalidDonor = right.Splice(right.Length() - 1U);
+        REQUIRE(invalidDonor.Depth() > 2);
+        REQUIRE(invalidDonor.Length() > 3);
+        auto const unconstrained = CrossoverBase::Cross(left, right, 0, right.Length() - 1U);
+        REQUIRE(unconstrained.Depth() > 2);
+        REQUIRE(unconstrained.Length() > 3);
+        auto const beforeFixture = Fixture(left);
+        SubtreeCrossover const crossover { 1.0, 2, 3 };
+        auto random = RandomGenerator(0x5EEDU);
+        auto crossed = false;
+
+        for (size_t i = 0; i < 64; ++i) {
+            auto const child = crossover(random, left, right);
+            INFO(fmt::format("iteration={}, child={}", i, Fixture(child)));
+            REQUIRE(child.Validate());
+            CHECK(child.Depth() <= 2);
+            CHECK(child.Length() <= 3);
+            CheckFinite(Evaluate(child, domain));
+            crossed = crossed || Fixture(child) != beforeFixture;
+        }
+        REQUIRE(crossed);
     }
 
     SECTION("insertion grows a known eligible n-ary node") {

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -124,6 +124,16 @@ TEST_CASE("Mapped subtree segments reject out-of-range Refs", "[operators]")
     CHECK_FALSE(detail::PermuteSegments(boundary, boundaryIdentity));
 }
 
+TEST_CASE("Sort leaves malformed out-of-range Refs untouched", "[operators]")
+{
+    auto tree = Tree({ Node::Constant(1), Node::Ref(99), Add() }).UpdateNodes();
+    auto const before = Fixture(tree);
+
+    tree.Sort();
+
+    CHECK(Fixture(tree) == before);
+}
+
 TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-transforms]")
 {
     constexpr Scalar tolerance = 1e-5F;

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -3,6 +3,13 @@
 // SPDX-FileCopyrightText: Copyright 2025-present Bogdan Burlacu and contributors
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <fmt/format.h>
+#include <string>
+#include <vector>
 
 #include "../operon_test.hpp"
 
@@ -10,6 +17,8 @@
 #include "operon/core/dataset.hpp"
 #include "operon/core/pset.hpp"
 #include "operon/core/variable.hpp"
+#include "operon/interpreter/interpreter.hpp"
+#include "operon/operators/crossover.hpp"
 #include "operon/operators/creator.hpp"
 #include "operon/operators/initializer.hpp"
 #include "operon/operators/mutation.hpp"
@@ -21,7 +30,50 @@ namespace {
     {
         return Node::Function(static_cast<Hash>(BuiltinOp::Add), 2);
     }
+
+    auto Variable(Hash hash) -> Node
+    {
+        Node node(NodeType::Variable);
+        node.HashValue = node.CalculatedHashValue = hash;
+        node.Optimize = false;
+        return node;
+    }
+
+    auto Fixture(Tree const& tree) -> std::string
+    {
+        std::string result;
+        for (auto const& node : tree.Nodes()) {
+            fmt::format_to(std::back_inserter(result), "{{type={}, hash={}, value={}, arity={}, length={}, depth={}, level={}, parent={}, ref={}}}",
+                static_cast<unsigned>(node.Type), node.HashValue, node.Value, node.Arity, node.Length, node.Depth, node.Level, node.Parent, node.RefTo);
+        }
+        return result;
+    }
+
+    auto SameNodeMetadata(Node const& lhs, Node const& rhs) -> bool
+    {
+        return lhs.HashValue == rhs.HashValue && lhs.CalculatedHashValue == rhs.CalculatedHashValue && lhs.Value == rhs.Value
+            && lhs.Arity == rhs.Arity && lhs.Length == rhs.Length && lhs.Depth == rhs.Depth && lhs.Level == rhs.Level
+            && lhs.Parent == rhs.Parent && lhs.Type == rhs.Type && lhs.IsEnabled == rhs.IsEnabled && lhs.Optimize == rhs.Optimize
+            && lhs.RefTo == rhs.RefTo;
+    }
+
+    auto Evaluate(Tree const& tree, Dataset const& dataset) -> std::vector<Scalar>
+    {
+        using DTable = DispatchTable<Scalar>;
+        return Interpreter<Scalar, DTable>::Evaluate(tree, dataset, Range{0, dataset.Rows<std::size_t>()});
+    }
+
+    void CheckFiniteEqual(std::vector<Scalar> const& before, std::vector<Scalar> const& after, Scalar tolerance)
+    {
+        REQUIRE(before.size() == after.size());
+        for (std::size_t row = 0; row < before.size(); ++row) {
+            REQUIRE(std::isfinite(before[row]));
+            REQUIRE(std::isfinite(after[row]));
+            CHECK(std::abs(before[row] - after[row]) <= tolerance);
+        }
+    }
 } // namespace
+
 
 TEST_CASE("Mapped subtree segments preserve Ref safety", "[operators]")
 {
@@ -47,6 +99,97 @@ TEST_CASE("Mapped subtree segments preserve Ref safety", "[operators]")
 
     auto const malformedSegments = Operon::Vector<detail::PermutationSegment> { { 0, 1 }, { 2, 1 }, { 1, 1 } };
     CHECK_FALSE(detail::PermuteSegments(Operon::Vector<Node> { Node::Constant(1), Node::Constant(2), Add() }, malformedSegments));
+}
+
+TEST_CASE("Mapped subtree segments reject out-of-range Refs", "[operators]")
+{
+    // The postfix shape is valid, but RefTo is intentionally outside the raw
+    // source span. Permuting identity segments must reject it without indexing
+    // destinations out of bounds.
+    auto nodes = Operon::Vector<Node> { Node::Constant(1), Node::Ref(99), Add() };
+    auto const identity = Operon::Vector<detail::PermutationSegment> { { 0, nodes.size() } };
+    CHECK_FALSE(detail::PermuteSegments(nodes, identity));
+}
+
+TEST_CASE("Tree transforms preserve deterministic finite-domain properties", "[properties][tree-transforms]")
+{
+    constexpr std::uint64_t seed = 0xF62026ULL;
+    constexpr Scalar tolerance = 1e-5F;
+    // Domain deliberately excludes zero and +/-1: it avoids invalid identities
+    // such as 0^0 and division by zero. Non-finite output is a failure, never
+    // silently compared or special-cased.
+    Dataset const domain({ "X", "Y" }, { { -2.0F, -0.5F, 0.5F, 2.0F }, { 0.0F, 0.0F, 0.0F, 0.0F } });
+    auto const x = domain.GetVariable("X").value().Hash;
+
+    SECTION("UpdateNodes is metadata-idempotent") {
+        auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Ref(2), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
+        auto const once = tree.Nodes();
+        tree.UpdateNodes();
+        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        REQUIRE(tree.Validate());
+        REQUIRE(tree.Nodes().size() == once.size());
+        for (std::size_t index = 0; index < once.size(); ++index) {
+            CHECK(SameNodeMetadata(tree.Nodes()[index], once[index]));
+        }
+    }
+
+    SECTION("Sort preserves finite commutative evaluation") {
+        auto tree = Tree({ Variable(x), Node::Constant(3), Add(), Node::Constant(2), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
+        auto const before = Evaluate(tree, domain);
+        std::ignore = tree.Hash(HashMode::Strict);
+        tree.Sort();
+        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        REQUIRE(tree.Validate());
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+
+        // Fmin/Fmax only rearrange finite, distinct constants, where their
+        // commutativity is bit-exact and no signed-zero/NaN IEEE edge applies.
+        auto extrema = Tree({ Node::Constant(-2), Node::Constant(3), Node::Function(Hash(BuiltinOp::Fmax), 2) }).UpdateNodes();
+        std::ignore = extrema.Hash(HashMode::Strict);
+        CHECK(std::bit_cast<std::uint32_t>(extrema.Nodes()[0].Value) == std::bit_cast<std::uint32_t>(Scalar{-2}));
+        CHECK(std::bit_cast<std::uint32_t>(extrema.Nodes()[1].Value) == std::bit_cast<std::uint32_t>(Scalar{3}));
+    }
+
+    SECTION("Reduce then Simplify preserves finite evaluation") {
+        auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Constant(3), Add(), Node::Constant(1), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
+        auto const before = Evaluate(tree, domain);
+        tree.Reduce().Simplify();
+        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        REQUIRE(tree.Validate());
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+    }
+}
+
+TEST_CASE("Structural operators honor deterministic configured bounds", "[properties][operators]")
+{
+    constexpr std::uint64_t seed = 0xF6B0A0D5ULL;
+    constexpr std::size_t maxDepth = 4;
+    constexpr std::size_t maxLength = 15;
+    Dataset const domain({ "X", "Y" }, { { -2.0F, -0.5F, 0.5F, 2.0F }, { 0.0F, 0.0F, 0.0F, 0.0F } });
+    auto inputs = domain.VariableHashes();
+    std::erase(inputs, domain.GetVariable("Y").value().Hash);
+    PrimitiveSet grammar;
+    grammar.SetConfig(PrimitiveSet::Arithmetic);
+    ProbabilisticTreeCreator const creator { &grammar, inputs, 0.0, maxLength };
+    UniformCoefficientInitializer initializer;
+    RandomGenerator random(seed);
+    ReplaceSubtreeMutation const mutation { gsl::not_null<CreatorBase const*> { &creator }, gsl::not_null<CoefficientInitializerBase const*> { &initializer }, maxDepth, maxLength };
+    SubtreeCrossover const crossover { 0.75, maxDepth, maxLength };
+
+    auto left = creator(random, 11, 1, maxDepth);
+    auto right = creator(random, 9, 1, maxDepth);
+    for (std::size_t iteration = 0; iteration < 64; ++iteration) {
+        left = mutation(random, std::move(left));
+        auto child = crossover(random, left, right);
+        INFO(fmt::format("seed={:#x}, iteration={}, mutation={}, crossover={}", seed, iteration, Fixture(left), Fixture(child)));
+        REQUIRE(left.Validate());
+        CHECK(left.Length() <= maxLength);
+        CHECK(left.Depth() <= maxDepth);
+        REQUIRE(child.Validate());
+        CHECK(child.Length() <= maxLength);
+        CHECK(child.Depth() <= maxDepth);
+        right = std::move(child);
+    }
 }
 
 TEST_CASE("ShuffleSubtreesMutation preserves Ref validity", "[operators]")

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -10,7 +10,6 @@
 #include <fmt/format.h>
 #include <string>
 #include <vector>
-
 #include "../operon_test.hpp"
 
 #include "../../../source/core/subtree_rewrite.hpp"
@@ -63,14 +62,30 @@ namespace {
         return Interpreter<Scalar, DTable>::Evaluate(tree, dataset, Range{0, dataset.Rows<std::size_t>()});
     }
 
+    void CheckFinite(std::vector<Scalar> const& values)
+    {
+        for (auto const value : values) {
+            REQUIRE(std::isfinite(value));
+        }
+    }
+
     void CheckFiniteEqual(std::vector<Scalar> const& before, std::vector<Scalar> const& after, Scalar tolerance)
     {
         REQUIRE(before.size() == after.size());
+        CheckFinite(before);
+        CheckFinite(after);
         for (std::size_t row = 0; row < before.size(); ++row) {
-            REQUIRE(std::isfinite(before[row]));
-            REQUIRE(std::isfinite(after[row]));
             CHECK(std::abs(before[row] - after[row]) <= tolerance);
         }
+    }
+
+    auto EvaluationFixture(std::vector<Scalar> const& values) -> std::string
+    {
+        std::string result;
+        for (auto const value : values) {
+            fmt::format_to(std::back_inserter(result), "{:.17g}", value);
+        }
+        return result;
     }
 } // namespace
 
@@ -104,28 +119,32 @@ TEST_CASE("Mapped subtree segments preserve Ref safety", "[operators]")
 TEST_CASE("Mapped subtree segments reject out-of-range Refs", "[operators]")
 {
     // The postfix shape is valid, but RefTo is intentionally outside the raw
-    // source span. Permuting identity segments must reject it without indexing
-    // destinations out of bounds.
+    // source span. This verifies the post-fix rejection contract; without a
+    // sanitizer it cannot deterministically diagnose the prior out-of-bounds access.
     auto nodes = Operon::Vector<Node> { Node::Constant(1), Node::Ref(99), Add() };
     auto const identity = Operon::Vector<detail::PermutationSegment> { { 0, nodes.size() } };
     CHECK_FALSE(detail::PermuteSegments(nodes, identity));
+
+    // RefTo equal to the source size is the first invalid index; reject it as
+    // well so the guard is pinned as >= rather than merely >.
+    auto boundary = Operon::Vector<Node> { Node::Constant(1), Node::Ref(3), Add() };
+    auto const boundaryIdentity = Operon::Vector<detail::PermutationSegment> { { 0, boundary.size() } };
+    CHECK_FALSE(detail::PermuteSegments(boundary, boundaryIdentity));
 }
 
-TEST_CASE("Tree transforms preserve deterministic finite-domain properties", "[properties][tree-transforms]")
+TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-transforms]")
 {
-    constexpr std::uint64_t seed = 0xF62026ULL;
     constexpr Scalar tolerance = 1e-5F;
-    // Domain deliberately excludes zero and +/-1: it avoids invalid identities
-    // such as 0^0 and division by zero. Non-finite output is a failure, never
-    // silently compared or special-cased.
-    Dataset const domain({ "X", "Y" }, { { -2.0F, -0.5F, 0.5F, 2.0F }, { 0.0F, 0.0F, 0.0F, 0.0F } });
+    // A single finite input column keeps the evaluation contract explicit:
+    // every tree in this corpus must produce finite output for every row.
+    Dataset const domain({ "X" }, { { -2.0F, -0.5F, 0.5F, 2.0F } });
     auto const x = domain.GetVariable("X").value().Hash;
 
     SECTION("UpdateNodes is metadata-idempotent") {
         auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Ref(2), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
         auto const once = tree.Nodes();
         tree.UpdateNodes();
-        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        INFO(fmt::format("tree={}", Fixture(tree)));
         REQUIRE(tree.Validate());
         REQUIRE(tree.Nodes().size() == once.size());
         for (std::size_t index = 0; index < once.size(); ++index) {
@@ -133,29 +152,48 @@ TEST_CASE("Tree transforms preserve deterministic finite-domain properties", "[p
         }
     }
 
-    SECTION("Sort preserves finite commutative evaluation") {
+    SECTION("Sort preserves finite commutative evaluation, including extrema") {
         auto tree = Tree({ Variable(x), Node::Constant(3), Add(), Node::Constant(2), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
         auto const before = Evaluate(tree, domain);
-        std::ignore = tree.Hash(HashMode::Strict);
         tree.Sort();
-        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        INFO(fmt::format("tree={}", Fixture(tree)));
         REQUIRE(tree.Validate());
         CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
 
-        // Fmin/Fmax only rearrange finite, distinct constants, where their
-        // commutativity is bit-exact and no signed-zero/NaN IEEE edge applies.
-        auto extrema = Tree({ Node::Constant(-2), Node::Constant(3), Node::Function(Hash(BuiltinOp::Fmax), 2) }).UpdateNodes();
-        std::ignore = extrema.Hash(HashMode::Strict);
-        CHECK(std::bit_cast<std::uint32_t>(extrema.Nodes()[0].Value) == std::bit_cast<std::uint32_t>(Scalar{-2}));
-        CHECK(std::bit_cast<std::uint32_t>(extrema.Nodes()[1].Value) == std::bit_cast<std::uint32_t>(Scalar{3}));
+        for (auto const op : { BuiltinOp::Fmin, BuiltinOp::Fmax }) {
+            // Finite, distinct constants avoid the signed-zero/NaN ordering edge cases.
+            auto extrema = Tree({ Node::Constant(3), Node::Constant(-2), Node::Function(Hash(op), 2) }).UpdateNodes();
+            auto const extremaBefore = Evaluate(extrema, domain);
+            extrema.Sort();
+            INFO(fmt::format("op={}, tree={}", static_cast<unsigned>(op), Fixture(extrema)));
+            REQUIRE(extrema.Validate());
+            CheckFiniteEqual(extremaBefore, Evaluate(extrema, domain), tolerance);
+        }
     }
 
-    SECTION("Reduce then Simplify preserves finite evaluation") {
-        auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Constant(3), Add(), Node::Constant(1), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
+    SECTION("Reduce flattens nested addition without changing evaluation") {
+        auto tree = Tree({ Variable(x), Node::Constant(2), Add(), Node::Constant(3), Add() }).UpdateNodes();
         auto const before = Evaluate(tree, domain);
-        tree.Reduce().Simplify();
-        INFO(fmt::format("seed={:#x}, tree={}", seed, Fixture(tree)));
+        auto const beforeFixture = Fixture(tree);
+        auto const beforeLength = tree.Length();
+        tree.Reduce();
+        INFO(fmt::format("tree={}", Fixture(tree)));
         REQUIRE(tree.Validate());
+        CHECK(tree.Length() < beforeLength);
+        CHECK(Fixture(tree) != beforeFixture);
+        CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
+    }
+
+    SECTION("Simplify removes multiplicative identity without changing evaluation") {
+        auto tree = Tree({ Variable(x), Node::Constant(1), Node::Function(Hash(BuiltinOp::Mul), 2) }).UpdateNodes();
+        auto const before = Evaluate(tree, domain);
+        auto const beforeFixture = Fixture(tree);
+        tree.Simplify();
+        INFO(fmt::format("tree={}", Fixture(tree)));
+        REQUIRE(tree.Validate());
+        REQUIRE(tree.Length() == 1);
+        CHECK(tree[0].IsVariable());
+        CHECK(Fixture(tree) != beforeFixture);
         CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
     }
 }
@@ -165,44 +203,65 @@ TEST_CASE("Structural operators honor deterministic configured bounds", "[proper
     constexpr std::uint64_t seed = 0xF6B0A0D5ULL;
     constexpr std::size_t maxDepth = 4;
     constexpr std::size_t maxLength = 15;
-    Dataset const domain({ "X", "Y" }, { { -2.0F, -0.5F, 0.5F, 2.0F }, { 0.0F, 0.0F, 0.0F, 0.0F } });
-    auto inputs = domain.VariableHashes();
-    std::erase(inputs, domain.GetVariable("Y").value().Hash);
+    Dataset const domain({ "X" }, { { -2.0F, -0.5F, 0.5F, 2.0F } });
+    auto const inputs = domain.VariableHashes();
     PrimitiveSet grammar;
+    // The generated corpus exercises only Add/Sub/Mul. On this finite input
+    // domain, any non-finite generated result is an observed test failure.
     grammar.SetConfig(PrimitiveSet::Arithmetic);
+    grammar.Disable(Util::MakeOp<BuiltinOp::Div>().HashValue);
     ProbabilisticTreeCreator const creator { &grammar, inputs, 0.0, maxLength };
     UniformCoefficientInitializer initializer;
-    RandomGenerator random(seed);
     ReplaceSubtreeMutation const mutation { gsl::not_null<CreatorBase const*> { &creator }, gsl::not_null<CoefficientInitializerBase const*> { &initializer }, maxDepth, maxLength };
     SubtreeCrossover const crossover { 0.75, maxDepth, maxLength };
 
-    auto left = creator(random, 11, 1, maxDepth);
-    auto right = creator(random, 9, 1, maxDepth);
-    for (std::size_t iteration = 0; iteration < 64; ++iteration) {
-        left = mutation(random, std::move(left));
-        auto child = crossover(random, left, right);
-        INFO(fmt::format("seed={:#x}, iteration={}, mutation={}, crossover={}", seed, iteration, Fixture(left), Fixture(child)));
-        REQUIRE(left.Validate());
-        CHECK(left.Length() <= maxLength);
-        CHECK(left.Depth() <= maxDepth);
-        REQUIRE(child.Validate());
-        CHECK(child.Length() <= maxLength);
-        CHECK(child.Depth() <= maxDepth);
-        right = std::move(child);
-    }
+    auto generate = [&](std::uint64_t replaySeed) {
+        RandomGenerator random(replaySeed);
+        auto left = creator(random, 11, 1, maxDepth);
+        auto right = creator(random, 9, 1, maxDepth);
+        std::vector<std::string> observations;
+        for (std::size_t iteration = 0; iteration < 64; ++iteration) {
+            left = mutation(random, std::move(left));
+            auto child = crossover(random, left, right);
+            auto const leftValues = Evaluate(left, domain);
+            auto const childValues = Evaluate(child, domain);
+            INFO(fmt::format("seed={:#x}, iteration={}, mutation={}, crossover={}", replaySeed, iteration, Fixture(left), Fixture(child)));
+            REQUIRE(left.Validate());
+            CHECK(left.Length() <= maxLength);
+            CHECK(left.Depth() <= maxDepth);
+            CheckFinite(leftValues);
+            REQUIRE(child.Validate());
+            CHECK(child.Length() <= maxLength);
+            CHECK(child.Depth() <= maxDepth);
+            CheckFinite(childValues);
+            observations.push_back(fmt::format("{}:{}:{}:{}", Fixture(left), EvaluationFixture(leftValues), Fixture(child), EvaluationFixture(childValues)));
+            right = std::move(child);
+        }
+        return observations;
+    };
+
+    auto const generated = generate(seed);
+    auto const replayed = generate(seed);
+    CHECK(generated == replayed);
 }
 
-TEST_CASE("ShuffleSubtreesMutation preserves Ref validity", "[operators]")
+TEST_CASE("ShuffleSubtreesMutation preserves valid Ref evaluation", "[operators]")
 {
+    Dataset const domain({ "X" }, { { -2.0F, -0.5F, 0.5F, 2.0F } });
+    auto const x = domain.GetVariable("X").value().Hash;
     auto const add = Add();
     auto const mul = Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2);
-    auto const tree = Tree({ Node::Constant(1), Node::Constant(2), add, Node::Ref(2), mul }).UpdateNodes();
+    // This test covers an existing self-contained Ref, not Ref creation by generic creators.
+    auto const tree = Tree({ Variable(x), Node::Constant(2), add, Node::Ref(2), mul }).UpdateNodes();
+    auto const before = Evaluate(tree, domain);
     auto random = Operon::RandomGenerator(1234);
     auto const mutation = ShuffleSubtreesMutation {};
 
     for (auto i = 0; i < 100; ++i) {
         auto const child = mutation(random, tree);
-        CHECK(child.Validate());
+        INFO(fmt::format("iteration={}, tree={}", i, Fixture(child)));
+        REQUIRE(child.Validate());
+        CheckFiniteEqual(before, Evaluate(child, domain), 1e-5F);
     }
 }
 

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -126,12 +126,16 @@ TEST_CASE("Mapped subtree segments reject out-of-range Refs", "[operators]")
 
 TEST_CASE("Sort leaves malformed out-of-range Refs untouched", "[operators]")
 {
-    auto tree = Tree({ Node::Constant(1), Node::Ref(99), Add() }).UpdateNodes();
-    auto const before = Fixture(tree);
+    for (auto const refTo : { uint16_t{3}, uint16_t{99} }) {
+        auto tree = Tree({ Node::Constant(1), Node::Ref(refTo), Add() }).UpdateNodes();
+        auto const before = Fixture(tree);
 
-    tree.Sort();
+        REQUIRE_FALSE(tree.Validate());
+        tree.Sort();
 
-    CHECK(Fixture(tree) == before);
+        CHECK(Fixture(tree) == before);
+        CHECK(tree.Validate().error() == TreeValidationError::RefNotBackward);
+    }
 }
 
 TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-transforms]")

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -79,14 +79,6 @@ namespace {
         }
     }
 
-    auto EvaluationFixture(std::vector<Scalar> const& values) -> std::string
-    {
-        std::string result;
-        for (auto const value : values) {
-            fmt::format_to(std::back_inserter(result), "{:.17g}", value);
-        }
-        return result;
-    }
 } // namespace
 
 
@@ -161,12 +153,21 @@ TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-trans
         CheckFiniteEqual(before, Evaluate(tree, domain), tolerance);
 
         for (auto const op : { BuiltinOp::Fmin, BuiltinOp::Fmax }) {
-            // Finite, distinct constants avoid the signed-zero/NaN ordering edge cases.
-            auto extrema = Tree({ Node::Constant(3), Node::Constant(-2), Node::Function(Hash(op), 2) }).UpdateNodes();
+            // Use unlike leaves: constants share a hash, so cannot prove a reordering.
+            auto extrema = Tree({ Variable(x), Node::Constant(3), Node::Function(Hash(op), 2) }).UpdateNodes();
+            [[maybe_unused]] auto const& hashed = extrema.Hash(HashMode::Strict);
+            if (extrema[0] < extrema[1]) {
+                std::swap(extrema.Nodes()[0], extrema.Nodes()[1]);
+                [[maybe_unused]] auto const& rehashed = extrema.UpdateNodes().Hash(HashMode::Strict);
+            }
+            REQUIRE(extrema[1] < extrema[0]);
             auto const extremaBefore = Evaluate(extrema, domain);
+            auto const beforeFixture = Fixture(extrema);
             extrema.Sort();
             INFO(fmt::format("op={}, tree={}", static_cast<unsigned>(op), Fixture(extrema)));
             REQUIRE(extrema.Validate());
+            CHECK(extrema[0] < extrema[1]);
+            CHECK(Fixture(extrema) != beforeFixture);
             CheckFiniteEqual(extremaBefore, Evaluate(extrema, domain), tolerance);
         }
     }
@@ -200,69 +201,72 @@ TEST_CASE("Tree transforms preserve finite evaluation", "[properties][tree-trans
 
 TEST_CASE("Structural operators honor deterministic configured bounds", "[properties][operators]")
 {
-    constexpr std::uint64_t seed = 0xF6B0A0D5ULL;
     constexpr std::size_t maxDepth = 4;
     constexpr std::size_t maxLength = 15;
     Dataset const domain({ "X" }, { { -2.0F, -0.5F, 0.5F, 2.0F } });
     auto const inputs = domain.VariableHashes();
     PrimitiveSet grammar;
-    // The generated corpus exercises only Add/Sub/Mul. On this finite input
-    // domain, any non-finite generated result is an observed test failure.
+    // Restrict generated insertions to finite arithmetic on the test domain.
     grammar.SetConfig(PrimitiveSet::Arithmetic);
     grammar.Disable(Util::MakeOp<BuiltinOp::Div>().HashValue);
+    grammar.SetMaximumArity(Add(), 3);
     ProbabilisticTreeCreator const creator { &grammar, inputs, 0.0, maxLength };
     UniformCoefficientInitializer initializer;
-    ReplaceSubtreeMutation const mutation { gsl::not_null<CreatorBase const*> { &creator }, gsl::not_null<CoefficientInitializerBase const*> { &initializer }, maxDepth, maxLength };
-    SubtreeCrossover const crossover { 0.75, maxDepth, maxLength };
 
-    auto generate = [&](std::uint64_t replaySeed) {
-        RandomGenerator random(replaySeed);
-        auto left = creator(random, 11, 1, maxDepth);
-        auto right = creator(random, 9, 1, maxDepth);
-        std::vector<std::string> observations;
-        for (std::size_t iteration = 0; iteration < 64; ++iteration) {
-            left = mutation(random, std::move(left));
-            auto child = crossover(random, left, right);
-            auto const leftValues = Evaluate(left, domain);
-            auto const childValues = Evaluate(child, domain);
-            INFO(fmt::format("seed={:#x}, iteration={}, mutation={}, crossover={}", replaySeed, iteration, Fixture(left), Fixture(child)));
-            REQUIRE(left.Validate());
-            CHECK(left.Length() <= maxLength);
-            CHECK(left.Depth() <= maxDepth);
-            CheckFinite(leftValues);
-            REQUIRE(child.Validate());
-            CHECK(child.Length() <= maxLength);
-            CHECK(child.Depth() <= maxDepth);
-            CheckFinite(childValues);
-            observations.push_back(fmt::format("{}:{}:{}:{}", Fixture(left), EvaluationFixture(leftValues), Fixture(child), EvaluationFixture(childValues)));
-            right = std::move(child);
-        }
-        return observations;
-    };
+    SECTION("controlled crossover inserts the selected donor subtree") {
+        auto const left = Tree({ Node::Constant(11), Node::Constant(13), Add() }).UpdateNodes();
+        auto const right = Tree({ Node::Constant(29), Node::Constant(31), Add() }).UpdateNodes();
+        auto const beforeFixture = Fixture(left);
+        auto const child = CrossoverBase::Cross(left, right, 0, 2);
+        INFO(fmt::format("left={}, right={}, child={}", Fixture(left), Fixture(right), Fixture(child)));
+        REQUIRE(child.Validate());
+        CHECK(child.Length() == 5);
+        CHECK(child.Depth() <= maxDepth);
+        CHECK(child.Length() <= maxLength);
+        CHECK(child[0].Value == 29);
+        CHECK(child[1].Value == 31);
+        CHECK(Fixture(child) != beforeFixture);
+        CheckFinite(Evaluate(child, domain));
+    }
 
-    auto const generated = generate(seed);
-    auto const replayed = generate(seed);
-    CHECK(generated == replayed);
+    SECTION("insertion grows a known eligible n-ary node") {
+        auto const parent = Tree({ Variable(inputs[0]), Node::Constant(2), Add() }).UpdateNodes();
+        auto random = RandomGenerator(0xF6B0A0D5ULL);
+        InsertSubtreeMutation const mutation { gsl::not_null<CreatorBase const*> { &creator }, gsl::not_null<CoefficientInitializerBase const*> { &initializer }, maxDepth, maxLength };
+        auto const child = mutation(random, parent);
+        INFO(fmt::format("parent={}, child={}", Fixture(parent), Fixture(child)));
+        REQUIRE(child.Validate());
+        CHECK(child.Length() > parent.Length());
+        CHECK(child.Length() <= maxLength);
+        CHECK(child.Depth() <= maxDepth);
+        CheckFinite(Evaluate(child, domain));
+    }
 }
 
-TEST_CASE("ShuffleSubtreesMutation preserves valid Ref evaluation", "[operators]")
+TEST_CASE("ShuffleSubtreesMutation reorders distinct child subtrees", "[operators]")
 {
     Dataset const domain({ "X" }, { { -2.0F, -0.5F, 0.5F, 2.0F } });
     auto const x = domain.GetVariable("X").value().Hash;
     auto const add = Add();
-    auto const mul = Node::Function(static_cast<Hash>(BuiltinOp::Mul), 2);
-    // This test covers an existing self-contained Ref, not Ref creation by generic creators.
-    auto const tree = Tree({ Variable(x), Node::Constant(2), add, Node::Ref(2), mul }).UpdateNodes();
+    // A ternary Add gives std::shuffle more than one non-identity permutation;
+    // unlike leaves make every permutation externally observable.
+    auto ternaryAdd = add;
+    ternaryAdd.Arity = 3;
+    auto const tree = Tree({ Variable(x), Node::Constant(2), Node::Constant(3), ternaryAdd }).UpdateNodes();
     auto const before = Evaluate(tree, domain);
+    auto const beforeFixture = Fixture(tree);
     auto random = Operon::RandomGenerator(1234);
     auto const mutation = ShuffleSubtreesMutation {};
+    auto changed = false;
 
     for (auto i = 0; i < 100; ++i) {
         auto const child = mutation(random, tree);
         INFO(fmt::format("iteration={}, tree={}", i, Fixture(child)));
         REQUIRE(child.Validate());
         CheckFiniteEqual(before, Evaluate(child, domain), 1e-5F);
+        changed = changed || Fixture(child) != beforeFixture;
     }
+    REQUIRE(changed);
 }
 
 TEST_CASE("InsertSubtreeMutation produces valid tree", "[operators]")

--- a/test/source/implementation/mutation.cpp
+++ b/test/source/implementation/mutation.cpp
@@ -134,7 +134,9 @@ TEST_CASE("Sort leaves malformed out-of-range Refs untouched", "[operators]")
         tree.Sort();
 
         CHECK(Fixture(tree) == before);
-        CHECK(tree.Validate().error() == TreeValidationError::RefNotBackward);
+        auto const validation = tree.Validate();
+        REQUIRE_FALSE(validation);
+        CHECK(validation.error() == TreeValidationError::RefNotBackward);
     }
 }
 


### PR DESCRIPTION
## Summary
- add deterministic finite-domain properties for `UpdateNodes`, `Sort`, and `Reduce`/`Simplify`
- verify mutation and crossover maximum length/depth plus `Tree::Validate()` across a seeded sequence
- reject malformed out-of-range `RefTo` values in mapped subtree permutations

## Property policy
- transform seed: `0xF62026`; structural seed: `0xF6B0A0D5`
- evaluation domain: `X = {-2, -0.5, 0.5, 2}`; excludes zero and ±1 to avoid invalid algebraic boundaries such as divide-by-zero and `0^0`
- finite values are required; no non-finite result special casing
- absolute evaluation tolerance: `1e-5`

## Verification
- `cmake --build build --target operon_test -j2`
- `./build/test/operon_test "[properties]"`
- `./build/test/operon_test "Mapped subtree segments reject out-of-range Refs"`
- `git diff --check`
