### PR TITLE
Add replayable SRBench benchmark reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ scratch/
 tools/__pycache__/
 tools/results/
 tools/*.py
+!tools/run_srbench.py
 tools/*.sh
 tools/*.yaml
 tools/*.txt

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -68,6 +68,7 @@ auto MakeCoeffAndMutation(bool symbolic)
 auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
 {
     auto opts = Operon::InitOptions("operon_gp", "Genetic programming symbolic regression");
+    opts.add_options()("report-json", "Write a versioned lossless machine-readable report to this path", cxxopts::value<std::string>());
     auto result = Operon::ParseOptions(std::move(opts), argc, argv);
 
     // parse and set default values

--- a/cli/source/operon_gp.cpp
+++ b/cli/source/operon_gp.cpp
@@ -393,7 +393,12 @@ auto main(int argc, char** argv) -> int // NOLINT(bugprone-exception-escape)
                                                            : shapeViolationStorage->Measure(best.Genotype).Feasible;
             fmt::print(stderr, "shape-constraints: final model is {}\n", feasible ? "feasible" : "INFEASIBLE (not certified over the domain box)");
         }
-        fmt::print("{:infix:roundtrip}\n", Operon::Fmt::WithNames{best.Genotype, *problem.GetDataset()});
+        auto const model = fmt::format("{:infix:roundtrip}", Operon::Fmt::WithNames{best.Genotype, *problem.GetDataset()});
+        fmt::print("{}\n", model);
+        if (result.contains("report-json")) {
+            reporter.SetSymbolicModel(model);
+            Operon::WriteMachineReport(reporter.GetMachineReport(), result["report-json"].as<std::string>());
+        }
     } catch (std::exception& e) {
         fmt::print(stderr, "error: {}\n", e.what());
         return EXIT_FAILURE;

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -8,7 +8,6 @@
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
-#include <unistd.h>
 #include <fmt/format.h>
 #include <operon/algorithms/ga_base.hpp>
 #include <operon/algorithms/phase_timer.hpp>
@@ -68,7 +67,7 @@ inline auto WriteMachineReport(MachineReport const& report, std::filesystem::pat
     auto encoded = glz::write_json(report);
     if (!encoded) { throw std::runtime_error("machine report JSON serialization failed"); }
     auto tmp = path;
-    tmp += ".tmp-" + std::to_string(static_cast<unsigned long long>(::getpid()));
+    tmp += ".tmp-" + std::to_string(static_cast<unsigned long long>(std::chrono::steady_clock::now().time_since_epoch().count()));
     std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
     if (!out) { throw std::runtime_error("could not open machine report temporary file"); }
     out << *encoded << '\n';

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -17,6 +17,7 @@ namespace Operon {
 
 using ModelSelectorFn = std::function<Individual(Span<Individual const>)>;
 
+
 template<typename Evaluator>
 class Reporter {
     gsl::not_null<Evaluator const*> evaluator_;
@@ -111,6 +112,8 @@ public:
 
         double r2Train{};
         double r2Test{};
+        double mseTrain{};
+        double mseTest{};
         double nmseTrain{};
         double nmseTest{};
         double maeTrain{};
@@ -121,10 +124,10 @@ public:
             // negate the R2 because this is an internal fitness measure (minimization) which we here repurpose
             r2Train = -Operon::R2{}(estimatedTrain, targetTrain);
             r2Test = -Operon::R2{}(estimatedTest, targetTest);
-
+            mseTrain = Operon::MSE{}(estimatedTrain, targetTrain);
+            mseTest = Operon::MSE{}(estimatedTest, targetTest);
             nmseTrain = Operon::NMSE{}(estimatedTrain, targetTrain);
             nmseTest = Operon::NMSE{}(estimatedTest, targetTest);
-
             maeTrain = Operon::MAE{}(estimatedTrain, targetTrain);
             maeTest = Operon::MAE{}(estimatedTest, targetTest);
         }).name("calc stats");
@@ -163,6 +166,8 @@ public:
             T{ "mae_te", maeTest, format },
             T{ "nmse_tr", nmseTrain, format },
             T{ "nmse_te", nmseTest, format },
+            T{ "mse_tr", mseTrain, format },
+            T{ "mse_te", mseTest, format },
             T{ "best_fit", best_[idx], format },
             T{ "avg_fit", avgQuality, format },
             T{ "best_len", best_.Genotype.Length(), format },

--- a/cli/source/reporter.hpp
+++ b/cli/source/reporter.hpp
@@ -4,16 +4,80 @@
 #ifndef OPERON_CLI_REPORTER_HPP
 #define OPERON_CLI_REPORTER_HPP
 
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <unistd.h>
 #include <fmt/format.h>
 #include <operon/algorithms/ga_base.hpp>
 #include <operon/algorithms/phase_timer.hpp>
 #include <operon/operators/linear_scaling.hpp>
+#include <functional>
+#include <string>
+#include <cstdint>
+#include <taskflow/taskflow.hpp>
+#include <glaze/glaze.hpp>
+
+// Versioned machine-readable report. This is deliberately Operon-specific;
+// tree_node_count is not SRBench's model-complexity definition.
+namespace Operon {
+struct MachineMetrics {
+    double r2_train{}; double r2_test{}; double mae_train{}; double mae_test{};
+    double nmse_train{}; double nmse_test{}; double mse_train{}; double mse_test{};
+    double best_fitness{}; double average_fitness{}; double average_tree_node_count{};
+    double elapsed_seconds{}; std::uint64_t evaluator_calls{};
+    std::uint64_t result_evaluations{}; std::uint64_t jacobian_evaluations{}; double optimizer_seconds{};
+};
+struct MachineReport {
+    std::string report_kind{"operon_gp"}; int schema_version{1}; std::string symbolic_model{};
+    std::uint64_t tree_node_count{}; std::uint64_t seed{}; MachineMetrics metrics{};
+};
+}
+template <> struct glz::meta<Operon::MachineMetrics> {
+    using T = Operon::MachineMetrics;
+    static constexpr auto value = glz::object("r2_train", &T::r2_train, "r2_test", &T::r2_test,
+        "mae_train", &T::mae_train, "mae_test", &T::mae_test, "nmse_train", &T::nmse_train, "nmse_test", &T::nmse_test,
+        "mse_train", &T::mse_train, "mse_test", &T::mse_test, "best_fitness", &T::best_fitness,
+        "average_fitness", &T::average_fitness, "average_tree_node_count", &T::average_tree_node_count,
+        "elapsed_seconds", &T::elapsed_seconds, "evaluator_calls", &T::evaluator_calls,
+        "result_evaluations", &T::result_evaluations, "jacobian_evaluations", &T::jacobian_evaluations,
+        "optimizer_seconds", &T::optimizer_seconds);
+};
+template <> struct glz::meta<Operon::MachineReport> {
+    using T = Operon::MachineReport;
+    static constexpr auto value = glz::object("report_kind", &T::report_kind, "schema_version", &T::schema_version,
+        "symbolic_model", &T::symbolic_model, "tree_node_count", &T::tree_node_count, "seed", &T::seed, "metrics", &T::metrics);
+};
 
 #include <functional>
 #include <string>
 #include <taskflow/taskflow.hpp>
 
 namespace Operon {
+
+inline auto WriteMachineReport(MachineReport const& report, std::filesystem::path const& path) -> void {
+    auto finite = [](double value) { return std::isfinite(value); };
+    auto const& m = report.metrics;
+    if (!finite(m.r2_train) || !finite(m.r2_test) || !finite(m.mae_train) || !finite(m.mae_test) ||
+        !finite(m.nmse_train) || !finite(m.nmse_test) || !finite(m.mse_train) || !finite(m.mse_test) ||
+        !finite(m.best_fitness) || !finite(m.average_fitness) || !finite(m.average_tree_node_count) ||
+        !finite(m.elapsed_seconds) || !finite(m.optimizer_seconds)) {
+        throw std::runtime_error("machine report contains non-finite metric");
+    }
+    auto encoded = glz::write_json(report);
+    if (!encoded) { throw std::runtime_error("machine report JSON serialization failed"); }
+    auto tmp = path;
+    tmp += ".tmp-" + std::to_string(static_cast<unsigned long long>(::getpid()));
+    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+    if (!out) { throw std::runtime_error("could not open machine report temporary file"); }
+    out << *encoded << '\n';
+    out.close();
+    if (!out) { std::filesystem::remove(tmp); throw std::runtime_error("could not write machine report"); }
+    std::error_code ec;
+    std::filesystem::rename(tmp, path, ec);
+    if (ec) { std::filesystem::remove(tmp); throw std::runtime_error("could not publish machine report: " + ec.message()); }
+}
 
 using ModelSelectorFn = std::function<Individual(Span<Individual const>)>;
 
@@ -180,8 +244,21 @@ public:
             T{ "sort_ms", [&]{ auto const& t = gp.Timings(); auto it = t.find(std::string{SortTaskName}); return it != t.end() ? it->second * 1e3 : 0.0; }(), format },
             T{ "elapsed", gp.Elapsed(), ":>"},
         };
+        latest_.seed = config.Seed;
+        latest_.tree_node_count = best_.Genotype.Length();
+        latest_.symbolic_model.clear();
+        latest_.metrics = MachineMetrics{r2Train, r2Test, maeTrain, maeTest, nmseTrain, nmseTest,
+            mseTrain, mseTest, best_[idx], avgQuality, avgLength, gp.Elapsed(),
+            static_cast<std::uint64_t>(callCount), static_cast<std::uint64_t>(resEval),
+            static_cast<std::uint64_t>(jacEval), cfTime / 1e6};
         PrintStats({ stats.begin(), stats.end() }, gp.Generation() == 0);
     }
+
+    auto SetSymbolicModel(std::string model) const -> void { latest_.symbolic_model = std::move(model); }
+    auto GetMachineReport() const -> MachineReport const& { return latest_; }
+
+private:
+    mutable MachineReport latest_{};
 };
 } // namespace Operon
 

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -206,6 +206,7 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("shape-worst-value", "Fitness value assigned by hard-reject shape enforcement to infeasible individuals (finite)", cxxopts::value<double>()->default_value("1.0"))
         ("shape-bound-mode", "Arithmetic backend for shape-constraint bound computation: combined (affine intersected with interval, default), interval-only, affine-only", cxxopts::value<std::string>()->default_value("combined"))
         ("debug", "Debug mode (more information displayed)")
+        ("report-json", "Write a versioned lossless machine-readable report to this path", cxxopts::value<std::string>())
         ("help", "Print help")
         ("version", "Print version and program information");
     return opts;

--- a/cli/source/util.cpp
+++ b/cli/source/util.cpp
@@ -206,7 +206,6 @@ auto InitOptions(std::string const& name, std::string const& desc, int width) ->
         ("shape-worst-value", "Fitness value assigned by hard-reject shape enforcement to infeasible individuals (finite)", cxxopts::value<double>()->default_value("1.0"))
         ("shape-bound-mode", "Arithmetic backend for shape-constraint bound computation: combined (affine intersected with interval, default), interval-only, affine-only", cxxopts::value<std::string>()->default_value("combined"))
         ("debug", "Debug mode (more information displayed)")
-        ("report-json", "Write a versioned lossless machine-readable report to this path", cxxopts::value<std::string>())
         ("help", "Print help")
         ("version", "Print version and program information");
     return opts;

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -31,11 +31,18 @@ VALUE_DEFAULTS = {
     "checkpoint-interval": "0", "checkpoint-file": "checkpoint.beve", "nonfinite-penalty-weight": "1.0",
     "shape-penalty-weight": "1.0", "shape-unknown-violation": "1.0", "shape-worst-value": "1.0", "shape-bound-mode": "combined",
 }
-VALUE_OPTIONS = set(VALUE_DEFAULTS) | {"dataset", "train", "test", "target", "inputs", "enable-symbols", "disable-symbols", "pareto-front", "resume", "probes-config", "shape-constraints-config", "elitism"}
+VALUE_OPTIONS = set(VALUE_DEFAULTS) | {"dataset", "train", "test", "target", "inputs", "enable-symbols", "disable-symbols", "pareto-front", "resume", "probes-config", "shape-constraints-config", "shape-enforcement", "elitism"}
 ALL_OPTIONS = set(VALUE_OPTIONS) | BOOL_OPTIONS
 PATH_OPTIONS = {"dataset", "shape-constraints-config", "probes-config", "resume"}
 OUTPUT_PATH_OPTIONS = {"checkpoint-file", "pareto-front"}
+EXTERNAL_OUTPUT_OPTIONS = OUTPUT_PATH_OPTIONS | {"probes-config"}
 OBSERVATIONAL_RESULT_FIELDS = {"time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"}
+BOOL_DEFAULTS = {"shuffle": False, "standardize": False, "linear-scaling": True, "skip-nonfinite": False, "symbolic": False, "transposition-cache": False, "show-primitives": False, "debug": False}
+
+
+def _bool_value(value: str, name: str) -> bool:
+    if value.lower() not in {"true", "false"}: raise ValueError(f"--{name} expects true or false")
+    return value.lower() == "true"
 
 
 def sha256(path: Path) -> str:
@@ -77,13 +84,15 @@ def parse_args(args: list[str]) -> dict[str, Any]:
         if name == "report-json": raise ValueError("--report-json is wrapper-owned and must not be supplied")
         if name not in ALL_OPTIONS: raise ValueError(f"unknown operon_gp option --{name}")
         if name in values: raise ValueError(f"duplicate singleton GP option --{name}")
-        if not eq:
-            if name == "jit": value = "all"
-            elif name in VALUE_OPTIONS:
-                if i + 1 >= len(args) or args[i + 1].startswith("--"): raise ValueError(f"option --{name} requires a value")
-                i += 1; value = args[i]
-            else: value = True
-        elif name in BOOL_OPTIONS: raise ValueError(f"boolean option --{name} does not take a value")
+        if eq:
+            if name in BOOL_OPTIONS: value = _bool_value(value, name)
+        elif name == "jit": value = "all"
+        elif name in VALUE_OPTIONS:
+            if i + 1 >= len(args) or args[i + 1] == "--": raise ValueError(f"option --{name} requires a value")
+            i += 1; value = args[i]
+        elif i + 1 < len(args) and args[i + 1].lower() in {"true", "false"}:
+            i += 1; value = _bool_value(args[i], name)
+        else: value = True
         values[name] = value
         i += 1
     return values
@@ -95,14 +104,17 @@ def canonical_args(args: list[str], cwd: Path) -> tuple[list[str], dict[str, Any
         token = args[i]; name, eq, value = token[2:].partition("=")
         if not eq and name == "jit": value = "all"
         elif not eq and name in VALUE_OPTIONS: i += 1; value = args[i]
+        elif not eq and name in BOOL_OPTIONS and i + 1 < len(args) and args[i + 1].lower() in {"true", "false"}: i += 1; value = args[i]
         if name in PATH_OPTIONS or name in OUTPUT_PATH_OPTIONS: value = str((cwd / value).resolve())
-        out.append(f"--{name}" if name in BOOL_OPTIONS else f"--{name}={value}"); i += 1
+        out.append(f"--{name}={str(value).lower()}" if name in BOOL_OPTIONS else f"--{name}={value}"); i += 1
     effective = dict(VALUE_DEFAULTS)
     effective.update({k: v for k, v in vals.items() if k not in BOOL_OPTIONS})
-    for k in BOOL_OPTIONS: effective[k] = bool(vals.get(k, False if k != "linear-scaling" else True))
+    for k in BOOL_OPTIONS: effective[k] = vals.get(k, BOOL_DEFAULTS[k])
     effective["jit"] = vals.get("jit", VALUE_DEFAULTS["jit"])
     effective["canonical_argv"] = out
     return out, effective
+
+
 
 
 def cpu_identity() -> dict[str, Any]:
@@ -135,24 +147,40 @@ def validate_report(report: Any) -> dict[str, Any]:
     return report
 
 
+def _artifact_root(path: Path) -> Path:
+    path = path.resolve()
+    if path.is_file():
+        if path.name != "manifest.json": raise ValueError("--replay-manifest must name manifest.json or an artifact directory")
+        return path.parent
+    return path
+
+
 def _manifest_and_results(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    root = _artifact_root(root)
     manifest = _json_strict(root / "manifest.json"); results = _json_strict(root / "results.json")
-    if not isinstance(manifest, dict) or manifest.get("schema_version") != 2: raise ValueError("invalid manifest schema")
-    if not isinstance(results, dict) or results.get("schema_version") != 2: raise ValueError("invalid results schema")
+    manifest_keys = {"$schema", "schema_version", "replay_comparison", "invocation", "inputs", "effective_configuration", "implementation", "dependency_lock", "compiler", "cpu", "resource_budget", "seed", "result_schema"}
+    result_keys = {"$schema", "schema_version", "srbench_compatibility", "dataset", "algorithm", "params", "random_state", "time_time", "symbolic_model", "tree_node_count", "metrics", "operon", "manifest_sha256"}
+    if not isinstance(manifest, dict) or set(manifest) != manifest_keys or manifest.get("schema_version") != 2: raise ValueError("invalid or incomplete manifest schema")
+    if not isinstance(results, dict) or set(results) != result_keys or results.get("schema_version") != 2: raise ValueError("invalid or incomplete results schema")
+    if not isinstance(manifest["$schema"], str) or not isinstance(manifest["replay_comparison"], dict): raise ValueError("invalid manifest identity fields")
+    if not isinstance(manifest["inputs"], list) or not isinstance(manifest["effective_configuration"], dict) or not isinstance(manifest["implementation"], dict) or not isinstance(manifest["resource_budget"], dict) or not isinstance(manifest["seed"], int) or isinstance(manifest["seed"], bool): raise ValueError("invalid manifest field types")
+    if not isinstance(results["$schema"], str) or not isinstance(results["srbench_compatibility"], bool) or not isinstance(results["dataset"], str) or not isinstance(results["algorithm"], str) or not isinstance(results["params"], dict) or not isinstance(results["random_state"], int) or isinstance(results["random_state"], bool) or not isinstance(results["time_time"], (int, float)) or isinstance(results["time_time"], bool) or not isinstance(results["operon"], dict): raise ValueError("invalid result field types")
+    if not isinstance(manifest["dependency_lock"], dict) or not manifest["dependency_lock"].get("sha256"): raise ValueError("artifact lacks required dependency lock identity")
+    if not isinstance(results["manifest_sha256"], str) or results["manifest_sha256"] != sha256(root / "manifest.json"): raise ValueError("results are not bound to manifest bytes")
+    validate_report({"report_kind": "operon_gp", "schema_version": 1, "symbolic_model": results["symbolic_model"], "tree_node_count": results["tree_node_count"], "seed": results["random_state"], "metrics": results["metrics"]})
     return manifest, results
 
 
 def compare_artifacts(first: Path, second: Path) -> None:
     ma, ra = _manifest_and_results(first); mb, rb = _manifest_and_results(second)
-    # Validate both independently, and reject artifact-supplied comparison policies.
     for m in (ma, mb):
         if m.get("replay_comparison") != REPLAY_COMPARISON: raise ValueError("artifact contains unsupported replay policy")
     for path in ("implementation", "inputs", "dependency_lock", "effective_configuration", "seed", "resource_budget"):
-        if ma.get(path) != mb.get(path): raise ValueError(f"replay mismatch in manifest field {path}")
-    deterministic_a = {k: v for k, v in ra.items() if k not in {"time_time"}}
-    deterministic_b = {k: v for k, v in rb.items() if k not in {"time_time"}}
+        if ma[path] != mb[path]: raise ValueError(f"replay mismatch in manifest field {path}")
+    deterministic_a = dict(ra); deterministic_b = dict(rb)
     for path in OBSERVATIONAL_RESULT_FIELDS:
-        if path.startswith("metrics."): deterministic_a["metrics"].pop(path.split(".")[1], None); deterministic_b["metrics"].pop(path.split(".")[1], None)
+        if path == "time_time": deterministic_a.pop(path); deterministic_b.pop(path)
+        else: deterministic_a["metrics"].pop(path.split(".")[1]); deterministic_b["metrics"].pop(path.split(".")[1])
     if deterministic_a != deterministic_b: raise ValueError("replay mismatch in deterministic result fields")
 
 
@@ -185,32 +213,43 @@ def main() -> int:
         cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
         if not binary.is_file(): raise ValueError(f"operon_gp binary is not a file: {binary}")
         gp_args = argv[split + 1:]; canonical, opts = canonical_args(gp_args, cwd)
+        if EXTERNAL_OUTPUT_OPTIONS & set(opts): raise ValueError("checkpoint, pareto-front, and probes-config outputs are not supported by replay wrapper")
         if "dataset" not in opts or "seed" not in opts: raise ValueError("replayable runs require explicit --dataset and --seed")
         try: seed = int(opts["seed"])
         except (TypeError, ValueError): raise ValueError("--seed must be an integer")
-        if int(opts.get("evaluations", 0)) <= 0 and int(opts.get("timelimit", 2**64 - 1)) >= 2**64 - 1: raise ValueError("require a finite positive --evaluations or --timelimit")
-        output = parsed.output.resolve()
-        if output.exists(): raise ValueError(f"immutable output already exists: {output}")
+        output = parsed.output.resolve(); output.parent.mkdir(parents=True, exist_ok=True)
         dataset = Path(str(opts["dataset"])).resolve()
-        if not dataset.is_file(): raise ValueError(f"dataset is not a file: {dataset}")
-        lock = cwd / "flake.lock"; lock_snap = snapshot(lock) if lock.is_file() else None
-        binary_snap = snapshot(binary)
-        stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent)); staged_bin = stage / binary.name; shutil.copyfile(binary, staged_bin); staged_bin.chmod(binary.stat().st_mode | stat.S_IXUSR)
-        input_snaps: list[dict[str, Any]] = []; staged_args = list(gp_args)
+        lock = cwd / "flake.lock"
+        if not lock.is_file(): raise ValueError("replayable runs require flake.lock")
+        lock_snap = snapshot(lock); binary_snap = snapshot(binary)
+        stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+        staged_bin = stage / binary.name; shutil.copyfile(binary, staged_bin); staged_bin.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        staged_bin_snap = snapshot(staged_bin)
+        if staged_bin_snap["sha256"] != binary_snap["sha256"]: raise RuntimeError("executable changed while staging")
+        input_snaps: list[dict[str, Any]] = []; staged_by_original: dict[str, str] = {}
         for key in PATH_OPTIONS:
             if key not in opts: continue
             original = Path(str(opts[key])).resolve()
             if not original.is_file(): raise ValueError(f"input is not a file: {original}")
             snap = snapshot(original); staged = stage / (key + "-" + original.name); shutil.copyfile(original, staged); staged.chmod(stat.S_IRUSR | stat.S_IRGRP)
-            input_snaps.append({"option": "--" + key, **snap, "staged_path": str(staged)})
-            for j, token in enumerate(staged_args):
-                if token == str(original) or (j and staged_args[j-1] == "--" + key): staged_args[j] = str(staged)
-                elif token == "--" + key + "=" + str(original): staged_args[j] = "--" + key + "=" + str(staged)
-        # Version is obtained from exactly the immutable staged executable, bounded.
+            staged_snap = snapshot(staged)
+            if staged_snap["sha256"] != snap["sha256"]: raise RuntimeError(f"input changed while staging: {original}")
+            input_snaps.append({"option": "--" + key, **snap, "staged_path": str(staged), "staged_sha256": staged_snap["sha256"]}); staged_by_original[str(original)] = str(staged)
+        staged_args = list(gp_args); j = 0
+        while j < len(staged_args):
+            name, eq, value = staged_args[j][2:].partition("=")
+            if name in BOOL_OPTIONS and not eq:
+                if j + 1 < len(staged_args) and staged_args[j + 1].lower() in {"true", "false"}: j += 1
+                staged_args[j] = f"--{name}={str(opts[name]).lower()}"
+            elif name in PATH_OPTIONS and not eq:
+                j += 1; staged_args[j] = staged_by_original.get(str((cwd / staged_args[j]).resolve()), staged_args[j])
+            elif name in PATH_OPTIONS and eq:
+                staged_args[j] = f"--{name}=" + staged_by_original.get(str((cwd / value).resolve()), value)
+            j += 1
         version_out, version_err, version_rc = _run_bounded([str(staged_bin), "--version"], cwd=stage, timeout=min(parsed.timeout, 30.0))
         if version_rc != 0: raise ValueError(f"operon_gp --version failed: {version_err.strip()}")
         report_path = stage / "machine-report.json"
-        proc_out, proc_err, rc = _run_bounded([str(staged_bin), *staged_args, "--report-json", str(report_path)], cwd=cwd, timeout=parsed.timeout)
+        proc_out, proc_err, rc = _run_bounded([str(staged_bin), *staged_args, "--report-json", str(report_path)], cwd=stage, timeout=parsed.timeout)
         if rc != 0: raise RuntimeError(f"operon_gp exited with status {rc}: {proc_err.strip()}")
         if not report_path.is_file(): raise RuntimeError("operon_gp did not produce --report-json")
         report = validate_report(_json_strict(report_path))
@@ -218,17 +257,34 @@ def main() -> int:
         for item in input_snaps:
             now = snapshot(Path(item["path"]))
             if now["sha256"] != item["sha256"] or now["size"] != item["size"]: raise RuntimeError(f"input mutated during run: {item['path']}")
-        if lock_snap and (sha256(lock) != lock_snap["sha256"] or lock.stat().st_size != lock_snap["size"]): raise RuntimeError("dependency lock mutated during run")
-        output.parent.mkdir(parents=True, exist_ok=True)
-        executable = snapshot(binary)
+        if snapshot(binary)["sha256"] != binary_snap["sha256"]: raise RuntimeError("executable mutated during run")
+        if snapshot(lock)["sha256"] != lock_snap["sha256"]: raise RuntimeError("dependency lock mutated during run")
+        executable = {**binary_snap, "staged_sha256": staged_bin_snap["sha256"], "path": str(binary)}
         inputs = sorted(({k: v for k, v in item.items() if k != "staged_path"} for item in input_snaps), key=lambda x: x["option"])
         manifest = {"$schema": SCHEMA + "/manifest", "schema_version": 2, "replay_comparison": REPLAY_COMPARISON, "invocation": {"argv": [str(binary), *canonical], "machine_report_option": "--report-json <private-staging-path>"}, "inputs": inputs, "effective_configuration": opts, "implementation": {"name": "Operon", "version_output": version_out, "executable": executable}, "dependency_lock": lock_snap, "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": opts.get("evaluations"), "timelimit": opts.get("timelimit"), "status": "completed"}, "seed": seed, "result_schema": SCHEMA + "/results"}
-        metrics = report["metrics"]
-        results = {"$schema": SCHEMA + "/results", "schema_version": 2, "srbench_compatibility": False, "dataset": dataset.stem, "algorithm": "Operon-GP", "params": {"canonical_argv": canonical}, "random_state": seed, "time_time": metrics["elapsed_seconds"], "symbolic_model": report["symbolic_model"], "tree_node_count": report["tree_node_count"], "metrics": metrics, "operon": {"manifest": "manifest.json"}}
+        (stage / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
+        (stage / "results.json").write_text(json.dumps(results, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
         (stage / "stdout.txt").write_text(proc_out); (stage / "stderr.txt").write_text(proc_err)
-        for payload, name in ((manifest, "manifest.json"), (results, "results.json")):
-            with (stage / name).open("w", encoding="utf-8") as f: json.dump(payload, f, indent=2, sort_keys=True, allow_nan=False); f.write("\n")
-        os.replace(stage, output); print(output / "results.json"); return 0
+        # Reserve destination atomically; mkdir fails without touching a prior
+        # artifact.  Hard-link files into it so no replacement is possible.
+        output.mkdir()
+        linked: list[tuple[Path, int]] = []
+        try:
+            for item in stage.iterdir():
+                destination = output / item.name
+                os.link(item, destination)
+                linked.append((destination, item.stat().st_ino))
+                item.unlink()
+            stage.rmdir()
+        except Exception:
+            for destination, inode in linked:
+                try:
+                    if destination.stat().st_ino == inode: destination.unlink()
+                except OSError: pass
+            try: output.rmdir()
+            except OSError: pass
+            raise
+        print(output / "results.json"); return 0
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError, KeyError, OverflowError) as e:
         if 'stage' in locals(): shutil.rmtree(stage, ignore_errors=True)
         print(f"error: {e}", file=sys.stderr); return 1

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -1,35 +1,42 @@
 #!/usr/bin/env python3
-"""Run one replayable Operon GP benchmark.
-
-The wrapper consumes operon_gp's versioned ``--report-json`` report, rather
-than scraping human terminal output.  Output is published atomically only
-after the child exits successfully and report validation has completed.
-Results are Operon-specific schema v2: ``tree_node_count`` is the raw Operon
-genotype length and is *not* SRBench model complexity.
-"""
+"""Run one replayable Operon GP benchmark with verifiable provenance."""
 from __future__ import annotations
-import argparse, hashlib, json, math, os, platform, re, shutil, signal, subprocess, sys, tempfile, time
+import argparse, hashlib, json, math, os, platform, re, shutil, signal, stat, subprocess, sys, tempfile
 from pathlib import Path
 from typing import Any
 
 SCHEMA = "https://operon.dev/schemas/srbench-run/v2"
+# This policy is wrapper code, not data read from either artifact.  Timing and host
+# observations are deliberately excluded; every other published field is classified.
 REPLAY_COMPARISON = {
-    "required_equal": ["symbolic_model", "tree_node_count", "metrics.r2_train", "metrics.r2_test", "metrics.mae_train", "metrics.mae_test", "metrics.mse_train", "metrics.mse_test", "metrics.nmse_train", "metrics.nmse_test", "metrics.best_fitness", "metrics.evaluator_calls", "metrics.result_evaluations", "params.canonical_argv", "random_state", "operon.manifest", "manifest.provenance"],
-    "observational_excluded": ["time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"],
-    "note": "Replay equality requires model, loss metrics, effective configuration/budget, and provenance equality. Wall-clock and optimizer timing are observational and excluded because they vary between otherwise identical runs."
+    "required_equal": ["implementation", "inputs", "dependency_lock", "effective_configuration", "seed", "resource_budget", "result.deterministic"],
+    "observational_excluded": ["result.time_time", "result.metrics.elapsed_seconds", "result.metrics.optimizer_seconds", "manifest.cpu", "manifest.invocation.cwd"],
+    "policy_version": 1,
 }
-SINGLETONS = {
-    "dataset", "seed", "train", "test", "target", "inputs", "objective", "jit",
-    "shuffle", "standardize", "linear-scaling", "skip-nonfinite", "population-size", "pool-size",
-    "generations", "evaluations", "iterations", "timelimit", "threads", "maxlength", "maxdepth",
-    "creator", "creator-mindepth", "creator-maxdepth", "crossover-probability", "crossover-internal-probability",
-    "mutation-probability", "local-search-probability", "lamarckian-probability", "symbolic", "transposition-cache",
-    "cache-max-age", "female-selector", "male-selector", "offspring-generator", "reinserter", "mutators", "elitism",
-    "enable-symbols", "disable-symbols", "report-json", "probes-config", "shape-constraints-config", "shape-enforcement",
-    "shape-penalty-weight", "shape-unknown-violation", "shape-worst-value", "shape-bound-mode",
+
+# One authoritative description of every effective operon_gp option.  The C++ CLI
+# uses the same names/defaults (see cli/source/util.cpp); this table is only a
+# parser/canonicalizer, never a second accepted-option implementation.
+BOOL_OPTIONS = {"shuffle", "standardize", "linear-scaling", "skip-nonfinite", "symbolic", "transposition-cache", "show-primitives", "debug"}
+VALUE_DEFAULTS = {
+    "epsilon": "1e-6", "objective": "r2", "jit": "", "jit-max-length": "0", "jit-min-visits": "1",
+    "population-size": "1000", "pool-size": "1000", "seed": "0", "generations": "1000", "evaluations": "1000000",
+    "iterations": "0", "selection-pressure": "100", "maxlength": "50", "maxdepth": "10",
+    "crossover-probability": "1.0", "crossover-internal-probability": "0.9", "mutation-probability": "0.25",
+    "creator": "btc", "creator-mindepth": "1", "creator-maxdepth": "100", "female-selector": "tournament",
+    "male-selector": "tournament", "offspring-generator": "basic", "reinserter": "keep-best",
+    "mutators": "onepoint:1,changevar:1,changefunc:1,replacesubtree:1,insertsubtree:1,removesubtree:1,discretepoint:1",
+    "local-search-probability": "1.0", "lamarckian-probability": "1.0", "threads": "0",
+    "timelimit": str(2**64 - 1), "cache-max-age": "0", "model-selection": "obj0", "mdl-likelihood": "gaussian",
+    "checkpoint-interval": "0", "checkpoint-file": "checkpoint.beve", "nonfinite-penalty-weight": "1.0",
+    "shape-penalty-weight": "1.0", "shape-unknown-violation": "1.0", "shape-worst-value": "1.0", "shape-bound-mode": "combined",
 }
-VALUE_OPTIONS = SINGLETONS - {"shuffle", "standardize", "linear-scaling", "skip-nonfinite", "symbolic", "transposition-cache"}
-PATH_OPTIONS = {"dataset", "shape-constraints-config", "probes-config", "checkpoint-file", "resume", "pareto-front"}
+VALUE_OPTIONS = set(VALUE_DEFAULTS) | {"dataset", "train", "test", "target", "inputs", "enable-symbols", "disable-symbols", "pareto-front", "resume", "probes-config", "shape-constraints-config", "elitism"}
+ALL_OPTIONS = set(VALUE_OPTIONS) | BOOL_OPTIONS
+PATH_OPTIONS = {"dataset", "shape-constraints-config", "probes-config", "resume"}
+OUTPUT_PATH_OPTIONS = {"checkpoint-file", "pareto-front"}
+OBSERVATIONAL_RESULT_FIELDS = {"time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"}
+
 
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -37,10 +44,27 @@ def sha256(path: Path) -> str:
         for block in iter(lambda: f.read(1024 * 1024), b""): h.update(block)
     return h.hexdigest()
 
+
+def snapshot(path: Path) -> dict[str, Any]:
+    st = path.stat()
+    return {"path": str(path), "sha256": sha256(path), "size": st.st_size, "mode": stat.S_IMODE(st.st_mode)}
+
+
 def finite(value: Any, name: str) -> float:
     if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value)):
         raise ValueError(f"machine report field {name!r} must be finite")
     return float(value)
+
+
+def _json_strict(path: Path) -> Any:
+    def pairs(items):
+        out = {}
+        for key, value in items:
+            if key in out: raise ValueError(f"duplicate JSON key {key!r} in {path.name}")
+            out[key] = value
+        return out
+    return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in ()).throw(ValueError(f"nonstandard JSON constant {x}")))
+
 
 def parse_args(args: list[str]) -> dict[str, Any]:
     values: dict[str, Any] = {}
@@ -50,37 +74,36 @@ def parse_args(args: list[str]) -> dict[str, Any]:
         if token == "--": raise ValueError("unexpected '--' in GP arguments")
         if not token.startswith("--"): raise ValueError(f"unexpected positional GP argument {token!r}")
         name, eq, value = token[2:].partition("=")
-        if name not in SINGLETONS and name not in {"probes-config"}:
-            i += 1; continue
+        if name == "report-json": raise ValueError("--report-json is wrapper-owned and must not be supplied")
+        if name not in ALL_OPTIONS: raise ValueError(f"unknown operon_gp option --{name}")
         if name in values: raise ValueError(f"duplicate singleton GP option --{name}")
         if not eq:
-            if name in VALUE_OPTIONS:
-                if i + 1 >= len(args) or args[i + 1].startswith("--"):
-                    raise ValueError(f"option --{name} requires a value")
+            if name == "jit": value = "all"
+            elif name in VALUE_OPTIONS:
+                if i + 1 >= len(args) or args[i + 1].startswith("--"): raise ValueError(f"option --{name} requires a value")
                 i += 1; value = args[i]
             else: value = True
+        elif name in BOOL_OPTIONS: raise ValueError(f"boolean option --{name} does not take a value")
         values[name] = value
         i += 1
     return values
 
+
 def canonical_args(args: list[str], cwd: Path) -> tuple[list[str], dict[str, Any]]:
-    vals = parse_args(args)
-    out: list[str] = []
-    i = 0
+    vals = parse_args(args); out: list[str] = []; i = 0
     while i < len(args):
-        token = args[i]; name, eq, value = token[2:].partition("=") if token.startswith("--") else ("", "", "")
-        if name in PATH_OPTIONS:
-            if not eq:
-                i += 1; value = args[i]
-            resolved = str((cwd / value).resolve())
-            out.append(f"--{name}={resolved}")
-        elif name in SINGLETONS or name == "probes-config":
-            if not eq and name in VALUE_OPTIONS:
-                i += 1; value = args[i]
-            out.append(f"--{name}={value}" if eq or name in VALUE_OPTIONS else f"--{name}")
-        else: out.append(token)
-        i += 1
-    return out, vals
+        token = args[i]; name, eq, value = token[2:].partition("=")
+        if not eq and name == "jit": value = "all"
+        elif not eq and name in VALUE_OPTIONS: i += 1; value = args[i]
+        if name in PATH_OPTIONS or name in OUTPUT_PATH_OPTIONS: value = str((cwd / value).resolve())
+        out.append(f"--{name}" if name in BOOL_OPTIONS else f"--{name}={value}"); i += 1
+    effective = dict(VALUE_DEFAULTS)
+    effective.update({k: v for k, v in vals.items() if k not in BOOL_OPTIONS})
+    for k in BOOL_OPTIONS: effective[k] = bool(vals.get(k, False if k != "linear-scaling" else True))
+    effective["jit"] = vals.get("jit", VALUE_DEFAULTS["jit"])
+    effective["canonical_argv"] = out
+    return out, effective
+
 
 def cpu_identity() -> dict[str, Any]:
     result: dict[str, Any] = {"architecture": platform.machine(), "processor": platform.processor()}
@@ -91,110 +114,123 @@ def cpu_identity() -> dict[str, Any]:
             m = re.search(rf"^{re.escape(key)}\s*:\s*(.+)$", text, re.MULTILINE)
             if m: result[field] = m.group(1).split() if field == "features" else m.group(1)
     return result
+
+
+def _number(value: Any, name: str, integer: bool = False) -> None:
+    if integer:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0: raise ValueError(f"machine report field {name!r} must be a non-negative integer")
+    else: finite(value, name)
+
+
 def validate_report(report: Any) -> dict[str, Any]:
-    if not isinstance(report, dict) or report.get("report_kind") != "operon_gp" or report.get("schema_version") != 1:
-        raise ValueError("machine report has unsupported kind or schema version")
-    metrics = report.get("metrics")
-    if not isinstance(metrics, dict): raise ValueError("machine report lacks metrics object")
-    for k, v in metrics.items():
-        if isinstance(v, float): finite(v, k)
-    required = {"r2_train", "r2_test", "mae_train", "mae_test", "mse_train", "mse_test", "best_fitness", "elapsed_seconds"}
-    missing = required - metrics.keys()
-    if missing: raise ValueError(f"machine report missing fields: {', '.join(sorted(missing))}")
+    root = {"report_kind", "schema_version", "symbolic_model", "tree_node_count", "seed", "metrics"}
+    if not isinstance(report, dict) or set(report) != root or report.get("report_kind") != "operon_gp" or report.get("schema_version") != 1:
+        raise ValueError("machine report has unsupported or incomplete schema")
+    if not isinstance(report["symbolic_model"], str): raise ValueError("machine report symbolic_model must be a string")
+    _number(report["tree_node_count"], "tree_node_count", True); _number(report["seed"], "seed", True)
+    metric_types = {"r2_train": 0, "r2_test": 0, "mae_train": 0, "mae_test": 0, "nmse_train": 0, "nmse_test": 0, "mse_train": 0, "mse_test": 0, "best_fitness": 0, "average_fitness": 0, "average_tree_node_count": 0, "elapsed_seconds": 0, "evaluator_calls": 1, "result_evaluations": 1, "jacobian_evaluations": 1, "optimizer_seconds": 0}
+    metrics = report["metrics"]
+    if not isinstance(metrics, dict) or set(metrics) != set(metric_types): raise ValueError("machine report metrics schema is incomplete or has extra fields")
+    for key, integer in metric_types.items(): _number(metrics[key], key, bool(integer))
     return report
 
+
+def _manifest_and_results(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    manifest = _json_strict(root / "manifest.json"); results = _json_strict(root / "results.json")
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != 2: raise ValueError("invalid manifest schema")
+    if not isinstance(results, dict) or results.get("schema_version") != 2: raise ValueError("invalid results schema")
+    return manifest, results
+
+
 def compare_artifacts(first: Path, second: Path) -> None:
-    """Validate deterministic replay fields, excluding declared timing fields."""
-    a, b = (json.loads((p / "results.json").read_text()) for p in (first, second))
-    policy = json.loads((first / "manifest.json").read_text())["replay_comparison"]
-    for path in policy["required_equal"]:
-        if path == "manifest.provenance": continue
-        left = a; right = b
-        for component in path.split("."):
-            left = left[component]; right = right[component]
-        if left != right: raise ValueError(f"replay mismatch in required field {path}")
-    if policy["observational_excluded"] != ["time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"]:
-        raise ValueError("unsupported replay comparison policy")
+    ma, ra = _manifest_and_results(first); mb, rb = _manifest_and_results(second)
+    # Validate both independently, and reject artifact-supplied comparison policies.
+    for m in (ma, mb):
+        if m.get("replay_comparison") != REPLAY_COMPARISON: raise ValueError("artifact contains unsupported replay policy")
+    for path in ("implementation", "inputs", "dependency_lock", "effective_configuration", "seed", "resource_budget"):
+        if ma.get(path) != mb.get(path): raise ValueError(f"replay mismatch in manifest field {path}")
+    deterministic_a = {k: v for k, v in ra.items() if k not in {"time_time"}}
+    deterministic_b = {k: v for k, v in rb.items() if k not in {"time_time"}}
+    for path in OBSERVATIONAL_RESULT_FIELDS:
+        if path.startswith("metrics."): deterministic_a["metrics"].pop(path.split(".")[1], None); deterministic_b["metrics"].pop(path.split(".")[1], None)
+    if deterministic_a != deterministic_b: raise ValueError("replay mismatch in deterministic result fields")
+
+
+def _run_bounded(command: list[str], cwd: Path, timeout: float) -> tuple[str, str, int]:
+    proc = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, start_new_session=True)
+    try: stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        os.killpg(proc.pid, signal.SIGTERM)
+        try: stdout, stderr = proc.communicate(timeout=min(5.0, max(0.1, timeout)))
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGKILL); stdout, stderr = proc.communicate()
+        raise RuntimeError(f"helper exceeded timeout of {timeout:g}s") from exc
+    return stdout, stderr, proc.returncode
+
 
 def main() -> int:
-    argv = sys.argv[1:]
-    split = argv.index("--") if "--" in argv else len(argv)
+    argv = sys.argv[1:]; split = argv.index("--") if "--" in argv else len(argv)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("binary", type=Path, nargs="?")
-    parser.add_argument("--output", required=False, type=Path)
-    parser.add_argument("--timeout", type=float, default=3600.0, help="finite wrapper timeout in seconds")
-    parser.add_argument("--replay-manifest", type=Path, help="compare this artifact with --against-artifact")
-    parser.add_argument("--against-artifact", type=Path, help="second artifact for --replay-manifest comparison")
-    parsed = parser.parse_args(argv[:split] if "--" in argv else argv)
-    if parsed.replay_manifest:
-        if not parsed.against_artifact: raise SystemExit("error: --replay-manifest requires --against-artifact")
-        try: compare_artifacts(parsed.replay_manifest.resolve(), parsed.against_artifact.resolve())
-        except (OSError, KeyError, ValueError, json.JSONDecodeError) as e: raise SystemExit(f"error: replay comparison failed: {e}")
-        print("replay comparison passed (timing fields excluded by manifest policy)"); return 0
-    if "--" not in argv: raise SystemExit("error: use '--' before operon_gp arguments")
-    if parsed.binary is None or parsed.output is None: raise SystemExit("error: binary and --output are required")
-    gp_args = argv[split + 1:]
-    if not math.isfinite(parsed.timeout) or parsed.timeout <= 0: raise SystemExit("error: --timeout must be finite and positive")
-    cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
-    if not binary.is_file(): raise SystemExit(f"error: operon_gp binary is not a file: {binary}")
-    canonical, opts = canonical_args(gp_args, cwd)
-    if "dataset" not in opts or "seed" not in opts: raise SystemExit("error: replayable runs require explicit --dataset and --seed")
-    try: seed = int(opts["seed"])
-    except (TypeError, ValueError): raise SystemExit("error: --seed must be an integer")
-    budget = opts.get("evaluations", 0); limit = opts.get("timelimit", 2**64 - 1)
-    try: budget_finite = int(budget) > 0; limit_finite = int(limit) < 2**64 - 1 and int(limit) > 0
-    except (TypeError, ValueError): budget_finite = limit_finite = False
-    if not budget_finite and not limit_finite: raise SystemExit("error: require a finite positive --evaluations or --timelimit")
-    dataset = Path(str(opts["dataset"])).resolve()
-    if not dataset.is_file(): raise SystemExit(f"error: dataset is not a file: {dataset}")
-    output = parsed.output.resolve()
-    if output.exists(): raise SystemExit(f"error: immutable output already exists: {output}")
-    parent = output.parent; parent.mkdir(parents=True, exist_ok=True)
-    stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=parent))
-    report_path = stage / "machine-report.json"
-    # report path is wrapper-owned and cannot be overridden by duplicate CLI input.
-    command = [str(binary), *gp_args, "--report-json", str(report_path)]
-    started = time.monotonic()
+    parser.add_argument("binary", type=Path, nargs="?"); parser.add_argument("--output", type=Path)
+    parser.add_argument("--timeout", type=float, default=3600.0); parser.add_argument("--replay-manifest", type=Path); parser.add_argument("--against-artifact", type=Path)
+    try: parsed = parser.parse_args(argv[:split] if "--" in argv else argv)
+    except SystemExit as e: return int(e.code)
     try:
-        proc = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-                                start_new_session=True)
-        try: stdout, stderr = proc.communicate(timeout=parsed.timeout)
-        except subprocess.TimeoutExpired:
-            os.killpg(proc.pid, signal.SIGTERM)
-            try: stdout, stderr = proc.communicate(timeout=5)
-            except subprocess.TimeoutExpired:
-                os.killpg(proc.pid, signal.SIGKILL); stdout, stderr = proc.communicate()
-            raise RuntimeError(f"operon_gp exceeded wrapper timeout of {parsed.timeout:g}s")
-        if proc.returncode != 0: raise RuntimeError(f"operon_gp exited with status {proc.returncode}: {stderr.strip()}")
-        if not report_path.is_file(): raise RuntimeError("operon_gp did not produce --report-json")
-        try: report = validate_report(json.loads(report_path.read_text()))
-        except (json.JSONDecodeError, ValueError) as e: raise RuntimeError(f"invalid machine report: {e}") from e
-        (stage / "stdout.txt").write_text(stdout); (stage / "stderr.txt").write_text(stderr)
-        version_run = subprocess.run([str(binary), "--version"], cwd=cwd, capture_output=True, text=True, check=False)
-        version = version_run.stdout + version_run.stderr
-        inputs = []
+        if parsed.replay_manifest:
+            if not parsed.against_artifact: raise ValueError("--replay-manifest requires --against-artifact")
+            compare_artifacts(parsed.replay_manifest.resolve(), parsed.against_artifact.resolve()); print("replay comparison passed"); return 0
+        if "--" not in argv: raise ValueError("use '--' before operon_gp arguments")
+        if parsed.binary is None or parsed.output is None: raise ValueError("binary and --output are required")
+        if not math.isfinite(parsed.timeout) or parsed.timeout <= 0: raise ValueError("--timeout must be finite and positive")
+        cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
+        if not binary.is_file(): raise ValueError(f"operon_gp binary is not a file: {binary}")
+        gp_args = argv[split + 1:]; canonical, opts = canonical_args(gp_args, cwd)
+        if "dataset" not in opts or "seed" not in opts: raise ValueError("replayable runs require explicit --dataset and --seed")
+        try: seed = int(opts["seed"])
+        except (TypeError, ValueError): raise ValueError("--seed must be an integer")
+        if int(opts.get("evaluations", 0)) <= 0 and int(opts.get("timelimit", 2**64 - 1)) >= 2**64 - 1: raise ValueError("require a finite positive --evaluations or --timelimit")
+        output = parsed.output.resolve()
+        if output.exists(): raise ValueError(f"immutable output already exists: {output}")
+        dataset = Path(str(opts["dataset"])).resolve()
+        if not dataset.is_file(): raise ValueError(f"dataset is not a file: {dataset}")
+        lock = cwd / "flake.lock"; lock_snap = snapshot(lock) if lock.is_file() else None
+        binary_snap = snapshot(binary)
+        stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent)); staged_bin = stage / binary.name; shutil.copyfile(binary, staged_bin); staged_bin.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        input_snaps: list[dict[str, Any]] = []; staged_args = list(gp_args)
         for key in PATH_OPTIONS:
-            if key in opts:
-                p = Path(str(opts[key])).resolve()
-                if p.is_file(): inputs.append({"option": f"--{key}", "path": str(p), "sha256": sha256(p), "size": p.stat().st_size})
-        stat = binary.stat()
-        manifest = {
-            "$schema": SCHEMA + "/manifest", "schema_version": 2,
-            "schema_description": "Replay provenance; timing fields are observational and not replay-equality claims.",
-            "replay_comparison": REPLAY_COMPARISON,
-            "invocation": {"argv": [str(binary), *canonical], "cwd": str(cwd), "machine_report_option": "--report-json <private-staging-path>"},
-            "inputs": sorted(inputs, key=lambda x: x["option"]), "effective_configuration": {k: opts[k] for k in sorted(opts)},
-            "implementation": {"name": "Operon", "version_output": version, "executable": {"path": str(binary), "size": stat.st_size, "sha256": sha256(binary)}},
-            "dependency_lock": {"path": str((cwd / "flake.lock").resolve()), "sha256": sha256(cwd / "flake.lock")} if (cwd / "flake.lock").is_file() else None,
-            "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": budget if budget_finite else None, "timelimit": limit if limit_finite else None, "status": "completed"},
-            "dataset": {"path": str(dataset), "sha256": sha256(dataset), "size": dataset.stat().st_size}, "seed": seed, "result_schema": SCHEMA + "/results",
-        }
+            if key not in opts: continue
+            original = Path(str(opts[key])).resolve()
+            if not original.is_file(): raise ValueError(f"input is not a file: {original}")
+            snap = snapshot(original); staged = stage / (key + "-" + original.name); shutil.copyfile(original, staged); staged.chmod(stat.S_IRUSR | stat.S_IRGRP)
+            input_snaps.append({"option": "--" + key, **snap, "staged_path": str(staged)})
+            for j, token in enumerate(staged_args):
+                if token == str(original) or (j and staged_args[j-1] == "--" + key): staged_args[j] = str(staged)
+                elif token == "--" + key + "=" + str(original): staged_args[j] = "--" + key + "=" + str(staged)
+        # Version is obtained from exactly the immutable staged executable, bounded.
+        version_out, version_err, version_rc = _run_bounded([str(staged_bin), "--version"], cwd=stage, timeout=min(parsed.timeout, 30.0))
+        if version_rc != 0: raise ValueError(f"operon_gp --version failed: {version_err.strip()}")
+        report_path = stage / "machine-report.json"
+        proc_out, proc_err, rc = _run_bounded([str(staged_bin), *staged_args, "--report-json", str(report_path)], cwd=cwd, timeout=parsed.timeout)
+        if rc != 0: raise RuntimeError(f"operon_gp exited with status {rc}: {proc_err.strip()}")
+        if not report_path.is_file(): raise RuntimeError("operon_gp did not produce --report-json")
+        report = validate_report(_json_strict(report_path))
+        if report["seed"] != seed: raise ValueError("machine report seed does not match requested seed")
+        for item in input_snaps:
+            now = snapshot(Path(item["path"]))
+            if now["sha256"] != item["sha256"] or now["size"] != item["size"]: raise RuntimeError(f"input mutated during run: {item['path']}")
+        if lock_snap and (sha256(lock) != lock_snap["sha256"] or lock.stat().st_size != lock_snap["size"]): raise RuntimeError("dependency lock mutated during run")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        executable = snapshot(binary)
+        inputs = sorted(({k: v for k, v in item.items() if k != "staged_path"} for item in input_snaps), key=lambda x: x["option"])
+        manifest = {"$schema": SCHEMA + "/manifest", "schema_version": 2, "replay_comparison": REPLAY_COMPARISON, "invocation": {"argv": [str(binary), *canonical], "machine_report_option": "--report-json <private-staging-path>"}, "inputs": inputs, "effective_configuration": opts, "implementation": {"name": "Operon", "version_output": version_out, "executable": executable}, "dependency_lock": lock_snap, "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": opts.get("evaluations"), "timelimit": opts.get("timelimit"), "status": "completed"}, "seed": seed, "result_schema": SCHEMA + "/results"}
         metrics = report["metrics"]
-        results = {"$schema": SCHEMA + "/results", "schema_version": 2, "schema_description": "Operon-specific record; tree_node_count is genotype length, not SRBench model complexity.", "srbench_compatibility": False, "dataset": dataset.stem, "algorithm": "Operon-GP", "params": {"canonical_argv": canonical}, "random_state": seed, "time_time": finite(metrics["elapsed_seconds"], "elapsed_seconds"), "symbolic_model": report["symbolic_model"], "tree_node_count": report["tree_node_count"], "metrics": metrics, "operon": {"manifest": "manifest.json"}}
+        results = {"$schema": SCHEMA + "/results", "schema_version": 2, "srbench_compatibility": False, "dataset": dataset.stem, "algorithm": "Operon-GP", "params": {"canonical_argv": canonical}, "random_state": seed, "time_time": metrics["elapsed_seconds"], "symbolic_model": report["symbolic_model"], "tree_node_count": report["tree_node_count"], "metrics": metrics, "operon": {"manifest": "manifest.json"}}
+        (stage / "stdout.txt").write_text(proc_out); (stage / "stderr.txt").write_text(proc_err)
         for payload, name in ((manifest, "manifest.json"), (results, "results.json")):
             with (stage / name).open("w", encoding="utf-8") as f: json.dump(payload, f, indent=2, sort_keys=True, allow_nan=False); f.write("\n")
         os.replace(stage, output); print(output / "results.json"); return 0
-    except (OSError, RuntimeError, ValueError) as e:
-        shutil.rmtree(stage, ignore_errors=True); print(f"error: {e}", file=sys.stderr); return 1
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError, KeyError, OverflowError) as e:
+        if 'stage' in locals(): shutil.rmtree(stage, ignore_errors=True)
+        print(f"error: {e}", file=sys.stderr); return 1
 
 if __name__ == "__main__": raise SystemExit(main())

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA = "https://operon.dev/schemas/srbench-run/v2"
+REPLAY_COMPARISON = {
+    "required_equal": ["symbolic_model", "tree_node_count", "metrics.r2_train", "metrics.r2_test", "metrics.mae_train", "metrics.mae_test", "metrics.mse_train", "metrics.mse_test", "metrics.nmse_train", "metrics.nmse_test", "metrics.best_fitness", "metrics.evaluator_calls", "metrics.result_evaluations", "params.canonical_argv", "random_state", "operon.manifest", "manifest.provenance"],
+    "observational_excluded": ["time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"],
+    "note": "Replay equality requires model, loss metrics, effective configuration/budget, and provenance equality. Wall-clock and optimizer timing are observational and excluded because they vary between otherwise identical runs."
+}
 SINGLETONS = {
     "dataset", "seed", "train", "test", "target", "inputs", "objective", "jit",
     "shuffle", "standardize", "linear-scaling", "skip-nonfinite", "population-size", "pool-size",
@@ -98,15 +103,37 @@ def validate_report(report: Any) -> dict[str, Any]:
     if missing: raise ValueError(f"machine report missing fields: {', '.join(sorted(missing))}")
     return report
 
+def compare_artifacts(first: Path, second: Path) -> None:
+    """Validate deterministic replay fields, excluding declared timing fields."""
+    a, b = (json.loads((p / "results.json").read_text()) for p in (first, second))
+    policy = json.loads((first / "manifest.json").read_text())["replay_comparison"]
+    for path in policy["required_equal"]:
+        if path == "manifest.provenance": continue
+        left = a; right = b
+        for component in path.split("."):
+            left = left[component]; right = right[component]
+        if left != right: raise ValueError(f"replay mismatch in required field {path}")
+    if policy["observational_excluded"] != ["time_time", "metrics.elapsed_seconds", "metrics.optimizer_seconds"]:
+        raise ValueError("unsupported replay comparison policy")
+
 def main() -> int:
     argv = sys.argv[1:]
-    if "--" not in argv: raise SystemExit("error: use '--' before operon_gp arguments")
-    split = argv.index("--")
+    split = argv.index("--") if "--" in argv else len(argv)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("binary", type=Path)
-    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("binary", type=Path, nargs="?")
+    parser.add_argument("--output", required=False, type=Path)
     parser.add_argument("--timeout", type=float, default=3600.0, help="finite wrapper timeout in seconds")
-    parsed = parser.parse_args(argv[:split]); gp_args = argv[split + 1:]
+    parser.add_argument("--replay-manifest", type=Path, help="compare this artifact with --against-artifact")
+    parser.add_argument("--against-artifact", type=Path, help="second artifact for --replay-manifest comparison")
+    parsed = parser.parse_args(argv[:split] if "--" in argv else argv)
+    if parsed.replay_manifest:
+        if not parsed.against_artifact: raise SystemExit("error: --replay-manifest requires --against-artifact")
+        try: compare_artifacts(parsed.replay_manifest.resolve(), parsed.against_artifact.resolve())
+        except (OSError, KeyError, ValueError, json.JSONDecodeError) as e: raise SystemExit(f"error: replay comparison failed: {e}")
+        print("replay comparison passed (timing fields excluded by manifest policy)"); return 0
+    if "--" not in argv: raise SystemExit("error: use '--' before operon_gp arguments")
+    if parsed.binary is None or parsed.output is None: raise SystemExit("error: binary and --output are required")
+    gp_args = argv[split + 1:]
     if not math.isfinite(parsed.timeout) or parsed.timeout <= 0: raise SystemExit("error: --timeout must be finite and positive")
     cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
     if not binary.is_file(): raise SystemExit(f"error: operon_gp binary is not a file: {binary}")
@@ -153,9 +180,10 @@ def main() -> int:
         stat = binary.stat()
         manifest = {
             "$schema": SCHEMA + "/manifest", "schema_version": 2,
+            "schema_description": "Replay provenance; timing fields are observational and not replay-equality claims.",
+            "replay_comparison": REPLAY_COMPARISON,
             "invocation": {"argv": [str(binary), *canonical], "cwd": str(cwd), "machine_report_option": "--report-json <private-staging-path>"},
-            "inputs": sorted(inputs, key=lambda x: x["option"]),
-            "effective_configuration": {k: opts[k] for k in sorted(opts)},
+            "inputs": sorted(inputs, key=lambda x: x["option"]), "effective_configuration": {k: opts[k] for k in sorted(opts)},
             "implementation": {"name": "Operon", "version_output": version, "executable": {"path": str(binary), "size": stat.st_size, "sha256": sha256(binary)}},
             "dependency_lock": {"path": str((cwd / "flake.lock").resolve()), "sha256": sha256(cwd / "flake.lock")} if (cwd / "flake.lock").is_file() else None,
             "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": budget if budget_finite else None, "timelimit": limit if limit_finite else None, "status": "completed"},

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -106,7 +106,11 @@ def canonical_args(args: list[str], cwd: Path) -> tuple[list[str], dict[str, Any
         elif not eq and name in VALUE_OPTIONS: i += 1; value = args[i]
         elif not eq and name in BOOL_OPTIONS and i + 1 < len(args) and args[i + 1].lower() in {"true", "false"}: i += 1; value = args[i]
         if name in PATH_OPTIONS or name in OUTPUT_PATH_OPTIONS: value = str((cwd / value).resolve())
-        out.append(f"--{name}={str(value).lower()}" if name in BOOL_OPTIONS else f"--{name}={value}"); i += 1
+        if name in BOOL_OPTIONS:
+            out.append(f"--{name}" if vals[name] else f"--{name}=false")
+        else:
+            out.append(f"--{name}={value}")
+        i += 1
     effective = dict(VALUE_DEFAULTS)
     effective.update({k: v for k, v in vals.items() if k not in BOOL_OPTIONS})
     for k in BOOL_OPTIONS: effective[k] = vals.get(k, BOOL_DEFAULTS[k])
@@ -212,8 +216,11 @@ def main() -> int:
         if not math.isfinite(parsed.timeout) or parsed.timeout <= 0: raise ValueError("--timeout must be finite and positive")
         cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
         if not binary.is_file(): raise ValueError(f"operon_gp binary is not a file: {binary}")
-        gp_args = argv[split + 1:]; canonical, opts = canonical_args(gp_args, cwd)
-        if EXTERNAL_OUTPUT_OPTIONS & set(opts): raise ValueError("checkpoint, pareto-front, and probes-config outputs are not supported by replay wrapper")
+        gp_args = argv[split + 1:]
+        explicit_opts = parse_args(gp_args)
+        canonical, opts = canonical_args(gp_args, cwd)
+        if EXTERNAL_OUTPUT_OPTIONS & set(explicit_opts):
+            raise ValueError("checkpoint, pareto-front, and probes-config outputs are not supported by replay wrapper")
         if "dataset" not in opts or "seed" not in opts: raise ValueError("replayable runs require explicit --dataset and --seed")
         try: seed = int(opts["seed"])
         except (TypeError, ValueError): raise ValueError("--seed must be an integer")
@@ -261,8 +268,15 @@ def main() -> int:
         if snapshot(lock)["sha256"] != lock_snap["sha256"]: raise RuntimeError("dependency lock mutated during run")
         executable = {**binary_snap, "staged_sha256": staged_bin_snap["sha256"], "path": str(binary)}
         inputs = sorted(({k: v for k, v in item.items() if k != "staged_path"} for item in input_snaps), key=lambda x: x["option"])
+        metrics = report["metrics"]
         manifest = {"$schema": SCHEMA + "/manifest", "schema_version": 2, "replay_comparison": REPLAY_COMPARISON, "invocation": {"argv": [str(binary), *canonical], "machine_report_option": "--report-json <private-staging-path>"}, "inputs": inputs, "effective_configuration": opts, "implementation": {"name": "Operon", "version_output": version_out, "executable": executable}, "dependency_lock": lock_snap, "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": opts.get("evaluations"), "timelimit": opts.get("timelimit"), "status": "completed"}, "seed": seed, "result_schema": SCHEMA + "/results"}
-        (stage / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
+        manifest_path = stage / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
+        results = {"$schema": SCHEMA + "/results", "schema_version": 2, "srbench_compatibility": False,
+                   "dataset": dataset.stem, "algorithm": "Operon-GP", "params": {"canonical_argv": canonical},
+                   "random_state": seed, "time_time": metrics["elapsed_seconds"], "symbolic_model": report["symbolic_model"],
+                   "tree_node_count": report["tree_node_count"], "metrics": metrics,
+                   "operon": {"manifest": "manifest.json"}, "manifest_sha256": sha256(manifest_path)}
         (stage / "results.json").write_text(json.dumps(results, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
         (stage / "stdout.txt").write_text(proc_out); (stage / "stderr.txt").write_text(proc_err)
         # Reserve destination atomically; mkdir fails without touching a prior

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Run one replayable Operon tree-GP benchmark and write immutable SRBench results.
+
+The output directory is created exclusively and contains `manifest.json` and
+`results.json`.  `results.json` deliberately retains the field names used by
+SRBench's experiment/optimize_model.py: dataset, algorithm, params,
+random_state, time_time, symbolic_model, mse_{train,test}, mae_{train,test},
+r2_{train,test}, and model_size.  The nested `operon` object links those
+comparison fields to the complete replay provenance in `manifest.json`.
+
+The separator `--` is required; everything after it is passed unchanged to
+operon_gp.  The passed command must include `--dataset` and `--seed`, which
+makes the dataset and random stream explicit in the recorded invocation.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import subprocess
+import sys
+import time
+from typing import Any
+
+SCHEMA = "https://operon.dev/schemas/srbench-run/v1"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def option_value(arguments: list[str], name: str) -> str | None:
+    prefix = name + "="
+    for index, argument in enumerate(arguments):
+        if argument.startswith(prefix):
+            return argument[len(prefix):]
+        if argument == name and index + 1 < len(arguments):
+            return arguments[index + 1]
+    return None
+
+
+def cpu_identity() -> dict[str, Any]:
+    identity: dict[str, Any] = {"architecture": platform.machine(), "processor": platform.processor()}
+    cpuinfo = Path("/proc/cpuinfo")
+    if cpuinfo.exists():
+        text = cpuinfo.read_text()
+        model = re.search(r"^model name\s*: (.+)$", text, re.MULTILINE)
+        flags = re.search(r"^flags\s*: (.+)$", text, re.MULTILINE)
+        if model:
+            identity["model"] = model.group(1)
+        if flags:
+            identity["features"] = flags.group(1).split()
+    return identity
+
+
+def parse_gp_output(stdout: str) -> tuple[dict[str, float], str]:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    header_index = next((i for i, line in enumerate(lines) if "iteration" in line.split() and "r2_tr" in line.split()), None)
+    if header_index is None:
+        raise ValueError("operon_gp output did not contain its metrics table")
+    fields = lines[header_index].split()
+    rows: list[dict[str, float]] = []
+    for line in lines[header_index + 1:]:
+        values = line.split()
+        if len(values) != len(fields):
+            break
+        try:
+            rows.append(dict(zip(fields, map(float, values), strict=True)))
+        except ValueError:
+            break
+    if not rows:
+        raise ValueError("operon_gp metrics table did not contain a data row")
+    model_lines = lines[header_index + 1 + len(rows):]
+    if not model_lines:
+        raise ValueError("operon_gp did not print a final symbolic model")
+    return rows[-1], model_lines[-1]
+
+
+def write_exclusive(path: Path, payload: dict[str, Any]) -> None:
+    with path.open("x", encoding="utf-8") as destination:
+        json.dump(payload, destination, indent=2, sort_keys=True)
+        destination.write("\n")
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if "--" not in argv:
+        raise SystemExit("error: use '--' before operon_gp arguments")
+    separator = argv.index("--")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", type=Path, help="path to operon_gp")
+    parser.add_argument("--output", required=True, type=Path, help="new immutable output directory")
+    parsed = parser.parse_args(argv[:separator])
+    gp_args = argv[separator + 1:]
+
+    dataset_arg = option_value(gp_args, "--dataset")
+    seed_arg = option_value(gp_args, "--seed")
+    if dataset_arg is None or seed_arg is None:
+        raise SystemExit("error: replayable runs require explicit --dataset and --seed after '--'")
+    try:
+        seed = int(seed_arg)
+    except ValueError as error:
+        raise SystemExit(f"error: --seed must be an integer: {error}") from error
+    dataset = Path(dataset_arg).resolve()
+    if not dataset.is_file():
+        raise SystemExit(f"error: dataset is not a file: {dataset}")
+    binary = parsed.binary.resolve()
+    if not binary.is_file():
+        raise SystemExit(f"error: operon_gp binary is not a file: {binary}")
+    try:
+        parsed.output.mkdir(mode=0o755)
+    except FileExistsError as error:
+        raise SystemExit(f"error: immutable output directory already exists: {parsed.output}") from error
+
+    started = time.time()
+    completed = subprocess.run([str(binary), *gp_args], capture_output=True, text=True, check=False)
+    (parsed.output / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
+    (parsed.output / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
+    if completed.returncode != 0:
+        raise SystemExit(f"error: operon_gp exited with status {completed.returncode}; see {parsed.output}/stderr.txt")
+    metrics, model = parse_gp_output(completed.stdout)
+    version = subprocess.run([str(binary), "--version"], capture_output=True, text=True, check=True).stdout.strip()
+    revision = re.search(r"operon rev\. (\S+)", version)
+    repository = Path(__file__).resolve().parents[1]
+    lock = repository / "flake.lock"
+    elapsed = time.time() - started
+
+    manifest = {
+        "$schema": SCHEMA + "/manifest",
+        "schema_version": 1,
+        "schema_description": "Immutable replay provenance. Hashes are lowercase SHA-256; ranges use Operon's half-open start:end syntax.",
+        "implementation": {"name": "Operon", "revision": revision.group(1) if revision else "unknown", "version": version},
+        "dependency_lock": {"path": "flake.lock", "sha256": sha256(lock)} if lock.is_file() else None,
+        "compiler": {"identity": version.splitlines()[-1] if version else "unknown"},
+        "cpu": cpu_identity(),
+        "seed": seed,
+        "dataset": {"path": dataset.name, "sha256": sha256(dataset)},
+        "primitive_set": {"enable_symbols": option_value(gp_args, "--enable-symbols"), "disable_symbols": option_value(gp_args, "--disable-symbols")},
+        "algorithm": {"name": "operon_gp", "configuration": gp_args},
+        "evaluator": {"objective": option_value(gp_args, "--objective") or "r2", "jit": option_value(gp_args, "--jit") or ""},
+        "budget": {key: option_value(gp_args, "--" + key) for key in ("generations", "evaluations", "timelimit", "population-size", "pool-size", "iterations", "threads")},
+        "result_schema": SCHEMA + "/results",
+    }
+    results = {
+        "$schema": SCHEMA + "/results",
+        "schema_version": 1,
+        "schema_description": "SRBench-compatible comparison record; train/test metrics are evaluated by Operon on its configured ranges.",
+        "dataset": dataset.stem,
+        "algorithm": "Operon-GP",
+        "params": {"operon_gp_arguments": gp_args},
+        "random_state": seed,
+        "time_time": elapsed,
+        "grid_time": 0.0,
+        "symbolic_model": model,
+        "mse_train": metrics["mse_tr"],
+        "mse_test": metrics["mse_te"],
+        "mae_train": metrics["mae_tr"],
+        "mae_test": metrics["mae_te"],
+        "r2_train": metrics["r2_tr"],
+        "r2_test": metrics["r2_te"],
+        "model_size": int(metrics["best_len"]),
+        "operon": {"manifest": "manifest.json", "best_fitness": metrics["best_fit"], "evaluator_calls": int(metrics["eval_cnt"]), "elapsed_seconds": metrics["elapsed"]},
+    }
+    write_exclusive(parsed.output / "manifest.json", manifest)
+    write_exclusive(parsed.output / "results.json", results)
+    print(parsed.output / "results.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_srbench.py
+++ b/tools/run_srbench.py
@@ -1,180 +1,172 @@
 #!/usr/bin/env python3
-"""Run one replayable Operon tree-GP benchmark and write immutable SRBench results.
+"""Run one replayable Operon GP benchmark.
 
-The output directory is created exclusively and contains `manifest.json` and
-`results.json`.  `results.json` deliberately retains the field names used by
-SRBench's experiment/optimize_model.py: dataset, algorithm, params,
-random_state, time_time, symbolic_model, mse_{train,test}, mae_{train,test},
-r2_{train,test}, and model_size.  The nested `operon` object links those
-comparison fields to the complete replay provenance in `manifest.json`.
-
-The separator `--` is required; everything after it is passed unchanged to
-operon_gp.  The passed command must include `--dataset` and `--seed`, which
-makes the dataset and random stream explicit in the recorded invocation.
+The wrapper consumes operon_gp's versioned ``--report-json`` report, rather
+than scraping human terminal output.  Output is published atomically only
+after the child exits successfully and report validation has completed.
+Results are Operon-specific schema v2: ``tree_node_count`` is the raw Operon
+genotype length and is *not* SRBench model complexity.
 """
 from __future__ import annotations
-
-import argparse
-import csv
-import hashlib
-import json
-import os
+import argparse, hashlib, json, math, os, platform, re, shutil, signal, subprocess, sys, tempfile, time
 from pathlib import Path
-import platform
-import re
-import subprocess
-import sys
-import time
 from typing import Any
 
-SCHEMA = "https://operon.dev/schemas/srbench-run/v1"
-
+SCHEMA = "https://operon.dev/schemas/srbench-run/v2"
+SINGLETONS = {
+    "dataset", "seed", "train", "test", "target", "inputs", "objective", "jit",
+    "shuffle", "standardize", "linear-scaling", "skip-nonfinite", "population-size", "pool-size",
+    "generations", "evaluations", "iterations", "timelimit", "threads", "maxlength", "maxdepth",
+    "creator", "creator-mindepth", "creator-maxdepth", "crossover-probability", "crossover-internal-probability",
+    "mutation-probability", "local-search-probability", "lamarckian-probability", "symbolic", "transposition-cache",
+    "cache-max-age", "female-selector", "male-selector", "offspring-generator", "reinserter", "mutators", "elitism",
+    "enable-symbols", "disable-symbols", "report-json", "probes-config", "shape-constraints-config", "shape-enforcement",
+    "shape-penalty-weight", "shape-unknown-violation", "shape-worst-value", "shape-bound-mode",
+}
+VALUE_OPTIONS = SINGLETONS - {"shuffle", "standardize", "linear-scaling", "skip-nonfinite", "symbolic", "transposition-cache"}
+PATH_OPTIONS = {"dataset", "shape-constraints-config", "probes-config", "checkpoint-file", "resume", "pareto-front"}
 
 def sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as source:
-        for block in iter(lambda: source.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""): h.update(block)
+    return h.hexdigest()
 
+def finite(value: Any, name: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(float(value)):
+        raise ValueError(f"machine report field {name!r} must be finite")
+    return float(value)
 
-def option_value(arguments: list[str], name: str) -> str | None:
-    prefix = name + "="
-    for index, argument in enumerate(arguments):
-        if argument.startswith(prefix):
-            return argument[len(prefix):]
-        if argument == name and index + 1 < len(arguments):
-            return arguments[index + 1]
-    return None
+def parse_args(args: list[str]) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token == "--": raise ValueError("unexpected '--' in GP arguments")
+        if not token.startswith("--"): raise ValueError(f"unexpected positional GP argument {token!r}")
+        name, eq, value = token[2:].partition("=")
+        if name not in SINGLETONS and name not in {"probes-config"}:
+            i += 1; continue
+        if name in values: raise ValueError(f"duplicate singleton GP option --{name}")
+        if not eq:
+            if name in VALUE_OPTIONS:
+                if i + 1 >= len(args) or args[i + 1].startswith("--"):
+                    raise ValueError(f"option --{name} requires a value")
+                i += 1; value = args[i]
+            else: value = True
+        values[name] = value
+        i += 1
+    return values
 
+def canonical_args(args: list[str], cwd: Path) -> tuple[list[str], dict[str, Any]]:
+    vals = parse_args(args)
+    out: list[str] = []
+    i = 0
+    while i < len(args):
+        token = args[i]; name, eq, value = token[2:].partition("=") if token.startswith("--") else ("", "", "")
+        if name in PATH_OPTIONS:
+            if not eq:
+                i += 1; value = args[i]
+            resolved = str((cwd / value).resolve())
+            out.append(f"--{name}={resolved}")
+        elif name in SINGLETONS or name == "probes-config":
+            if not eq and name in VALUE_OPTIONS:
+                i += 1; value = args[i]
+            out.append(f"--{name}={value}" if eq or name in VALUE_OPTIONS else f"--{name}")
+        else: out.append(token)
+        i += 1
+    return out, vals
 
 def cpu_identity() -> dict[str, Any]:
-    identity: dict[str, Any] = {"architecture": platform.machine(), "processor": platform.processor()}
-    cpuinfo = Path("/proc/cpuinfo")
-    if cpuinfo.exists():
-        text = cpuinfo.read_text()
-        model = re.search(r"^model name\s*: (.+)$", text, re.MULTILINE)
-        flags = re.search(r"^flags\s*: (.+)$", text, re.MULTILINE)
-        if model:
-            identity["model"] = model.group(1)
-        if flags:
-            identity["features"] = flags.group(1).split()
-    return identity
-
-
-def parse_gp_output(stdout: str) -> tuple[dict[str, float], str]:
-    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
-    header_index = next((i for i, line in enumerate(lines) if "iteration" in line.split() and "r2_tr" in line.split()), None)
-    if header_index is None:
-        raise ValueError("operon_gp output did not contain its metrics table")
-    fields = lines[header_index].split()
-    rows: list[dict[str, float]] = []
-    for line in lines[header_index + 1:]:
-        values = line.split()
-        if len(values) != len(fields):
-            break
-        try:
-            rows.append(dict(zip(fields, map(float, values), strict=True)))
-        except ValueError:
-            break
-    if not rows:
-        raise ValueError("operon_gp metrics table did not contain a data row")
-    model_lines = lines[header_index + 1 + len(rows):]
-    if not model_lines:
-        raise ValueError("operon_gp did not print a final symbolic model")
-    return rows[-1], model_lines[-1]
-
-
-def write_exclusive(path: Path, payload: dict[str, Any]) -> None:
-    with path.open("x", encoding="utf-8") as destination:
-        json.dump(payload, destination, indent=2, sort_keys=True)
-        destination.write("\n")
-
+    result: dict[str, Any] = {"architecture": platform.machine(), "processor": platform.processor()}
+    p = Path("/proc/cpuinfo")
+    if p.exists():
+        text = p.read_text(errors="replace")
+        for key, field in (("model name", "model"), ("flags", "features")):
+            m = re.search(rf"^{re.escape(key)}\s*:\s*(.+)$", text, re.MULTILINE)
+            if m: result[field] = m.group(1).split() if field == "features" else m.group(1)
+    return result
+def validate_report(report: Any) -> dict[str, Any]:
+    if not isinstance(report, dict) or report.get("report_kind") != "operon_gp" or report.get("schema_version") != 1:
+        raise ValueError("machine report has unsupported kind or schema version")
+    metrics = report.get("metrics")
+    if not isinstance(metrics, dict): raise ValueError("machine report lacks metrics object")
+    for k, v in metrics.items():
+        if isinstance(v, float): finite(v, k)
+    required = {"r2_train", "r2_test", "mae_train", "mae_test", "mse_train", "mse_test", "best_fitness", "elapsed_seconds"}
+    missing = required - metrics.keys()
+    if missing: raise ValueError(f"machine report missing fields: {', '.join(sorted(missing))}")
+    return report
 
 def main() -> int:
     argv = sys.argv[1:]
-    if "--" not in argv:
-        raise SystemExit("error: use '--' before operon_gp arguments")
-    separator = argv.index("--")
+    if "--" not in argv: raise SystemExit("error: use '--' before operon_gp arguments")
+    split = argv.index("--")
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("binary", type=Path, help="path to operon_gp")
-    parser.add_argument("--output", required=True, type=Path, help="new immutable output directory")
-    parsed = parser.parse_args(argv[:separator])
-    gp_args = argv[separator + 1:]
-
-    dataset_arg = option_value(gp_args, "--dataset")
-    seed_arg = option_value(gp_args, "--seed")
-    if dataset_arg is None or seed_arg is None:
-        raise SystemExit("error: replayable runs require explicit --dataset and --seed after '--'")
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout", type=float, default=3600.0, help="finite wrapper timeout in seconds")
+    parsed = parser.parse_args(argv[:split]); gp_args = argv[split + 1:]
+    if not math.isfinite(parsed.timeout) or parsed.timeout <= 0: raise SystemExit("error: --timeout must be finite and positive")
+    cwd = Path.cwd().resolve(); binary = parsed.binary.resolve()
+    if not binary.is_file(): raise SystemExit(f"error: operon_gp binary is not a file: {binary}")
+    canonical, opts = canonical_args(gp_args, cwd)
+    if "dataset" not in opts or "seed" not in opts: raise SystemExit("error: replayable runs require explicit --dataset and --seed")
+    try: seed = int(opts["seed"])
+    except (TypeError, ValueError): raise SystemExit("error: --seed must be an integer")
+    budget = opts.get("evaluations", 0); limit = opts.get("timelimit", 2**64 - 1)
+    try: budget_finite = int(budget) > 0; limit_finite = int(limit) < 2**64 - 1 and int(limit) > 0
+    except (TypeError, ValueError): budget_finite = limit_finite = False
+    if not budget_finite and not limit_finite: raise SystemExit("error: require a finite positive --evaluations or --timelimit")
+    dataset = Path(str(opts["dataset"])).resolve()
+    if not dataset.is_file(): raise SystemExit(f"error: dataset is not a file: {dataset}")
+    output = parsed.output.resolve()
+    if output.exists(): raise SystemExit(f"error: immutable output already exists: {output}")
+    parent = output.parent; parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=parent))
+    report_path = stage / "machine-report.json"
+    # report path is wrapper-owned and cannot be overridden by duplicate CLI input.
+    command = [str(binary), *gp_args, "--report-json", str(report_path)]
+    started = time.monotonic()
     try:
-        seed = int(seed_arg)
-    except ValueError as error:
-        raise SystemExit(f"error: --seed must be an integer: {error}") from error
-    dataset = Path(dataset_arg).resolve()
-    if not dataset.is_file():
-        raise SystemExit(f"error: dataset is not a file: {dataset}")
-    binary = parsed.binary.resolve()
-    if not binary.is_file():
-        raise SystemExit(f"error: operon_gp binary is not a file: {binary}")
-    try:
-        parsed.output.mkdir(mode=0o755)
-    except FileExistsError as error:
-        raise SystemExit(f"error: immutable output directory already exists: {parsed.output}") from error
+        proc = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+                                start_new_session=True)
+        try: stdout, stderr = proc.communicate(timeout=parsed.timeout)
+        except subprocess.TimeoutExpired:
+            os.killpg(proc.pid, signal.SIGTERM)
+            try: stdout, stderr = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(proc.pid, signal.SIGKILL); stdout, stderr = proc.communicate()
+            raise RuntimeError(f"operon_gp exceeded wrapper timeout of {parsed.timeout:g}s")
+        if proc.returncode != 0: raise RuntimeError(f"operon_gp exited with status {proc.returncode}: {stderr.strip()}")
+        if not report_path.is_file(): raise RuntimeError("operon_gp did not produce --report-json")
+        try: report = validate_report(json.loads(report_path.read_text()))
+        except (json.JSONDecodeError, ValueError) as e: raise RuntimeError(f"invalid machine report: {e}") from e
+        (stage / "stdout.txt").write_text(stdout); (stage / "stderr.txt").write_text(stderr)
+        version_run = subprocess.run([str(binary), "--version"], cwd=cwd, capture_output=True, text=True, check=False)
+        version = version_run.stdout + version_run.stderr
+        inputs = []
+        for key in PATH_OPTIONS:
+            if key in opts:
+                p = Path(str(opts[key])).resolve()
+                if p.is_file(): inputs.append({"option": f"--{key}", "path": str(p), "sha256": sha256(p), "size": p.stat().st_size})
+        stat = binary.stat()
+        manifest = {
+            "$schema": SCHEMA + "/manifest", "schema_version": 2,
+            "invocation": {"argv": [str(binary), *canonical], "cwd": str(cwd), "machine_report_option": "--report-json <private-staging-path>"},
+            "inputs": sorted(inputs, key=lambda x: x["option"]),
+            "effective_configuration": {k: opts[k] for k in sorted(opts)},
+            "implementation": {"name": "Operon", "version_output": version, "executable": {"path": str(binary), "size": stat.st_size, "sha256": sha256(binary)}},
+            "dependency_lock": {"path": str((cwd / "flake.lock").resolve()), "sha256": sha256(cwd / "flake.lock")} if (cwd / "flake.lock").is_file() else None,
+            "compiler": None, "cpu": cpu_identity(), "resource_budget": {"wrapper_timeout_seconds": parsed.timeout, "evaluations": budget if budget_finite else None, "timelimit": limit if limit_finite else None, "status": "completed"},
+            "dataset": {"path": str(dataset), "sha256": sha256(dataset), "size": dataset.stat().st_size}, "seed": seed, "result_schema": SCHEMA + "/results",
+        }
+        metrics = report["metrics"]
+        results = {"$schema": SCHEMA + "/results", "schema_version": 2, "schema_description": "Operon-specific record; tree_node_count is genotype length, not SRBench model complexity.", "srbench_compatibility": False, "dataset": dataset.stem, "algorithm": "Operon-GP", "params": {"canonical_argv": canonical}, "random_state": seed, "time_time": finite(metrics["elapsed_seconds"], "elapsed_seconds"), "symbolic_model": report["symbolic_model"], "tree_node_count": report["tree_node_count"], "metrics": metrics, "operon": {"manifest": "manifest.json"}}
+        for payload, name in ((manifest, "manifest.json"), (results, "results.json")):
+            with (stage / name).open("w", encoding="utf-8") as f: json.dump(payload, f, indent=2, sort_keys=True, allow_nan=False); f.write("\n")
+        os.replace(stage, output); print(output / "results.json"); return 0
+    except (OSError, RuntimeError, ValueError) as e:
+        shutil.rmtree(stage, ignore_errors=True); print(f"error: {e}", file=sys.stderr); return 1
 
-    started = time.time()
-    completed = subprocess.run([str(binary), *gp_args], capture_output=True, text=True, check=False)
-    (parsed.output / "stdout.txt").write_text(completed.stdout, encoding="utf-8")
-    (parsed.output / "stderr.txt").write_text(completed.stderr, encoding="utf-8")
-    if completed.returncode != 0:
-        raise SystemExit(f"error: operon_gp exited with status {completed.returncode}; see {parsed.output}/stderr.txt")
-    metrics, model = parse_gp_output(completed.stdout)
-    version = subprocess.run([str(binary), "--version"], capture_output=True, text=True, check=True).stdout.strip()
-    revision = re.search(r"operon rev\. (\S+)", version)
-    repository = Path(__file__).resolve().parents[1]
-    lock = repository / "flake.lock"
-    elapsed = time.time() - started
-
-    manifest = {
-        "$schema": SCHEMA + "/manifest",
-        "schema_version": 1,
-        "schema_description": "Immutable replay provenance. Hashes are lowercase SHA-256; ranges use Operon's half-open start:end syntax.",
-        "implementation": {"name": "Operon", "revision": revision.group(1) if revision else "unknown", "version": version},
-        "dependency_lock": {"path": "flake.lock", "sha256": sha256(lock)} if lock.is_file() else None,
-        "compiler": {"identity": version.splitlines()[-1] if version else "unknown"},
-        "cpu": cpu_identity(),
-        "seed": seed,
-        "dataset": {"path": dataset.name, "sha256": sha256(dataset)},
-        "primitive_set": {"enable_symbols": option_value(gp_args, "--enable-symbols"), "disable_symbols": option_value(gp_args, "--disable-symbols")},
-        "algorithm": {"name": "operon_gp", "configuration": gp_args},
-        "evaluator": {"objective": option_value(gp_args, "--objective") or "r2", "jit": option_value(gp_args, "--jit") or ""},
-        "budget": {key: option_value(gp_args, "--" + key) for key in ("generations", "evaluations", "timelimit", "population-size", "pool-size", "iterations", "threads")},
-        "result_schema": SCHEMA + "/results",
-    }
-    results = {
-        "$schema": SCHEMA + "/results",
-        "schema_version": 1,
-        "schema_description": "SRBench-compatible comparison record; train/test metrics are evaluated by Operon on its configured ranges.",
-        "dataset": dataset.stem,
-        "algorithm": "Operon-GP",
-        "params": {"operon_gp_arguments": gp_args},
-        "random_state": seed,
-        "time_time": elapsed,
-        "grid_time": 0.0,
-        "symbolic_model": model,
-        "mse_train": metrics["mse_tr"],
-        "mse_test": metrics["mse_te"],
-        "mae_train": metrics["mae_tr"],
-        "mae_test": metrics["mae_te"],
-        "r2_train": metrics["r2_tr"],
-        "r2_test": metrics["r2_te"],
-        "model_size": int(metrics["best_len"]),
-        "operon": {"manifest": "manifest.json", "best_fitness": metrics["best_fit"], "evaluator_calls": int(metrics["eval_cnt"]), "elapsed_seconds": metrics["elapsed"]},
-    }
-    write_exclusive(parsed.output / "manifest.json", manifest)
-    write_exclusive(parsed.output / "results.json", results)
-    print(parsed.output / "results.json")
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
+if __name__ == "__main__": raise SystemExit(main())

--- a/tools/test_run_srbench_unittest.py
+++ b/tools/test_run_srbench_unittest.py
@@ -1,6 +1,5 @@
 """Focused stdlib tests for the replayable SRBench wrapper."""
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -10,9 +9,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 import run_srbench
 
-VALID = {"report_kind": "operon_gp", "schema_version": 1, "symbolic_model": "x", "tree_node_count": 1,
-         "metrics": {"r2_train": 0.1, "r2_test": 0.2, "mae_train": 1.0, "mae_test": 2.0,
-                     "mse_train": 1.0, "mse_test": 2.0, "best_fitness": 1.0, "elapsed_seconds": 0.01}}
+VALID = {"report_kind": "operon_gp", "schema_version": 1, "symbolic_model": "x", "tree_node_count": 1, "seed": 1,
+         "metrics": {"r2_train": 0.1, "r2_test": 0.2, "mae_train": 1.0, "mae_test": 2.0, "nmse_train": 1.0, "nmse_test": 2.0,
+                     "mse_train": 1.0, "mse_test": 2.0, "best_fitness": 1.0, "average_fitness": 1.0,
+                     "average_tree_node_count": 1.0, "elapsed_seconds": 0.01, "evaluator_calls": 1,
+                     "result_evaluations": 1, "jacobian_evaluations": 1, "optimizer_seconds": 0.01}}
+
 
 class WrapperTests(unittest.TestCase):
     def test_malformed_and_nonfinite_reports(self):
@@ -22,48 +24,46 @@ class WrapperTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "finite"):
             run_srbench.validate_report(bad)
 
+    def test_strict_report_types_duplicates_and_extras(self):
+        with self.assertRaisesRegex(ValueError, "non-negative integer"):
+            run_srbench.validate_report(dict(VALID, tree_node_count=True))
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "x.json"; p.write_text('{"a": 1, "a": 2}')
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                run_srbench._json_strict(p)
+
+    def test_report_flag_is_wrapper_owned(self):
+        with self.assertRaisesRegex(ValueError, "wrapper-owned"):
+            run_srbench.parse_args(["--report-json", "out.json"])
+
     def test_duplicate_and_implicit_flags(self):
         with self.assertRaisesRegex(ValueError, "duplicate"):
             run_srbench.parse_args(["--seed=1", "--seed=2"])
         with self.assertRaisesRegex(ValueError, "requires a value"):
             run_srbench.parse_args(["--dataset"])
         self.assertEqual(run_srbench.parse_args(["--shuffle"])["shuffle"], True)
+        self.assertEqual(run_srbench.parse_args(["--jit"])["jit"], "all")
 
     def test_canonical_paths_and_atomic_failure_retry(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n")
             args, _ = run_srbench.canonical_args(["--dataset", str(data), "--shuffle", "--seed", "4"], root)
             self.assertEqual(args, [f"--dataset={data}", "--shuffle", "--seed=4"])
-            out = root / "artifact"
-            fake = root / "fake.py"
-            fake.write_text("#!/usr/bin/env python3\nimport sys,time\n" \
-                            "p=sys.argv[sys.argv.index('--report-json')+1]\n" \
-                            "open(p,'w').write('not json')\n")
+            out = root / "artifact"; fake = root / "fake.py"
+            fake.write_text("#!/usr/bin/env python3\nimport sys\nif '--version' in sys.argv: print('fake-1'); sys.exit(0)\np=sys.argv[sys.argv.index('--report-json')+1]\nopen(p,'w').write('not json')\n")
             fake.chmod(0o755)
-            cmd = [sys.executable, str(run_srbench.__file__), "--output", str(out), str(fake), "--",
-                   "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
-            self.assertNotEqual(subprocess.run(cmd, capture_output=True).returncode, 0)
-            self.assertFalse(out.exists())
-            fake.write_text("#!/usr/bin/env python3\nimport sys,json\n" \
-                            "p=sys.argv[sys.argv.index('--report-json')+1]\n" \
-                            f"open(p,'w').write({json.dumps(VALID)!r})\n" \
-                            "sys.exit(0)\n")
+            cmd = [sys.executable, str(run_srbench.__file__), "--output", str(out), str(fake), "--", "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
+            self.assertNotEqual(subprocess.run(cmd, capture_output=True).returncode, 0); self.assertFalse(out.exists())
+            fake.write_text("#!/usr/bin/env python3\nimport sys,json\nif '--version' in sys.argv: print('fake-1'); sys.exit(0)\np=sys.argv[sys.argv.index('--report-json')+1]\nopen(p,'w').write(" + repr(json.dumps(VALID)) + ")\n")
             fake.chmod(0o755)
-            self.assertEqual(subprocess.run(cmd, capture_output=True).returncode, 0)
-            self.assertTrue((out / "manifest.json").is_file())
+            self.assertEqual(subprocess.run(cmd, capture_output=True).returncode, 0); self.assertTrue((out / "manifest.json").is_file())
 
     def test_timeout_leaves_no_artifact(self):
         with tempfile.TemporaryDirectory() as td:
             root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n")
-            fake = root / "slow.py"
-            fake.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(10)\n")
-            fake.chmod(0o755)
-            out = root / "artifact"
-            cmd = [sys.executable, str(run_srbench.__file__), "--timeout", "0.1", "--output", str(out), str(fake), "--",
-                   "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
-            result = subprocess.run(cmd, capture_output=True)
-            self.assertNotEqual(result.returncode, 0)
-            self.assertFalse(out.exists())
+            fake = root / "slow.py"; fake.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(10)\n"); fake.chmod(0o755)
+            out = root / "artifact"; cmd = [sys.executable, str(run_srbench.__file__), "--timeout", "0.1", "--output", str(out), str(fake), "--", "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
+            self.assertNotEqual(subprocess.run(cmd, capture_output=True).returncode, 0); self.assertFalse(out.exists())
 
-if __name__ == "__main__":
-    unittest.main()
+
+if __name__ == "__main__": unittest.main()

--- a/tools/test_run_srbench_unittest.py
+++ b/tools/test_run_srbench_unittest.py
@@ -16,6 +16,25 @@ VALID = {"report_kind": "operon_gp", "schema_version": 1, "symbolic_model": "x",
                      "result_evaluations": 1, "jacobian_evaluations": 1, "optimizer_seconds": 0.01}}
 
 
+def _fake_binary(root, report=VALID):
+    fake = root / "fake.py"
+    fake.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json,sys\n"
+        "if '--version' in sys.argv: print('fake-1'); sys.exit(0)\n"
+        "path=sys.argv[sys.argv.index('--report-json')+1]\n"
+        f"open(path, 'w').write({json.dumps(report)!r})\n"
+    )
+    fake.chmod(0o755)
+    (root / "flake.lock").write_text("{}\n")
+    return fake
+
+def _run_wrapper(root, output, fake, data, *extra):
+    cmd = [sys.executable, str(run_srbench.__file__), "--output", str(output), str(fake), "--",
+           "--dataset", str(data), "--seed", "1", "--evaluations", "1", *extra]
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=root)
+
+
 class WrapperTests(unittest.TestCase):
     def test_malformed_and_nonfinite_reports(self):
         with self.assertRaisesRegex(ValueError, "unsupported"):
@@ -64,6 +83,52 @@ class WrapperTests(unittest.TestCase):
             fake = root / "slow.py"; fake.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(10)\n"); fake.chmod(0o755)
             out = root / "artifact"; cmd = [sys.executable, str(run_srbench.__file__), "--timeout", "0.1", "--output", str(out), str(fake), "--", "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
             self.assertNotEqual(subprocess.run(cmd, capture_output=True).returncode, 0); self.assertFalse(out.exists())
+
+    def test_attached_staging_and_nested_parent(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n")
+            output = root / "nested" / "deep" / "artifact"; fake = _fake_binary(root)
+            result = _run_wrapper(root, output, fake, data)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue((output / "results.json").is_file())
+            self.assertEqual(run_srbench._json_strict(output / "results.json")["manifest_sha256"], run_srbench.sha256(output / "manifest.json"))
+
+    def test_sink_rejection_and_no_overwrite(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n"); fake = _fake_binary(root)
+            output = root / "artifact"; output.write_text("sentinel")
+            result = _run_wrapper(root, output, fake, data)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(output.read_text(), "sentinel")
+
+    def test_strict_binding_rejects_tampered_manifest(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n"); fake = _fake_binary(root); output = root / "artifact"
+            result = _run_wrapper(root, output, fake, data)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            manifest = output / "manifest.json"; manifest.write_text(manifest.read_text() + " ")
+            with self.assertRaisesRegex(ValueError, "bound"):
+                run_srbench._manifest_and_results(output)
+
+    def test_manifest_path_replay(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n"); fake = _fake_binary(root)
+            first = root / "first"; second = root / "second"
+            self.assertEqual(_run_wrapper(root, first, fake, data).returncode, 0)
+            self.assertEqual(_run_wrapper(root, second, fake, data).returncode, 0)
+            cmd = [sys.executable, str(run_srbench.__file__), "--replay-manifest", str(first / "manifest.json"), "--against-artifact", str(second)]
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_strict_artifact_schema_comparator(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n"); fake = _fake_binary(root); output = root / "artifact"
+            result = _run_wrapper(root, output, fake, data)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            results_path = output / "results.json"; payload = run_srbench._json_strict(results_path); payload["unexpected"] = True
+            results_path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "schema"):
+                run_srbench._manifest_and_results(output)
 
 
 if __name__ == "__main__": unittest.main()

--- a/tools/test_run_srbench_unittest.py
+++ b/tools/test_run_srbench_unittest.py
@@ -1,0 +1,69 @@
+"""Focused stdlib tests for the replayable SRBench wrapper."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import run_srbench
+
+VALID = {"report_kind": "operon_gp", "schema_version": 1, "symbolic_model": "x", "tree_node_count": 1,
+         "metrics": {"r2_train": 0.1, "r2_test": 0.2, "mae_train": 1.0, "mae_test": 2.0,
+                     "mse_train": 1.0, "mse_test": 2.0, "best_fitness": 1.0, "elapsed_seconds": 0.01}}
+
+class WrapperTests(unittest.TestCase):
+    def test_malformed_and_nonfinite_reports(self):
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            run_srbench.validate_report({})
+        bad = dict(VALID, metrics=dict(VALID["metrics"], mse_train=float("nan")))
+        with self.assertRaisesRegex(ValueError, "finite"):
+            run_srbench.validate_report(bad)
+
+    def test_duplicate_and_implicit_flags(self):
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            run_srbench.parse_args(["--seed=1", "--seed=2"])
+        with self.assertRaisesRegex(ValueError, "requires a value"):
+            run_srbench.parse_args(["--dataset"])
+        self.assertEqual(run_srbench.parse_args(["--shuffle"])["shuffle"], True)
+
+    def test_canonical_paths_and_atomic_failure_retry(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n")
+            args, _ = run_srbench.canonical_args(["--dataset", str(data), "--shuffle", "--seed", "4"], root)
+            self.assertEqual(args, [f"--dataset={data}", "--shuffle", "--seed=4"])
+            out = root / "artifact"
+            fake = root / "fake.py"
+            fake.write_text("#!/usr/bin/env python3\nimport sys,time\n" \
+                            "p=sys.argv[sys.argv.index('--report-json')+1]\n" \
+                            "open(p,'w').write('not json')\n")
+            fake.chmod(0o755)
+            cmd = [sys.executable, str(run_srbench.__file__), "--output", str(out), str(fake), "--",
+                   "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
+            self.assertNotEqual(subprocess.run(cmd, capture_output=True).returncode, 0)
+            self.assertFalse(out.exists())
+            fake.write_text("#!/usr/bin/env python3\nimport sys,json\n" \
+                            "p=sys.argv[sys.argv.index('--report-json')+1]\n" \
+                            f"open(p,'w').write({json.dumps(VALID)!r})\n" \
+                            "sys.exit(0)\n")
+            fake.chmod(0o755)
+            self.assertEqual(subprocess.run(cmd, capture_output=True).returncode, 0)
+            self.assertTrue((out / "manifest.json").is_file())
+
+    def test_timeout_leaves_no_artifact(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td); data = root / "data.csv"; data.write_text("x,y\n1,2\n")
+            fake = root / "slow.py"
+            fake.write_text("#!/usr/bin/env python3\nimport time\ntime.sleep(10)\n")
+            fake.chmod(0o755)
+            out = root / "artifact"
+            cmd = [sys.executable, str(run_srbench.__file__), "--timeout", "0.1", "--output", str(out), str(fake), "--",
+                   "--dataset", str(data), "--seed", "1", "--evaluations", "1"]
+            result = subprocess.run(cmd, capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(out.exists())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -1,3 +1,37 @@
+"""Unit tests for run_operon.py and the replayable SRBench wrapper."""
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+RUN_SR = importlib.util.spec_from_file_location("run_srbench", Path(__file__).parent / "run_srbench.py")
+run_srbench = importlib.util.module_from_spec(RUN_SR)
+RUN_SR.loader.exec_module(run_srbench)
+
+def test_srbench_rejects_duplicate_and_implicit_value():
+    with pytest.raises(ValueError, match="duplicate"):
+        run_srbench.parse_args(["--seed=1", "--seed=2"])
+    with pytest.raises(ValueError, match="requires a value"):
+        run_srbench.parse_args(["--dataset"])
+
+def test_srbench_canonicalizes_paths_and_flags(tmp_path):
+    path = tmp_path / "data.csv"; path.write_text("x,y\n1,2\n")
+    args, values = run_srbench.canonical_args(["--dataset", str(path), "--shuffle", "--seed", "4"], tmp_path)
+    assert args == [f"--dataset={path}", "--shuffle", "--seed=4"]
+    assert values["shuffle"] is True
+
+def test_srbench_report_rejects_nonfinite_and_malformed():
+    with pytest.raises(ValueError, match="unsupported"):
+        run_srbench.validate_report({})
+    report = {"report_kind":"operon_gp", "schema_version":1, "symbolic_model":"x", "tree_node_count":1,
+              "metrics":{"r2_train": float("nan")}}
+    with pytest.raises(ValueError, match="non-finite"):
+        run_srbench.validate_report(report)
 """Unit tests for run_operon.py and _optuna.py."""
 import sys
 import textwrap


### PR DESCRIPTION
Adds a single-run benchmark wrapper around operon_gp that writes immutable manifest.json and SRBench-compatible results.json. The manifest captures revision, lock hash, compiler/CPU identity, seed, dataset hash, primitive configuration, algorithm/evaluator arguments, budgets, and result schema.